### PR TITLE
refactor: separate and make abstract gdoc api

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable
+
+from config import ManytaskDeadlinesConfig
+from glab import Student
+
+
+class ViewerApi(ABC):
+    @abstractmethod
+    def get_spreadsheet_url(self) -> str:
+        ...
+
+
+class StorageApi(ABC):
+    @abstractmethod
+    def get_scores(
+        self,
+        username: str,
+    ) -> dict[str, int]:
+        ...
+
+    @abstractmethod
+    def get_bonus_score(
+        self,
+        username: str,
+    ) -> int:
+        ...
+
+    @abstractmethod
+    def get_all_scores(self) -> dict[str, dict[str, int]]:
+        ...
+
+    @abstractmethod
+    def get_stats(self) -> dict[str, float]:
+        ...
+
+    @abstractmethod
+    def get_scores_update_timestamp(self) -> str:
+        ...
+
+    @abstractmethod
+    def update_cached_scores(self) -> None:
+        ...
+
+    @abstractmethod
+    def store_score(
+        self,
+        student: Student,
+        task_name: str,
+        update_fn: Callable[..., Any],
+    ) -> int:
+        ...
+
+    @abstractmethod
+    def sync_columns(
+        self,
+        deadlines_config: ManytaskDeadlinesConfig,
+    ) -> None:
+        ...

--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import Any, Callable
 
-from config import ManytaskDeadlinesConfig
-from glab import Student
+from .config import ManytaskDeadlinesConfig
+from .glab import Student
 
 
 class ViewerApi(ABC):

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -197,7 +197,7 @@ def report_score() -> ResponseReturnValue:
         submit_time=submit_time,
         check_deadline=check_deadline,
     )
-    final_score = course.rating_table.store_score(student, task.name, update_function)
+    final_score = course.storage_api.store_score(student, task.name, update_function)
 
     # save pushed files if sent
     with tempfile.TemporaryDirectory() as temp_folder_str:
@@ -254,7 +254,7 @@ def get_score() -> ResponseReturnValue:
             student = course.gitlab_api.get_student(user_id)
         else:
             assert False, "unreachable"
-        student_scores = course.rating_table.get_scores(student.username)
+        student_scores = course.storage_api.get_scores(student.username)
     except Exception:
         return f"There is no student with user_id {user_id} or username {username}", 404
 
@@ -290,7 +290,7 @@ def update_config() -> ResponseReturnValue:
     # ----- logic ----- #
     # TODO: fix course config storing. may work one thread only =(
     # sync columns
-    course.rating_table.sync_columns(course.deadlines)
+    course.storage_api.sync_columns(course.deadlines)
 
     return "", 200
 
@@ -303,7 +303,7 @@ def update_cache() -> ResponseReturnValue:
     logger.info("Running update_cache")
 
     # ----- logic ----- #
-    course.rating_table.update_cached_scores()
+    course.storage_api.update_cached_scores()
 
     return "", 200
 

--- a/manytask/course.py
+++ b/manytask/course.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 from zoneinfo import ZoneInfo
-from abc import ABC, abstractmethod
 
 from cachelib import BaseCache
 
@@ -38,61 +37,14 @@ def validate_submit_time(commit_time: datetime | None, current_time: datetime) -
     return current_time
 
 
-from . import config, gdoc, glab, solutions  # noqa: E402, F401
+from . import config, gdoc, glab, solutions, abstract  # noqa: E402, F401
 
