### PR TITLE
feat: create a database and make it possible to use it instead of gsheet

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -1,0 +1,59 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable
+
+from .config import ManytaskDeadlinesConfig
+from .glab import Student
+
+
+class ViewerApi(ABC):
+    @abstractmethod
+    def get_spreadsheet_url(self) -> str:
+        ...
+
+
+class StorageApi(ABC):
+    @abstractmethod
+    def get_scores(
+        self,
+        username: str,
+    ) -> dict[str, int]:
+        ...
+
+    @abstractmethod
+    def get_bonus_score(
+        self,
+        username: str,
+    ) -> int:
+        ...
+
+    @abstractmethod
+    def get_all_scores(self) -> dict[str, dict[str, int]]:
+        ...
+
+    @abstractmethod
+    def get_stats(self) -> dict[str, float]:
+        ...
+
+    @abstractmethod
+    def get_scores_update_timestamp(self) -> str:
+        ...
+
+    @abstractmethod
+    def update_cached_scores(self) -> None:
+        ...
+
+    @abstractmethod
+    def store_score(
+        self,
+        student: Student,
+        task_name: str,
+        update_fn: Callable[..., Any],
+    ) -> int:
+        ...
+
+    @abstractmethod
+    def sync_columns(
+        self,
+        deadlines_config: ManytaskDeadlinesConfig,
+    ) -> None:
+        ...

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -197,7 +197,7 @@ def report_score() -> ResponseReturnValue:
         submit_time=submit_time,
         check_deadline=check_deadline,
     )
-    final_score = course.rating_table.store_score(student, task.name, update_function)
+    final_score = course.storage_api.store_score(student, task.name, update_function)
 
     # save pushed files if sent
     with tempfile.TemporaryDirectory() as temp_folder_str:
@@ -254,7 +254,7 @@ def get_score() -> ResponseReturnValue:
             student = course.gitlab_api.get_student(user_id)
         else:
             assert False, "unreachable"
-        student_scores = course.rating_table.get_scores(student.username)
+        student_scores = course.storage_api.get_scores(student.username)
     except Exception:
         return f"There is no student with user_id {user_id} or username {username}", 404
 
@@ -290,7 +290,7 @@ def update_config() -> ResponseReturnValue:
     # ----- logic ----- #
     # TODO: fix course config storing. may work one thread only =(
     # sync columns
-    course.rating_table.sync_columns(course.deadlines)
+    course.storage_api.sync_columns(course.deadlines)
 
     return "", 200
 
@@ -303,7 +303,7 @@ def update_cache() -> ResponseReturnValue:
     logger.info("Running update_cache")
 
     # ----- logic ----- #
-    course.rating_table.update_cached_scores()
+    course.storage_api.update_cached_scores()
 
     return "", 200
 

--- a/manytask/course.py
+++ b/manytask/course.py
@@ -37,7 +37,7 @@ def validate_submit_time(commit_time: datetime | None, current_time: datetime) -
     return current_time
 
 
-from . import config, gdoc, glab, solutions, abstract  # noqa: E402, F401
+from . import abstract, config, gdoc, glab, solutions  # noqa: E402, F401
 
 
 class Course:

--- a/manytask/course.py
+++ b/manytask/course.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any
 from zoneinfo import ZoneInfo
-from abc import ABC, abstractmethod
 
 from cachelib import BaseCache
 
@@ -38,61 +37,14 @@ def validate_submit_time(commit_time: datetime | None, current_time: datetime) -
     return current_time
 
 
-from . import config, gdoc, glab, solutions  # noqa: E402, F401
+from . import config, gdoc, glab, solutions, abstract  # noqa: E402, F401
 
