### PR TITLE
fix: remove x-scroll

### DIFF
--- a/manytask/templates/base.html
+++ b/manytask/templates/base.html
@@ -18,8 +18,6 @@
             font-family: 'Source Code Pro', monospace;
             display: flex;
             text-decoration: none;
-            width: 100vw;
-            height: 100vh;
         }
 
         :root body * {


### PR DESCRIPTION
## Description
Remove x-scroll appearing in some browsers


## Screenshots
Before commit:
![image](https://github.com/manytask/manytask/assets/45245696/8b7091f4-bd47-4bb9-9c7e-648112f3998f)
After:
![image](https://github.com/manytask/manytask/assets/45245696/554a7532-103a-4231-b1b1-a32d0d932e9a)