-class RatingTableAbs(ABC):
-
-    @abstractmethod
-    def get_scores(
-        self,
-        username: str,
-    ) -> dict[str, int]:
-        pass
-
-    @abstractmethod
-    def get_bonus_score(
-        self,
-        username: str,
-    ) -> int:
-        pass
-
-    @abstractmethod
-    def get_all_scores(self) -> dict[str, dict[str, int]]:
-        pass
-        
-    @abstractmethod
-    def get_stats(self) -> dict[str, float]:
-        pass
-        
-    @abstractmethod
-    def get_scores_update_timestamp(self) -> str:
-        pass
-    
-    @abstractmethod
-    def update_cached_scores(self) -> None:
-        pass
-    
-    @abstractmethod
-    def store_score(
-        self,
-        student: glab.Student,
-        task_name: str,
-        update_fn: Callable[..., Any],
-    ) -> int:
-        pass
-
-    @abstractmethod
-    def sync_columns(
-        self,
-        deadlines_config: ManytaskDeadlinesConfig,
-    ) -> None:
-        pass
- 
 
 class Course:
     def __init__(
         self,
-        googledoc_api: gdoc.GoogleDocApi,
+        viewer_api: abstract.ViewerApi,
+        storage_api: abstract.StorageApi,
         gitlab_api: glab.GitLabApi,
         solutions_api: solutions.SolutionsApi,
         registration_secret: str,
@@ -102,7 +54,8 @@ class Course:
         *,
         debug: bool = False,
     ):
-        self.googledoc_api = googledoc_api
+        self.viewer_api = viewer_api
+        self.storage_api = storage_api
         self.gitlab_api = gitlab_api
         self.solutions_api = solutions_api
 
@@ -151,6 +104,3 @@ class Course:
         ManytaskConfig(**content)
         self._cache.set("__config__", content)
 
-    @property
-    def rating_table(self) -> "gdoc.RatingTable":
-        return self.googledoc_api.fetch_rating_table()

--- a/manytask/gdoc.py
+++ b/manytask/gdoc.py
@@ -17,7 +17,7 @@ from gspread.utils import ValueInputOption, ValueRenderOption, a1_to_rowcol, row
 from .config import ManytaskConfig, ManytaskDeadlinesConfig
 from .course import get_current_time
 from .glab import Student
-from .course import RatingTableAbs
+from abstract import ViewerApi, StorageApi
 
 
 logger = logging.getLogger(__name__)
@@ -85,14 +85,13 @@ class TaskNotFound(KeyError):
     pass
 
 