-class RatingTableAbs(ABC):
-
-    @abstractmethod
-    def get_scores(
-        self,
-        username: str,
-    ) -> dict[str, int]:
-        pass
-
-    @abstractmethod
-    def get_bonus_score(
-        self,
-        username: str,
-    ) -> int:
-        pass
-
-    @abstractmethod
-    def get_all_scores(self) -> dict[str, dict[str, int]]:
-        pass
-        
-    @abstractmethod
-    def get_stats(self) -> dict[str, float]:
-        pass
-        
-    @abstractmethod
-    def get_scores_update_timestamp(self) -> str:
-        pass
-    
-    @abstractmethod
-    def update_cached_scores(self) -> None:
-        pass
-    
-    @abstractmethod
-    def store_score(
-        self,
-        student: glab.Student,
-        task_name: str,
-        update_fn: Callable[..., Any],
-    ) -> int:
-        pass
-
-    @abstractmethod
-    def sync_columns(
-        self,
-        deadlines_config: ManytaskDeadlinesConfig,
-    ) -> None:
-        pass
- 
 
 class Course:
     def __init__(
         self,
-        googledoc_api: gdoc.GoogleDocApi,
+        viewer_api: abstract.ViewerApi,
+        storage_api: abstract.StorageApi,
         gitlab_api: glab.GitLabApi,
         solutions_api: solutions.SolutionsApi,
         registration_secret: str,
@@ -102,7 +54,8 @@ class Course:
         *,
         debug: bool = False,
     ):
-        self.googledoc_api = googledoc_api
+        self.viewer_api = viewer_api
+        self.storage_api = storage_api
         self.gitlab_api = gitlab_api
         self.solutions_api = solutions_api
 
@@ -151,6 +104,3 @@ class Course:
         ManytaskConfig(**content)
         self._cache.set("__config__", content)
 
-    @property
-    def rating_table(self) -> "gdoc.RatingTable":
-        return self.googledoc_api.fetch_rating_table()

--- a/manytask/course.py
+++ b/manytask/course.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any
+from typing import Any, Callable
 from zoneinfo import ZoneInfo
+from abc import ABC, abstractmethod
 
 from cachelib import BaseCache
 
@@ -39,6 +40,54 @@ def validate_submit_time(commit_time: datetime | None, current_time: datetime) -
 
 from . import config, gdoc, glab, solutions  # noqa: E402, F401
 
