### PR TITLE
fix: Allow non-integer number format for score reporting

### DIFF
--- a/manytask/api.py
+++ b/manytask/api.py
@@ -131,14 +131,6 @@ def report_score() -> ResponseReturnValue:
     if "check_deadline" in request.form:
         check_deadline = request.form["check_deadline"] is True or request.form["check_deadline"] == "True"
 
-    reported_score: int | None = None
-    if "score" in request.form:
-        score_str = request.form["score"]
-        try:
-            reported_score = int(score_str)
-        except ValueError:
-            return f"Cannot parse `score` <{reported_score}> to int`", 400
-
     submit_time = None
     submit_time_str = None
     if "submit_time" in request.form:
@@ -159,6 +151,21 @@ def report_score() -> ResponseReturnValue:
             f"There is no task with name `{task_name}` (or it is closed for submission)",
             404,
         )
+
+    reported_score: int | None = None
+    if "score" in request.form:
+        score_str = request.form["score"]
+        try:
+            if score_str.isdigit():
+                reported_score = int(score_str)
+            elif float(score_str) < 0.0:
+                reported_score = 0
+            elif float(score_str) > 1.0:
+                reported_score = int(round(float(score_str)))
+            else:
+                reported_score = int(round(float(score_str) * task.score))
+        except ValueError:
+            return f"Cannot parse `score` <{reported_score}> to a number`", 400
 
     try:
         if username:

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -162,7 +162,7 @@ def report_score() -> ResponseReturnValue:
                 reported_score = 0
             elif float(score_str) > 2.0:
                 return f"Reported `score` <{reported_score}> is too large. " + \
-                        "Should be integer or float between 0.0 and 2.0`", 400
+                        "Should be integer or float between 0.0 and 2.0.", 400
             else:
                 reported_score = round(float(score_str) * task.score)
         except ValueError:

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -160,8 +160,8 @@ def report_score() -> ResponseReturnValue:
                 reported_score = int(score_str)
             elif float(score_str) < 0.0:
                 reported_score = 0
-            elif float(score_str) > 1.0:
-                reported_score = int(round(float(score_str)))
+            elif float(score_str) > 2.0:
+                return f"Reported `score` <{reported_score}> is too large. Should be ineger or float between 0.0 and 2.0`", 400
             else:
                 reported_score = int(round(float(score_str) * task.score))
         except ValueError:

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -162,7 +162,7 @@ def report_score() -> ResponseReturnValue:
                 reported_score = 0
             elif float(score_str) > 2.0:
                 return f"Reported `score` <{reported_score}> is too large. " + \
-                f"Should be integer or float between 0.0 and 2.0`", 400
+                        "Should be integer or float between 0.0 and 2.0`", 400
             else:
                 reported_score = round(float(score_str) * task.score)
         except ValueError:

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -163,7 +163,7 @@ def report_score() -> ResponseReturnValue:
             elif float(score_str) > 2.0:
                 return f"Reported `score` <{reported_score}> is too large. Should be ineger or float between 0.0 and 2.0`", 400
             else:
-                reported_score = int(round(float(score_str) * task.score))
+                reported_score = round(float(score_str) * task.score)
         except ValueError:
             return f"Cannot parse `score` <{reported_score}> to a number`", 400
 

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -161,7 +161,8 @@ def report_score() -> ResponseReturnValue:
             elif float(score_str) < 0.0:
                 reported_score = 0
             elif float(score_str) > 2.0:
-                return f"Reported `score` <{reported_score}> is too large. Should be ineger or float between 0.0 and 2.0`", 400
+                return f"Reported `score` <{reported_score}> is too large. " + \
+                f"Should be integer or float between 0.0 and 2.0`", 400
             else:
                 reported_score = round(float(score_str) * task.score)
         except ValueError:


### PR DESCRIPTION
Current version of a checker returns score as a string that represents float number, which is casted directly to int. This cause a value error.

The proposed fis allow to push integers or floats in the score string, with the following behavior:
1. If integer is passed, it is taken as final score for the task
2. If a float less than zero is passed, set the score to 0
3. If a float larger than 2.0 is passed, report and error
4. If a float between 0.0 and 2.0 is passed, use it a fractional score, i.e. multiply it by the maximum score for the task.