-class GoogleDocApi:
+class GoogleDocInit:
     def __init__(
         self,
         base_url: str,
         gdoc_credentials: dict[str, Any],
         public_worksheet_id: str,
-        public_scoreboard_sheet: int,
-        cache: BaseCache,
+        public_scoreboard_sheet: int
     ):
         """
         :param base_url:
@@ -109,7 +108,6 @@ class GoogleDocApi:
         self._assertion_session = self._create_assertion_session()
 
         self._public_scores_sheet = self._get_sheet(public_worksheet_id, public_scoreboard_sheet)
-        self._cache = cache
 
     def _create_assertion_session(self) -> AssertionSession:
         """Create AssertionSession to auto refresh access to google api"""
@@ -145,23 +143,31 @@ class GoogleDocApi:
         gs: gspread.Client = gspread.Client(AnonymousCredentials(), session=self._assertion_session)
         worksheet: gspread.Spreadsheet = gs.open_by_key(worksheet_id)
         return worksheet.get_worksheet(sheet_id)
-
-    def fetch_rating_table(self) -> "RatingTable":
-        return RatingTable(self._public_scores_sheet, self._cache)
+    
+    def get_scores_sheet(self) -> gspread.Worksheet:
+        return self._public_scores_sheet
 
     def get_spreadsheet_url(self) -> str:
         return f"{self._url}/spreadsheets/d/{self._public_worksheet_id}#gid={self._public_scoreboard_sheet}"
 
 
-class RatingTable(RatingTableAbs):
+class GoogleDocApi(ViewerApi, StorageApi):
     def __init__(
         self,
-        worksheet: gspread.Worksheet,
+        base_url: str,
+        gdoc_credentials: dict[str, Any],
+        public_worksheet_id: str,
+        public_scoreboard_sheet: int,
         cache: BaseCache,
     ):
+        gdoc_init = GoogleDocInit(base_url, gdoc_credentials, public_worksheet_id, public_scoreboard_sheet)
+        self.ws = gdoc_init.get_scores_sheet()
+        self._spreadsheet_url = gdoc_init.get_spreadsheet_url()
         self._cache = cache
-        self.ws = worksheet
-
+    
+    def get_spreadsheet_url(self) -> str:
+        return self._spreadsheet_url
+    
     def get_scores(
         self,
         username: str,

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -188,7 +188,7 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
 
     # debug updates
     if app.course.debug:
-        with open("/app/manytask/.manytask.example.yml", "r") as f:
+        with open(".manytask.example.yml", "r") as f:
             debug_manytask_config_data = yaml.load(f, Loader=yaml.SafeLoader)
         app.course.store_config(debug_manytask_config_data)
 

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -147,6 +147,7 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
         public_scoreboard_sheet=int(app.app_config.gdoc_scoreboard_sheet),
         cache=cache,
     )
+
     solutions_api = solutions.SolutionsApi(
         base_folder=(".tmp/solution" if app.debug else os.environ.get("SOLUTIONS_DIR", "/solutions")),
     )
@@ -161,6 +162,7 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
 
     # create course
     _course = course.Course(
+        gdoc_api,
         gdoc_api,
         gitlab_api,
         solutions_api,
@@ -186,7 +188,7 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
 
     # debug updates
     if app.course.debug:
-        with open(".manytask.example.yml", "r") as f:
+        with open("/app/manytask/.manytask.example.yml", "r") as f:
             debug_manytask_config_data = yaml.load(f, Loader=yaml.SafeLoader)
         app.course.store_config(debug_manytask_config_data)
 

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -50,22 +50,22 @@ def course_page() -> ResponseReturnValue:
         student_repo = session["gitlab"]["repo"]
         student_course_admin = session["gitlab"]["course_admin"]
 
-    rating_table = course.rating_table
+    storage_api = course.storage_api
 
     # update cache if more than 1h passed or in debug mode
     try:
-        cache_time = datetime.fromisoformat(str(rating_table.get_scores_update_timestamp()))
+        cache_time = datetime.fromisoformat(str(storage_api.get_scores_update_timestamp()))
         cache_delta = datetime.now(tz=cache_time.tzinfo) - cache_time
     except ValueError:
         cache_delta = timedelta(days=365)
     if course.debug or cache_delta.total_seconds() > 3600:
-        rating_table.update_cached_scores()
-        cache_time = datetime.fromisoformat(str(rating_table.get_scores_update_timestamp()))
+        storage_api.update_cached_scores()
+        cache_time = datetime.fromisoformat(str(storage_api.get_scores_update_timestamp()))
         cache_delta = datetime.now(tz=cache_time.tzinfo) - cache_time
 
     # get scores
-    tasks_scores = rating_table.get_scores(student_username)
-    tasks_stats = rating_table.get_stats()
+    tasks_scores = storage_api.get_scores(student_username)
+    tasks_stats = storage_api.get_stats()
 
     return render_template(
         "tasks.html",
@@ -74,14 +74,14 @@ def course_page() -> ResponseReturnValue:
         course_name=course.name,
         current_course=course,
         gitlab_url=course.gitlab_api.base_url,
-        gdoc_url=course.googledoc_api.get_spreadsheet_url(),
+        gdoc_url=course.viewer_api.get_spreadsheet_url(),
         show_allscores=course.show_allscores,
         student_repo_url=student_repo,
         student_ci_url=f"{student_repo}/pipelines",
         manytask_version=course.manytask_version,
         links=course.config.ui.links or dict(),
         scores=tasks_scores,
-        bonus_score=rating_table.get_bonus_score(student_username),
+        bonus_score=storage_api.get_bonus_score(student_username),
         now=get_current_time(),
         task_stats=tasks_stats,
         course_favicon=course.favicon,


### PR DESCRIPTION
### Separate GoogleDocApi into viewer and storage api

Separate GoogleDocApi into GoogleDocViewerApi and GoogleDocStorageApi.
Separate RatingTable into ViewerRatingTable and StorageRatingTable.
In Course instead of googledoc_api using viewer_api and storage_api.

### Make separated classes abstract

Create abstract classes(ViewStoreApi, RatingApiBase, ViewerRatingApi, StorageRatingApi).
ViewStoreApi using in initial classes like GoogleDocViewerApi/GoogleDocStorageApi for having fetch_rating_api method.
RatingApiBase using in viewer/storage classes like ViewerRatingTable/StorageRatingTable for having methods which work with cache.
ViewerRatingApi/StorageRatingApi also unsing in viewer/storage classes for having view/store data methods.