+class RatingTableAbs(ABC):
+
+    @abstractmethod
+    def get_scores(
+        self,
+        username: str,
+    ) -> dict[str, int]:
+        pass
+
+    @abstractmethod
+    def get_bonus_score(
+        self,
+        username: str,
+    ) -> int:
+        pass
+
+    @abstractmethod
+    def get_all_scores(self) -> dict[str, dict[str, int]]:
+        pass
+        
+    @abstractmethod
+    def get_stats(self) -> dict[str, float]:
+        pass
+        
+    @abstractmethod
+    def get_scores_update_timestamp(self) -> str:
+        pass
+    
+    @abstractmethod
+    def update_cached_scores(self) -> None:
+        pass
+    
+    @abstractmethod
+    def store_score(
+        self,
+        student: glab.Student,
+        task_name: str,
+        update_fn: Callable[..., Any],
+    ) -> int:
+        pass
+
+    @abstractmethod
+    def sync_columns(
+        self,
+        deadlines_config: ManytaskDeadlinesConfig,
+    ) -> None:
+        pass
+ 
 
 class Course:
     def __init__(

--- a/manytask/gdoc.py
+++ b/manytask/gdoc.py
@@ -17,6 +17,7 @@ from gspread.utils import ValueInputOption, ValueRenderOption, a1_to_rowcol, row
 from .config import ManytaskConfig, ManytaskDeadlinesConfig
 from .course import get_current_time
 from .glab import Student
+from .course import RatingTableAbs
 
 
 logger = logging.getLogger(__name__)
@@ -152,7 +153,7 @@ class GoogleDocApi:
         return f"{self._url}/spreadsheets/d/{self._public_worksheet_id}#gid={self._public_scoreboard_sheet}"
 
 
-class RatingTable:
+class RatingTable(RatingTableAbs):
     def __init__(
         self,
         worksheet: gspread.Worksheet,

--- a/manytask/gdoc.py
+++ b/manytask/gdoc.py
@@ -17,7 +17,7 @@ from gspread.utils import ValueInputOption, ValueRenderOption, a1_to_rowcol, row
 from .config import ManytaskConfig, ManytaskDeadlinesConfig
 from .course import get_current_time
 from .glab import Student
-from .course import RatingTableAbs
+from .abstract import ViewerApi, StorageApi
 
 
 logger = logging.getLogger(__name__)
@@ -85,7 +85,7 @@ class TaskNotFound(KeyError):
     pass
 
 
-class GoogleDocApi:
+class GoogleDocApi(ViewerApi, StorageApi):
     def __init__(
         self,
         base_url: str,
@@ -110,6 +110,8 @@ class GoogleDocApi:
 
         self._public_scores_sheet = self._get_sheet(public_worksheet_id, public_scoreboard_sheet)
         self._cache = cache
+
+        self.ws = self.get_scores_sheet()
 
     def _create_assertion_session(self) -> AssertionSession:
         """Create AssertionSession to auto refresh access to google api"""
@@ -146,21 +148,11 @@ class GoogleDocApi:
         worksheet: gspread.Spreadsheet = gs.open_by_key(worksheet_id)
         return worksheet.get_worksheet(sheet_id)
 
-    def fetch_rating_table(self) -> "RatingTable":
-        return RatingTable(self._public_scores_sheet, self._cache)
+    def get_scores_sheet(self) -> gspread.Worksheet:
+        return self._public_scores_sheet
 
     def get_spreadsheet_url(self) -> str:
         return f"{self._url}/spreadsheets/d/{self._public_worksheet_id}#gid={self._public_scoreboard_sheet}"
-
-
-class RatingTable(RatingTableAbs):
-    def __init__(
-        self,
-        worksheet: gspread.Worksheet,
-        cache: BaseCache,
-    ):
-        self._cache = cache
-        self.ws = worksheet
 
     def get_scores(
         self,

--- a/manytask/gdoc.py
+++ b/manytask/gdoc.py
@@ -14,10 +14,10 @@ from google.auth.credentials import AnonymousCredentials
 from gspread import Cell as GCell
 from gspread.utils import ValueInputOption, ValueRenderOption, a1_to_rowcol, rowcol_to_a1
 
+from .abstract import StorageApi, ViewerApi
 from .config import ManytaskConfig, ManytaskDeadlinesConfig
 from .course import get_current_time
 from .glab import Student
-from .abstract import ViewerApi, StorageApi
 
 
 logger = logging.getLogger(__name__)

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -147,6 +147,7 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
         public_scoreboard_sheet=int(app.app_config.gdoc_scoreboard_sheet),
         cache=cache,
     )
+
     solutions_api = solutions.SolutionsApi(
         base_folder=(".tmp/solution" if app.debug else os.environ.get("SOLUTIONS_DIR", "/solutions")),
     )
@@ -161,6 +162,7 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
 
     # create course
     _course = course.Course(
+        gdoc_api,
         gdoc_api,
         gitlab_api,
         solutions_api,

--- a/manytask/models.py
+++ b/manytask/models.py
@@ -1,0 +1,117 @@
+from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase, relationship
+from sqlalchemy import ForeignKey, JSON, UniqueConstraint
+from typing import Optional, List
+from datetime import datetime, timezone
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class User(Base):
+    __tablename__ = 'users'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str]
+    gitlab_instance_host: Mapped[str]
+    is_manytask_admin: Mapped[bool] = mapped_column(default=False)
+
+    __table_args__ = (
+        UniqueConstraint(
+            'username',
+            'gitlab_instance_host',
+            name='_username_gitlab_instance_uc'
+        ),
+    )
+
+    # relationships
+    users_on_courses: Mapped[List['UserOnCourse']] = relationship(
+        back_populates='user', lazy='dynamic')
+    grades: Mapped[List['Grade']] = relationship(back_populates='user', lazy='dynamic')
+
+
+class Course(Base):
+    __tablename__ = 'courses'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(unique=True)
+    registration_secret: Mapped[str]
+    show_allscores: Mapped[bool] = mapped_column(default=False)
+
+    # relationships
+    tasks: Mapped[List['Task']] = relationship(back_populates='course', lazy='dynamic')
+    users_on_courses: Mapped[List['UserOnCourse']] = relationship(
+        back_populates='course', lazy='dynamic')
+
+
+class UserOnCourse(Base):
+    __tablename__ = 'users_on_courses'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey(User.id))
+    course_id: Mapped[int] = mapped_column(ForeignKey(Course.id))
+    is_course_admin: Mapped[bool] = mapped_column(default=False)
+    repo_name: Mapped[str]
+    join_date: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'course_id', name='_user_course_uc'),
+    )
+
+    # relationships
+    user: Mapped['User'] = relationship(back_populates='users_on_courses')
+    course: Mapped['Course'] = relationship(back_populates='users_on_courses')
+
+
+class Deadline(Base):
+    __tablename__ = 'deadlines'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    data: Mapped[JSON] = mapped_column(type_=JSON)
+
+    # relationships
+    task_group: Mapped['TaskGroup'] = relationship(back_populates='deadline')
+
+
+class TaskGroup(Base):
+    __tablename__ = 'task_groups'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    deadline_id: Mapped[Optional[int]] = mapped_column(ForeignKey(Deadline.id))
+
+    # relationships
+    deadline: Mapped['Deadline'] = relationship(back_populates='task_group')
+    tasks: Mapped[List['Task']] = relationship(back_populates='group', lazy='dynamic')
+
+
+class Task(Base):
+    __tablename__ = 'tasks'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str]
+    course_id: Mapped[int] = mapped_column(ForeignKey(Course.id))
+    group_id: Mapped[int] = mapped_column(ForeignKey(TaskGroup.id))
+
+    # relationships
+    course: Mapped['Course'] = relationship(back_populates='tasks')
+    group: Mapped['TaskGroup'] = relationship(back_populates='tasks')
+    grades: Mapped[List['Grade']] = relationship(back_populates='task', lazy='dynamic')
+
+
+class Grade(Base):
+    __tablename__ = 'grades'
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey(User.id))
+    task_id: Mapped[int] = mapped_column(ForeignKey(Task.id))
+    score: Mapped[int]
+    submit_date: Mapped[datetime]
+
+    __table_args__ = (
+        UniqueConstraint('user_id', 'task_id', name='_user_task_uc'),
+    )
+
+    # relationships
+    user: Mapped['User'] = relationship(back_populates='grades')
+    task: Mapped['Task'] = relationship(back_populates='grades')

