### PR TITLE
fix: Allow non-integer number format for score reporting

### DIFF
--- a/manytask/api.py
+++ b/manytask/api.py
@@ -135,9 +135,9 @@ def report_score() -> ResponseReturnValue:
     if "score" in request.form:
         score_str = request.form["score"]
         try:
-            reported_score = int(score_str)
+            reported_score = int(round(float(score_str)))
         except ValueError:
-            return f"Cannot parse `score` <{reported_score}> to int`", 400
+            return f"Cannot parse `score` <{reported_score}> to a number`", 400
 
     submit_time = None
     submit_time_str = None


### PR DESCRIPTION
## Description

Current version of a checker returns score as a string that represents float number. This causes value error when casted directly to int. Proposed fix casts to float, rounds the number and than makes and integer.

## Further work

This fix must be re-considered towards using floats to store the scores.
