### PR TITLE
feat: ask to re-type password

### DIFF
--- a/manytask/templates/signup.html
+++ b/manytask/templates/signup.html
@@ -45,6 +45,10 @@
                     <label for="floatingPassword">Password</label>
                 </div>
                 <div class="form-floating my-2">
+                    <input type="password" name="password2" class="form-control" id="floatingPassword" placeholder="Re-type password" pattern="\S*" minlength="6" required>
+                    <label for="floatingPassword">Re-type password</label>
+                </div>
+                <div class="form-floating my-2">
                     <input type="text" name="secret" class="form-control" id="floatingCode" placeholder="Code" required>
                     <label for="floatingCode">Secret Code</label>
                 </div>

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -162,6 +162,8 @@ def signup() -> ResponseReturnValue:
     try:
         if not secrets.compare_digest(request.form["secret"], course.registration_secret):
             raise Exception("Invalid registration secret")
+        if not secrets.compare_digest(request.form["password"], request.form["password2"]):
+            raise Exception("Passwords don't match")
         _ = course.gitlab_api.register_new_user(user)
     except Exception as e:
         logger.warning(f"User registration failed: {e}")


### PR DESCRIPTION
Currently, Manytask registration form asks to type password only once. Usually, when user is asked to set the password, it is typed twice. This is done to prevent setting password with a typo in it. Users are so used to having two forms when setting the password, they get confused whe asked to do it once, thinking that they need to type password that they set previously. This commit (1) adds another textfield to re-type password and (2) checks if two typed passwords are the same.