--- a/manytask/models.py
+++ b/manytask/models.py
@@ -1,7 +1,8 @@
-from sqlalchemy.orm import Mapped, mapped_column, DeclarativeBase, relationship
-from sqlalchemy import ForeignKey, JSON, UniqueConstraint
-from typing import Optional, List
 from datetime import datetime, timezone
+from typing import List, Optional
+
+from sqlalchemy import JSON, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
 class Base(DeclarativeBase):

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -50,22 +50,22 @@ def course_page() -> ResponseReturnValue:
         student_repo = session["gitlab"]["repo"]
         student_course_admin = session["gitlab"]["course_admin"]
 
-    rating_table = course.rating_table
+    storage_api = course.storage_api
 
     # update cache if more than 1h passed or in debug mode
     try:
-        cache_time = datetime.fromisoformat(str(rating_table.get_scores_update_timestamp()))
+        cache_time = datetime.fromisoformat(str(storage_api.get_scores_update_timestamp()))
         cache_delta = datetime.now(tz=cache_time.tzinfo) - cache_time
     except ValueError:
         cache_delta = timedelta(days=365)
     if course.debug or cache_delta.total_seconds() > 3600:
-        rating_table.update_cached_scores()
-        cache_time = datetime.fromisoformat(str(rating_table.get_scores_update_timestamp()))
+        storage_api.update_cached_scores()
+        cache_time = datetime.fromisoformat(str(storage_api.get_scores_update_timestamp()))
         cache_delta = datetime.now(tz=cache_time.tzinfo) - cache_time
 
     # get scores
-    tasks_scores = rating_table.get_scores(student_username)
-    tasks_stats = rating_table.get_stats()
+    tasks_scores = storage_api.get_scores(student_username)
+    tasks_stats = storage_api.get_stats()
 
     return render_template(
         "tasks.html",
@@ -74,14 +74,14 @@ def course_page() -> ResponseReturnValue:
         course_name=course.name,
         current_course=course,
         gitlab_url=course.gitlab_api.base_url,
-        gdoc_url=course.googledoc_api.get_spreadsheet_url(),
+        gdoc_url=course.viewer_api.get_spreadsheet_url(),
         show_allscores=course.show_allscores,
         student_repo_url=student_repo,
         student_ci_url=f"{student_repo}/pipelines",
         manytask_version=course.manytask_version,
         links=course.config.ui.links or dict(),
         scores=tasks_scores,
-        bonus_score=rating_table.get_bonus_score(student_username),
+        bonus_score=storage_api.get_bonus_score(student_username),
         now=get_current_time(),
         task_stats=tasks_stats,
         course_favicon=course.favicon,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ flask==3.0.1
 cachelib==0.13.0
 Werkzeug==3.0.6
 
+# api database
+Flask-SQLAlchemy==3.1.1
+psycopg2-binary==2.9.10
+
 # api interaction (gitlab, google sheets)
 gspread>=5.0.0,!=6.0.0,<7.0.0  # note, version 6.0.0 is broken and can not accept session in Client
 python-gitlab==4.13.0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,270 @@
+import pytest
+from datetime import datetime, timezone
+from sqlalchemy.exc import IntegrityError
+from manytask.models import User, Course, UserOnCourse, Deadline, TaskGroup, Task, Grade, Base
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+
+@pytest.fixture(scope='module')
+def engine():
+    return create_engine('sqlite:///:memory:', echo=False)
+
+
+@pytest.fixture(scope='module')
+def tables(engine):
+    Base.metadata.create_all(engine)
+    yield
+    Base.metadata.drop_all(engine)
+
+
+@pytest.fixture
+def session(engine, tables):
+    with Session(engine) as session:
+        yield session
+
+
+def test_user_simple(session):
+    user = User(username="test_user", gitlab_instance_host='gitlab.inst.org')
+    session.add(user)
+    session.commit()
+
+    retrieved = session.query(User).filter_by(username="test_user").first()
+    assert retrieved is not None
+    assert retrieved.username == "test_user"
+    assert retrieved.is_manytask_admin is False
+
+
+def test_user_unique_username_and_gitlab_instance(session):
+    user1 = User(username="unique_user1", gitlab_instance_host='gitlab.inst1.org')
+    user2 = User(username="unique_user1", gitlab_instance_host='gitlab.inst2.org')
+    user3 = User(username="unique_user2", gitlab_instance_host='gitlab.inst1.org')
+    user4 = User(username="unique_user2", gitlab_instance_host='gitlab.inst2.org')
+    user5 = User(username="unique_user1", gitlab_instance_host='gitlab.inst1.org')
+    session.add_all([user1, user2, user3, user4])
+    session.commit()
+    session.add(user5)
+    with pytest.raises(IntegrityError):
+        session.commit()
+
+
+def test_course(session):
+    course = Course(name="test_course", registration_secret="test_secret")
+    session.add(course)
+    session.commit()
+
+    retrieved = session.query(Course).filter_by(name="test_course").first()
+    assert retrieved is not None
+    assert retrieved.registration_secret == "test_secret"
+    assert retrieved.show_allscores is False
+
+
+def test_course_unique_name(session):
+    course1 = Course(name="unique_course", registration_secret="secret1")
+    course2 = Course(name="unique_course", registration_secret="secret2")
+    session.add(course1)
+    session.commit()
+    session.add(course2)
+    with pytest.raises(IntegrityError):
+        session.commit()
+
+
+def test_user_on_course(session):
+    user = User(username="user1", gitlab_instance_host='gitlab.inst.org')
+    course = Course(name="course1", registration_secret="secret1")
+    session.add_all([user, course])
+    session.commit()
+
+    user_on_course = UserOnCourse(
+        user=user,
+        course=course,
+        repo_name="user1_repo"
+    )
+    session.add(user_on_course)
+    session.commit()
+
+    retrieved_user = session.query(User).filter_by(username="user1").first()
+    assert len(retrieved_user.users_on_courses.all()) == 1
+    assert retrieved_user.users_on_courses[0].course.name == "course1"
+
+    retrieved_course = session.query(Course).filter_by(name="course1").first()
+    assert len(retrieved_course.users_on_courses.all()) == 1
+    assert retrieved_course.users_on_courses[0].user.username == "user1"
+
+
+def test_user_on_course_unique_ids(session):
+    user1 = User(username="user001", gitlab_instance_host='gitlab.inst.org')
+    course1 = Course(name="course001", registration_secret="secret001")
+    user2 = User(username="user002", gitlab_instance_host='gitlab.inst.org')
+    course2 = Course(name="course002", registration_secret="secret002")
+
+    user_on_course1 = UserOnCourse(
+        user=user1,
+        course=course1,
+        repo_name="user_repo01"
+    )
+    user_on_course2 = UserOnCourse(
+        user=user1,
+        course=course2,
+        repo_name="user_repo02"
+    )
+    user_on_course3 = UserOnCourse(
+        user=user2,
+        course=course1,
+        repo_name="user_repo03"
+    )
+    user_on_course4 = UserOnCourse(
+        user=user2,
+        course=course2,
+        repo_name="user_repo04"
+    )
+    session.add_all([user_on_course1, user_on_course2, user_on_course3, user_on_course4])
+    session.commit()
+
+    user_on_course5 = UserOnCourse(
+        user=user1,
+        course=course1,
+        repo_name="user_repo05"
+    )
+
+    session.add(user_on_course5)
+    with pytest.raises(IntegrityError):
+        session.commit()
+
+
+def test_deadline(session):
+    deadline = Deadline(data={"test_key": "test_value"})
+    session.add(deadline)
+    task_group = TaskGroup(name="group1", deadline=deadline)
+    session.add(task_group)
+    session.commit()
+
+    retrieved = session.query(TaskGroup).filter_by(name="group1").first()
+    assert retrieved.deadline is not None
+    assert retrieved.deadline.data["test_key"] == "test_value"
+
+
+def test_task_group(session):
+    task_group = TaskGroup(name="group2")
+    session.add(task_group)
+    session.commit()
+
+    retrieved = session.query(TaskGroup).filter_by(name="group2").first()
+    assert retrieved.deadline is None
+
+
+def test_task(session):
+    course = Course(name="course3", registration_secret="secret3")
+    task_group = TaskGroup(name="group3")
+    session.add_all([course, task_group])
+    session.commit()
+
+    task = Task(name="task1", course=course, group=task_group)
+    session.add(task)
+    session.commit()
+
+    retrieved_task = session.query(Task).filter_by(name="task1").first()
+    assert retrieved_task.course.name == "course3"
+    assert retrieved_task.group.name == "group3"
+
+
+def test_grade(session):
+    user = User(username="user2", gitlab_instance_host='gitlab.inst.org')
+    course = Course(name="course4", registration_secret="secret4")
+    task_group = TaskGroup(name="group4")
+    task = Task(name="task2", course=course, group=task_group)
+    session.add_all([user, course, task_group, task])
+    session.commit()
+
+    grade = Grade(
+        user=user,
+        task=task,
+        score=77,
+        submit_date=datetime.now(timezone.utc)
+    )
+    session.add(grade)
+    session.commit()
+
+    retrieved_grade = session.query(Grade).first()
+    assert retrieved_grade.user.username == "user2"
+    assert retrieved_grade.task.name == "task2"
+    assert retrieved_grade.score == 77
+
+
+def test_grade_unique_ids(session):
+    task_group = TaskGroup(name="group101")
+    course = Course(name="course101", registration_secret="secret101")
+    user1 = User(username="user101", gitlab_instance_host='gitlab.inst.org')
+    user2 = User(username="user102", gitlab_instance_host='gitlab.inst.org')
+    task1 = Task(name="task101", course=course, group=task_group)
+    task2 = Task(name="task102", course=course, group=task_group)
+    session.add_all([task_group, course, user1, user2, task1, task2])
+    session.commit()
+
+    grade1 = Grade(
+        user=user1,
+        task=task1,
+        score=11,
+        submit_date=datetime.now(timezone.utc)
+    )
+    grade2 = Grade(
+        user=user1,
+        task=task2,
+        score=11,
+        submit_date=datetime.now(timezone.utc)
+    )
+    grade3 = Grade(
+        user=user2,
+        task=task1,
+        score=11,
+        submit_date=datetime.now(timezone.utc)
+    )
+    grade4 = Grade(
+        user=user2,
+        task=task2,
+        score=11,
+        submit_date=datetime.now(timezone.utc)
+    )
+
+    session.add_all([grade1, grade2, grade3, grade4])
+    session.commit()
+
+    grade5 = Grade(
+        user=user1,
+        task=task1,
+        score=11,
+        submit_date=datetime.now(timezone.utc)
+    )
+    session.add(grade5)
+    with pytest.raises(IntegrityError):
+        session.commit()
+
+
+def test_course_tasks(session):
+    course = Course(name="course11", registration_secret="secret11")
+    task_group = TaskGroup(name="group11")
+    task1 = Task(name="task11_1", group=task_group, course=course)
+    task2 = Task(name="task11_2", group=task_group, course=course)
+    session.add_all([course, task_group, task1, task2])
+    session.commit()
+
+    retrieved_course = session.query(Course).filter_by(name="course11").first()
+    assert len(retrieved_course.tasks.all()) == 2
+    task_names = [task.name for task in retrieved_course.tasks]
+    assert "task11_1" in task_names
+    assert "task11_2" in task_names
+
+
+def test_task_group_tasks(session):
+    course = Course(name="course12", registration_secret="secret12")
+    task_group = TaskGroup(name="group12")
+    task1 = Task(name="task12_1", group=task_group, course=course)
+    task2 = Task(name="task12_2", group=task_group, course=course)
+    session.add_all([task_group, task1, task2])
+    session.commit()
+
+    retrieved_group = session.query(TaskGroup).filter_by(name="group12").first()
+    assert len(retrieved_group.tasks.all()) == 2
+    task_names = [task.name for task in retrieved_group.tasks]
+    assert "task12_1" in task_names
+    assert "task12_2" in task_names


### PR DESCRIPTION
Although it is very convenient to use google spreadsheets as a database, there are certain limitations that come with it. First ad formost, the google sheet does not allow to make several courses on a single web-application instance. Secondly, this solution relies on google api and service accounts, which may become unavailable. This change is the first step to make it possible to use database. It makes all the data interfaces abstract, which allows to switch between two backends. Also this change contains the design of the database, which can be in future used to store the data on many courses. This change, however, keeps the one-web-application - one-course paradigm to keep backward compatibility and allow comparison testing. 
