### PR TITLE
refactor: edit models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ GDOC_URL=https://docs.google.com
 GDOC_ACCOUNT_CREDENTIALS_BASE64=# (REMOVE THIS COMENT) check the README on how to generate your own google service account for spreadsheet API and put Base64 encoded key here
 GDOC_SPREADSHEET_ID=1cRah9NC5Nl7_NyzttC3Q5BtrnbdO6KyaG7gx5ZGusTM
 GDOC_SCOREBOARD_SHEET=0
+SHOW_ALLSCORES=true
+
+# database
+USE_DATABASE_AS_STORAGE=false
+DATABASE_URL=postgresql://postgres_user:postgres_password@postgres:5432/postgres_db
+UNIQUE_COURSE_NAME="Python SHAD 2024"

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,8 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+file::memory:
+file::memory:-journal
 
 # Translations
 *.mo

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -1,0 +1,471 @@
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Iterable, List, Optional, Type, TypeVar
+
+from sqlalchemy import and_, create_engine
+from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.functions import func
+
+from . import models
+from .abstract import StorageApi
+from .config import ManytaskDeadlinesConfig
+from .glab import Student
+
+
+logger = logging.getLogger(__name__)
+
+
+class DataBaseApi(StorageApi):
+    """Class for interacting with a database with the StorageApi functionality"""
+
+    ModelType = TypeVar('ModelType', bound=models.Base)
+
+    def __init__(
+        self,
+        database_url: str,
+        course_name: str,
+        gitlab_instance_host: str,
+        registration_secret: str,
+        show_allscores: bool
+    ):
+        """Constructor of DataBaseApi class
+
+        :param database_url: full url for database connection
+        :param course_name: unique course name
+        :param gitlab_instance_host: gitlab instance host url
+        :param registration_secret: secret to registering for course
+        :param show_allscores: flag for showing results to all users
+        """
+
+        self.engine = create_engine(database_url, echo=False)
+
+        with Session(self.engine) as session:
+            try:
+                course = self._get(session, models.Course, name=course_name)
+                if course.gitlab_instance_host != gitlab_instance_host:
+                    raise AttributeError(
+                        "Can't update gitlab_instance_host param on created course")
+            except NoResultFound:
+                pass
+
+            self.course_name = course_name
+            self._update_or_create(
+                session,
+                models.Course,
+                defaults={
+                    'gitlab_instance_host': gitlab_instance_host,
+                    'registration_secret': registration_secret,
+                    'show_allscores': show_allscores
+                },
+                name=self.course_name
+            )
+
+    def get_scores(
+        self,
+        username: str,
+    ) -> dict[str, int]:
+        """Method for getting all user scores
+
+        :param username: student username
+
+        :return: dict with the names of tasks and their scores
+        """
+
+        with Session(self.engine) as session:
+            grades = self._get_scores(session, username, only_bonus=False)
+
+            if grades is None:
+                return {}
+
+            scores: dict[str, int] = {}
+            for grade in grades:
+                scores[grade.task.name] = grade.score
+
+        return scores
+
+    def get_bonus_score(
+        self,
+        username: str,
+    ) -> int:
+        """Method for getting user's total bonus score
+
+        :param username: student username
+
+        :return: user's total bonus score
+        """
+
+        with Session(self.engine) as session:
+            grades = self._get_scores(session, username, only_bonus=True)
+
+        if grades is None:
+            return 0
+
+        return sum([grade.score for grade in grades])
+
+    def get_all_scores(self) -> dict[str, dict[str, int]]:
+        """Method for getting all scores for all users
+
+        :return: dict with usernames and all their scores
+        """
+
+        with Session(self.engine) as session:
+            all_users = self._get_all_users(session, self.course_name)
+
+        all_scores: dict[str, dict[str, int]] = {}
+        for username in all_users:
+            all_scores[username] = self.get_scores(username)
+
+        return all_scores
+
+    def get_stats(self) -> dict[str, float]:
+        """Method for getting stats of all tasks
+
+        :return: dict with the names of tasks and their stats
+        """
+
+        with Session(self.engine) as session:
+            tasks = self._get_all_tasks(session, self.course_name)
+
+            users_on_courses_count = self._get_course_users_on_courses_count(
+                session, self.course_name)
+            tasks_stats: dict[str, float] = {}
+            for task in tasks:
+                if users_on_courses_count == 0:
+                    tasks_stats[task.name] = 0
+                else:
+                    tasks_stats[task.name] = self._get_task_submits_count(
+                        session, task.id) / users_on_courses_count
+
+        return tasks_stats
+
+    def get_scores_update_timestamp(self) -> str:
+        """Method(deprecated) for getting last cached scores update timestamp
+
+        :return: last update timestamp
+        """
+
+        return datetime.now(timezone.utc).isoformat()
+
+    def update_cached_scores(self) -> None:
+        """Method(deprecated) for updating cached scores"""
+
+        return
+
+    def store_score(
+        self,
+        student: Student,
+        task_name: str,
+        update_fn: Callable[..., Any],
+    ) -> int:
+        """Method for storing user's task score
+
+        :param student: Student object
+        :param task_name: task name
+        :param update_fn: function for updating the score
+
+        :return: saved score
+        """
+
+        flags = ''  # TODO: in GoogleDocApi imported from google table, they used to increase the deadline for the user
+
+        with Session(self.engine) as session:
+            course = self._get(session, models.Course, name=self.course_name)
+            user = self._get_or_create(
+                session,
+                models.User,
+                username=student.username,
+                gitlab_instance_host=course.gitlab_instance_host
+            )
+
+            user_on_course = self._get_or_create(
+                session,
+                models.UserOnCourse,
+                defaults={
+                    'repo_name': student.repo
+                },
+                user_id=user.id,
+                course_id=course.id
+            )
+
+            try:
+                task = self._get_task_by_name_and_course_id(session, task_name, course.id)
+            except NoResultFound:
+                return 0
+
+            grade = self._get_or_create(
+                session,
+                models.Grade,
+                user_on_course_id=user_on_course.id,
+                task_id=task.id
+            )
+
+            new_score = update_fn(flags, grade.score)
+            self._update(
+                session,
+                models.Grade,
+                defaults={
+                    'score': new_score,
+                    'last_submit_date': datetime.now(timezone.utc)
+                },
+                id=grade.id
+            )
+
+        logger.info(f"Setting score = {new_score}")
+
+        return new_score
+
+    def sync_columns(
+        self,
+        deadlines_config: ManytaskDeadlinesConfig,
+    ) -> None:
+        """Method for updating deadlines config
+
+        :param deadlines_config: ManytaskDeadlinesConfig object
+        """
+
+        groups = deadlines_config.get_groups(enabled=True, started=True)
+        tasks = deadlines_config.get_tasks(enabled=True, started=True)
+
+        logger.info("Syncing database tasks...")
+        with Session(self.engine) as session:
+            course = self._get(session, models.Course, name=self.course_name)
+
+            for group in groups:
+                exist_tasks = [task for task in group.tasks if task in tasks]
+
+                if len(exist_tasks) == 0:
+                    continue
+
+                deadline_data = DataBaseApi._serialize_deadline_data(
+                    group.start, group.steps, group.end)
+
+                task_group = DataBaseApi._get_or_create(
+                    session,
+                    models.TaskGroup,
+                    name=group.name,
+                    course_id=course.id
+                )
+
+                DataBaseApi._update_deadline_for_task_group(session, task_group, deadline_data)
+
+                for task in exist_tasks:
+                    self._update_or_create(
+                        session,
+                        models.Task,
+                        defaults={
+                            'is_bonus': task.is_bonus
+                        },
+                        name=task.name,
+                        group_id=task_group.id
+                    )
+
+    def _get_scores(
+        self,
+        session: Session,
+        username: str,
+        only_bonus: bool = False
+    ) -> Optional[Iterable['models.Grade']]:
+        try:
+            course = self._get(session, models.Course, name=self.course_name)
+            user = self._get(
+                session,
+                models.User,
+                username=username,
+                gitlab_instance_host=course.gitlab_instance_host
+            )
+
+            user_on_course = self._get(
+                session,
+                models.UserOnCourse,
+                user_id=user.id,
+                course_id=course.id
+            )
+        except NoResultFound:
+            return None
+
+        grades = self._get_all_grades(user_on_course, only_bonus=only_bonus)
+        return grades
+
+    @staticmethod
+    def _serialize_deadline_data(  # serialize data to json from config.ManytaskGroupConfig params
+        start: datetime,
+        steps: dict[float, datetime | timedelta],
+        end: datetime | timedelta
+    ) -> dict[str, str | dict[str, str]]:
+        def convert(value: datetime | timedelta) -> str:
+            if isinstance(value, datetime):
+                return value.isoformat()
+            return (start + value).isoformat()
+
+        serialized: dict[str, str | dict[str, str]] = {
+            'start': convert(start),
+            'steps': {str(k): convert(v) for k, v in steps.items()},
+            'end': convert(end)
+        }
+
+        return serialized
+
+    @staticmethod
+    def _get(
+        session: Session,
+        model: Type[ModelType],
+        **kwargs: Any  # params for get
+    ) -> ModelType:
+        try:
+            return session.query(model).filter_by(**kwargs).one()
+        except NoResultFound:
+            raise NoResultFound(f"{model} not found with params: {kwargs}")
+
+    @staticmethod
+    def _update(
+        session: Session,
+        model: Type[ModelType],
+        defaults: Optional[dict[str, Any]] = None,  # params for update
+        **kwargs: Any  # params for get
+    ) -> ModelType:
+        instance = DataBaseApi._get(session, model, **kwargs)
+
+        if defaults:
+            for key, value in defaults.items():
+                setattr(instance, key, value)
+            session.commit()
+        return instance
+
+    @staticmethod
+    def _create(
+        session: Session,
+        model: Type[ModelType],
+        **kwargs: Any  # params for create
+    ) -> ModelType:
+        try:
+            instance = model(**kwargs)
+            session.add(instance)
+            session.commit()
+            return instance
+        except IntegrityError:
+            session.rollback()
+            return session.query(model).filter_by(**kwargs).one()
+
+    @staticmethod
+    def _get_or_create(
+        session: Session,
+        model: Type[ModelType],
+        defaults: Optional[dict[str, Any]] = None,  # params for create
+        **kwargs: Any  # params for get
+    ) -> ModelType:
+        instance = session.query(model).filter_by(**kwargs).one_or_none()
+        if instance:
+            return instance
+
+        if defaults is not None:
+            kwargs.update(defaults)
+
+        return DataBaseApi._create(session, model, **kwargs)
+
+    @staticmethod
+    def _update_or_create(
+        session: Session,
+        model: Type[ModelType],
+        defaults: Optional[dict[str, Any]] = None,  # params for update
+        create_defaults: Optional[dict[str, Any]] = None,  # params for create
+        **kwargs: Any  # params for get
+    ) -> ModelType:
+        instance = session.query(model).filter_by(**kwargs).one_or_none()
+        if instance:
+            if defaults:
+                for key, value in defaults.items():
+                    setattr(instance, key, value)
+                session.commit()
+            return instance
+
+        if defaults is not None:
+            kwargs.update(defaults)
+        if create_defaults is not None:
+            kwargs.update(create_defaults)
+
+        return DataBaseApi._create(session, model, **kwargs)
+
+    @staticmethod
+    def _get_task_by_name_and_course_id(
+        session: Session,
+        name: str,
+        course_id: int
+    ) -> models.Task:
+        return session.query(models.Task).filter_by(name=name).join(
+            models.TaskGroup).filter_by(course_id=course_id).one()
+
+    @staticmethod
+    def _update_deadline_for_task_group(
+        session: Session,
+        task_group: models.TaskGroup,
+        deadline_data: dict[Any, Any]  # json data
+    ) -> None:
+
+        if task_group.deadline_id is None:
+            deadline = DataBaseApi._create(session, models.Deadline, data=deadline_data)
+            DataBaseApi._update(
+                session,
+                models.TaskGroup,
+                defaults={
+                    'deadline_id': deadline.id
+                },
+                id=task_group.id
+            )
+        else:
+            DataBaseApi._update(
+                session,
+                models.Deadline,
+                defaults={
+                    'data': deadline_data
+                },
+                id=task_group.deadline.id
+            )
+
+    @staticmethod
+    def _get_all_grades(
+        user_on_course: models.UserOnCourse,
+        only_bonus: bool = False
+    ) -> Iterable['models.Grade']:
+        if only_bonus:
+            return user_on_course.grades.join(models.Task).filter_by(is_bonus=True).all()
+        return user_on_course.grades.all()
+
+    @staticmethod
+    def _get_all_users(
+        session: Session,
+        course_name: str,
+    ) -> Iterable[str]:
+        course = DataBaseApi._get(session, models.Course, name=course_name)
+
+        return [user_on_course.user.username for user_on_course in course.users_on_courses.all()]
+
+    @staticmethod
+    def _get_all_tasks(
+        session: Session,
+        course_name: str,
+    ) -> Iterable['models.Task']:
+        course = DataBaseApi._get(session, models.Course, name=course_name)
+
+        tasks: List['models.Task'] = []
+        for task_group in course.task_groups.all():
+            tasks.extend(task_group.tasks.all())
+
+        return tasks
+
+    @staticmethod
+    def _get_course_users_on_courses_count(
+        session: Session,
+        course_name: str,
+    ) -> int:
+        course = DataBaseApi._get(session, models.Course, name=course_name)
+
+        return session.query(func.count(models.UserOnCourse.id)).filter_by(course_id=course.id).one()[0]
+
+    @staticmethod
+    def _get_task_submits_count(
+        session: Session,
+        task_id: int,
+    ) -> int:
+        return session.query(func.count(models.Grade.id)).filter(
+            and_(models.Grade.task_id == task_id, models.Grade.score > 0)).one()[0]

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 from flask import Flask
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from . import course, gdoc, glab, local_config, solutions
+from . import abstract, course, database, gdoc, glab, local_config, solutions
 
 
 load_dotenv("../.env")  # take environment variables from .env.
@@ -140,13 +140,42 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
         default_branch=app.app_config.gitlab_default_branch,
     )
     _gdoc_credentials_string = base64.decodebytes(app.app_config.gdoc_account_credentials_base64.encode())
-    gdoc_api = gdoc.GoogleDocApi(
-        base_url=app.app_config.gdoc_url,
-        gdoc_credentials=json.loads(_gdoc_credentials_string),
-        public_worksheet_id=app.app_config.gdoc_spreadsheet_id,
-        public_scoreboard_sheet=int(app.app_config.gdoc_scoreboard_sheet),
-        cache=cache,
-    )
+
+    storage_api: abstract.StorageApi
+    viewer_api: abstract.ViewerApi
+
+    if os.environ.get("USE_DATABASE_AS_STORAGE", "false").lower() in ("true", "1", "yes"):
+        database_url = os.environ.get("DATABASE_URL", None)
+        course_name = os.environ.get("UNIQUE_COURSE_NAME", None)
+
+        if database_url is None:
+            raise EnvironmentError("Unable to find DATABASE_URL env")
+        if course_name is None:
+            raise EnvironmentError("Unable to find UNIQUE_COURSE_NAME env")
+
+        storage_api = database.DataBaseApi(
+            database_url=database_url,
+            course_name=course_name,
+            gitlab_instance_host=app.app_config.gitlab_url,
+            registration_secret=app.app_config.registration_secret,
+            show_allscores=app.app_config.show_allscores
+        )
+
+        viewer_api = gdoc.GoogleDocApi(
+            base_url=app.app_config.gdoc_url,
+            gdoc_credentials=json.loads(_gdoc_credentials_string),
+            public_worksheet_id=app.app_config.gdoc_spreadsheet_id,
+            public_scoreboard_sheet=int(app.app_config.gdoc_scoreboard_sheet),
+            cache=cache,
+        )
+    else:
+        viewer_api = storage_api = gdoc.GoogleDocApi(
+            base_url=app.app_config.gdoc_url,
+            gdoc_credentials=json.loads(_gdoc_credentials_string),
+            public_worksheet_id=app.app_config.gdoc_spreadsheet_id,
+            public_scoreboard_sheet=int(app.app_config.gdoc_scoreboard_sheet),
+            cache=cache,
+        )
 
     solutions_api = solutions.SolutionsApi(
         base_folder=(".tmp/solution" if app.debug else os.environ.get("SOLUTIONS_DIR", "/solutions")),
@@ -162,8 +191,8 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
 
     # create course
     _course = course.Course(
-        gdoc_api,
-        gdoc_api,
+        viewer_api,
+        storage_api,
         gitlab_api,
         solutions_api,
         app.app_config.registration_secret,

--- a/manytask/models.py
+++ b/manytask/models.py
@@ -1,9 +1,13 @@
+import logging
 from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import JSON, ForeignKey, UniqueConstraint, event, func
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import DeclarativeBase, DynamicMapped, Mapped, Mapper, Session, mapped_column, relationship
+
+
+logger = logging.getLogger(__name__)
 
 
 class Base(DeclarativeBase):
@@ -88,7 +92,9 @@ def validate_gitlab_instance_host(mapper: Mapper[UserOnCourse], connection: Conn
             course = target.course
         else:
             course = session.query(Course).filter_by(id=target.course_id).one()
-    except Exception:
+    except Exception as e:  # TODO: fix swallowing exception
+        logger.warning(
+            f"Swallowing exception in 'before_insert' event in UserOnCourse model: {repr(e)}")
         return
 
     if user.gitlab_instance_host != course.gitlab_instance_host:

--- a/manytask/models.py
+++ b/manytask/models.py
@@ -85,12 +85,12 @@ def validate_gitlab_instance_host(mapper: Mapper[UserOnCourse], connection: Conn
     try:
         if target.user:
             user = target.user
-        else:
+        else:  # target missing user if we gave user_id or nothing
             user = session.query(User).filter_by(id=target.user_id).one()
 
         if target.course:
             course = target.course
-        else:
+        else:  # target missing course if we gave course_id or nothing
             course = session.query(Course).filter_by(id=target.course_id).one()
     except Exception as e:  # TODO: fix swallowing exception
         logger.warning(

--- a/manytask/models.py
+++ b/manytask/models.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Optional
 
-from sqlalchemy import JSON, ForeignKey, UniqueConstraint
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy import JSON, ForeignKey, UniqueConstraint, event
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import DeclarativeBase, DynamicMapped, Mapped, Mapper, Session, mapped_column, relationship
 
 
 class Base(DeclarativeBase):
@@ -15,7 +16,6 @@ class User(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     username: Mapped[str]
     gitlab_instance_host: Mapped[str]
-    is_manytask_admin: Mapped[bool] = mapped_column(default=False)
 
     __table_args__ = (
         UniqueConstraint(
@@ -26,9 +26,8 @@ class User(Base):
     )
 
     # relationships
-    users_on_courses: Mapped[List['UserOnCourse']] = relationship(
-        back_populates='user', lazy='dynamic')
-    grades: Mapped[List['Grade']] = relationship(back_populates='user', lazy='dynamic')
+    users_on_courses: DynamicMapped['UserOnCourse'] = relationship(
+        back_populates='user')
 
 
 class Course(Base):
@@ -36,13 +35,15 @@ class Course(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(unique=True)
+    gitlab_instance_host: Mapped[str]
     registration_secret: Mapped[str]
     show_allscores: Mapped[bool] = mapped_column(default=False)
 
     # relationships
-    tasks: Mapped[List['Task']] = relationship(back_populates='course', lazy='dynamic')
-    users_on_courses: Mapped[List['UserOnCourse']] = relationship(
-        back_populates='course', lazy='dynamic')
+    task_groups: DynamicMapped['TaskGroup'] = relationship(
+        back_populates='course')
+    users_on_courses: DynamicMapped['UserOnCourse'] = relationship(
+        back_populates='course')
 
 
 class UserOnCourse(Base):
@@ -51,7 +52,6 @@ class UserOnCourse(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     user_id: Mapped[int] = mapped_column(ForeignKey(User.id))
     course_id: Mapped[int] = mapped_column(ForeignKey(Course.id))
-    is_course_admin: Mapped[bool] = mapped_column(default=False)
     repo_name: Mapped[str]
     join_date: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
 
@@ -62,13 +62,36 @@ class UserOnCourse(Base):
     # relationships
     user: Mapped['User'] = relationship(back_populates='users_on_courses')
     course: Mapped['Course'] = relationship(back_populates='users_on_courses')
+    grades: DynamicMapped['Grade'] = relationship(
+        back_populates='user_on_course')
+
+
+@event.listens_for(UserOnCourse, 'before_insert')
+def validate_gitlab_instance_host(mapper: Mapper[UserOnCourse], connection: Connection, target: UserOnCourse) -> None:
+    session = Session(bind=connection)
+
+    try:
+        if target.user:
+            user = target.user
+        else:
+            user = session.query(User).filter_by(id=target.user_id).one()
+
+        if target.course:
+            course = target.course
+        else:
+            course = session.query(Course).filter_by(id=target.course_id).one()
+    except Exception:
+        return
+
+    if user.gitlab_instance_host != course.gitlab_instance_host:
+        raise ValueError("Gitlab instances not equal")
 
 
 class Deadline(Base):
     __tablename__ = 'deadlines'
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    data: Mapped[JSON] = mapped_column(type_=JSON)
+    data: Mapped[JSON] = mapped_column(type_=JSON, default=dict)
 
     # relationships
     task_group: Mapped['TaskGroup'] = relationship(back_populates='deadline')
@@ -79,11 +102,13 @@ class TaskGroup(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
+    course_id: Mapped[int] = mapped_column(ForeignKey(Course.id))
     deadline_id: Mapped[Optional[int]] = mapped_column(ForeignKey(Deadline.id))
 
     # relationships
+    course: Mapped['Course'] = relationship(back_populates='task_groups')
     deadline: Mapped['Deadline'] = relationship(back_populates='task_group')
-    tasks: Mapped[List['Task']] = relationship(back_populates='group', lazy='dynamic')
+    tasks: DynamicMapped['Task'] = relationship(back_populates='group')
 
 
 class Task(Base):
@@ -91,28 +116,27 @@ class Task(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
-    course_id: Mapped[int] = mapped_column(ForeignKey(Course.id))
     group_id: Mapped[int] = mapped_column(ForeignKey(TaskGroup.id))
+    is_bonus: Mapped[bool] = mapped_column(default=False)
 
     # relationships
-    course: Mapped['Course'] = relationship(back_populates='tasks')
     group: Mapped['TaskGroup'] = relationship(back_populates='tasks')
-    grades: Mapped[List['Grade']] = relationship(back_populates='task', lazy='dynamic')
+    grades: DynamicMapped['Grade'] = relationship(back_populates='task')
 
 
 class Grade(Base):
     __tablename__ = 'grades'
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey(User.id))
+    user_on_course_id: Mapped[int] = mapped_column(ForeignKey(UserOnCourse.id))
     task_id: Mapped[int] = mapped_column(ForeignKey(Task.id))
-    score: Mapped[int]
-    submit_date: Mapped[datetime]
+    score: Mapped[int] = mapped_column(default=0)
+    last_submit_date: Mapped[datetime] = mapped_column(default=lambda: datetime.now(timezone.utc))
 
     __table_args__ = (
-        UniqueConstraint('user_id', 'task_id', name='_user_task_uc'),
+        UniqueConstraint('user_on_course_id', 'task_id', name='_user_on_course_task_uc'),
     )
 
     # relationships
-    user: Mapped['User'] = relationship(back_populates='grades')
+    user_on_course: Mapped['UserOnCourse'] = relationship(back_populates='grades')
     task: Mapped['Task'] = relationship(back_populates='grades')

--- a/tests/.deadlines.test.yml
+++ b/tests/.deadlines.test.yml
@@ -1,0 +1,85 @@
+deadlines:
+  timezone: Europe/Berlin
+
+  deadlines: hard  # hard/interpolate
+  max_submissions: 10  # optional
+  submission_penalty: 0.1  # optional
+
+  schedule:
+
+    - group: group_0
+      start: 2000-01-01 18:00
+      steps:
+        0.5: 2000-03-01 18:00
+      end: 2000-05-01 23:59
+      enabled: true
+      tasks:
+        - task: task_0_0
+          score: 10
+        - task: task_0_1
+          score: 10
+        - task: task_0_2
+          is_bonus: true
+          score: 10
+        - task: task_0_3
+          score: 10
+
+    - group: group_1
+      start: 2000-01-02 18:00
+      steps:
+        0.5: 2000-02-02 23:59
+      end: 2000-02-02 23:59
+      enabled: true
+      tasks:
+        - task: task_1_0
+          score: 10
+        - task: task_1_1
+          is_special: true
+          score: 10
+        - task: task_1_2
+          score: 10
+        - task: task_1_3
+          is_bonus: true
+          score: 10
+        - task: task_1_4
+          score: 10
+
+    - group: group_2
+      start: 2000-02-01 18:00
+      end: 2000-03-01 23:59
+      tasks:
+        - task: task_2_1
+          score: 20
+        - task: task_2_2
+          score: 20
+        - task: task_2_3
+          score: 20
+
+    - group: group_3
+      start: 2020-03-01 18:00
+      steps:
+        0.5: 2020-03-01 23:59
+      end: 2020-05-01 23:59
+      enabled: true
+      tasks:
+        - task: task_3_0
+          score: 30
+        - task: task_3_1
+          score: 30
+        - task: task_3_2
+          score: 30
+
+    - group: group_4
+      special: true
+      start: 2020-03-01 18:00
+      steps:
+        0.5: 2020-04-01 23:59
+      end: 2040-05-01 23:59
+      enabled: true
+      tasks:
+        - task: task_4_0
+          score: 40
+        - task: task_4_1
+          score: 40
+        - task: task_4_2
+          score: 40

--- a/tests/.deadlines.test2.yml
+++ b/tests/.deadlines.test2.yml
@@ -1,0 +1,132 @@
+deadlines:
+  timezone: Europe/Berlin
+
+  deadlines: hard # hard/interpolate
+  max_submissions: 10 # optional
+  submission_penalty: 0.1 # optional
+
+  schedule:
+    - group: group_0
+      start: 2000-01-01 18:00
+      steps:
+        0.5: 2000-03-01 18:00
+      end: 2000-05-01 23:59
+      enabled: true
+      tasks:
+        - task: task_0_0
+          score: 10
+        - task: task_0_1
+          score: 10
+        - task: task_0_2
+          is_bonus: true
+          score: 10
+        - task: task_0_3
+          score: 10
+        - task: task_0_4
+          score: 10
+        - task: task_0_5
+          score: 10
+
+    - group: group_1
+      start: 2000-01-01 18:00
+      steps:
+        0.5: 2000-02-01 23:59
+      end: 2000-02-01 23:59
+      enabled: true
+      tasks:
+        - task: task_1_0
+          score: 10
+        - task: task_1_1
+          is_special: true
+          score: 10
+        - task: task_1_2
+          score: 10
+        - task: task_1_3
+          is_bonus: true
+          score: 10
+        - task: task_1_4
+          score: 10
+
+    - group: group_2
+      start: 2000-02-01 18:00
+      end: 2000-03-01 23:59
+      tasks:
+        - task: task_2_0
+          score: 20
+        - task: task_2_1
+          score: 20
+        - task: task_2_2
+          score: 20
+        - task: task_2_3
+          score: 20
+
+    - group: group_3
+      start: 2020-03-01 18:00
+      steps:
+        0.5: 2020-03-01 23:59
+      end: 2020-05-01 23:59
+      enabled: true
+      tasks:
+        - task: task_3_0
+          score: 30
+        - task: task_3_1
+          score: 30
+        - task: task_3_2
+          score: 30
+        - task: task_3_3
+          score: 30
+
+    - group: group_4
+      special: true
+      start: 2020-03-01 18:00
+      steps:
+        0.5: 2020-04-01 23:59
+      end: 2040-05-01 23:59
+      enabled: true
+      tasks:
+        - task: task_4_0
+          score: 40
+        - task: task_4_1
+          score: 40
+        - task: task_4_2
+          score: 40
+
+    - group: group_5
+      start: 2020-05-01 18:00
+      steps:
+        0.5: 2040-01-01 23:59
+      end: 2040-02-01 23:59
+      enabled: true
+      tasks:
+        - task: task_5_0
+          score: 50
+        - task: task_5_1
+          score: 50
+        - task: task_5_2
+          score: 50
+
+    - group: group_6
+      start: 2020-05-01 18:00
+      steps:
+        0.5: 2020-05-02 23:59
+        0.3: 13d 05:00:00
+      end: 13d 05:59:59
+      enabled: false
+      tasks:
+        - task: task_6_0
+          is_bonus: true
+          is_special: true
+          score: 60
+          url: https://www.python.org/about/gettingstarted/
+        - task: task_6_1
+          score: 60
+
+    - group: group_7
+      start: 2040-03-01 18:00
+      steps:
+        0.5: 13d 05:00:00
+      end: 13d 05:59:59
+      enabled: true
+      tasks:
+        - task: task_7_0
+          score: 70

--- a/tests/test_db_api.py
+++ b/tests/test_db_api.py
@@ -1,0 +1,425 @@
+from typing import Any
+
+import pytest
+import yaml
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from manytask.config import ManytaskDeadlinesConfig
+from manytask.database import DataBaseApi
+from manytask.glab import Student
+from manytask.models import Base, Course, Deadline, Grade, Task, TaskGroup, User, UserOnCourse
+
+
+SQLALCHEMY_DATABASE_URL = 'sqlite:///file::memory:?cache=shared'
+
+DEADLINES_CONFIG_FILES = [  # part of manytask config file
+    'tests/.deadlines.test.yml',
+    'tests/.deadlines.test2.yml'
+]
+
+
+@pytest.fixture
+def engine():
+    return create_engine(SQLALCHEMY_DATABASE_URL, echo=False)
+
+
+@pytest.fixture
+def tables(engine):
+    Base.metadata.create_all(engine)
+    yield
+    Base.metadata.drop_all(engine)
+
+
+@pytest.fixture
+def session(engine, tables):
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture
+def first_course_db_api(tables):
+    return DataBaseApi(
+        database_url=SQLALCHEMY_DATABASE_URL,
+        course_name="Test Course",
+        gitlab_instance_host="gitlab.test.com",
+        registration_secret="secret",
+        show_allscores=True
+    )
+
+
+@pytest.fixture
+def second_course_db_api(tables):
+    return DataBaseApi(
+        database_url=SQLALCHEMY_DATABASE_URL,
+        course_name="Another Test Course",
+        gitlab_instance_host="gitlab.test.com",
+        registration_secret="secret",
+        show_allscores=True
+    )
+
+
+def load_deadlines_config_and_sync_columns(db_api: DataBaseApi, yaml_file_file_path: str):
+    with open(yaml_file_file_path, "r") as f:
+        deadlines_config_data: dict[str, Any] = yaml.load(f, Loader=yaml.SafeLoader)
+    deadlines_config = ManytaskDeadlinesConfig(**deadlines_config_data['deadlines'])
+
+    db_api.sync_columns(deadlines_config)
+
+
+def update_func(add: int):
+    def _update_func(_, score):
+        return score + add
+
+    return _update_func
+
+
+def test_empty_course(first_course_db_api, session):
+    assert session.query(Course).count() == 1
+    course = session.query(Course).one()
+
+    assert course.name == 'Test Course'
+    assert course.gitlab_instance_host == 'gitlab.test.com'
+    assert course.registration_secret == 'secret'
+    assert course.show_allscores == True
+
+    stats = first_course_db_api.get_stats()
+    all_scores = first_course_db_api.get_all_scores()
+    bonus_score = first_course_db_api.get_bonus_score('some_user')
+    scores = first_course_db_api.get_scores('some_user')
+
+    assert stats == {}
+    assert all_scores == {}
+    assert bonus_score == 0
+    assert scores == {}
+
+
+def test_sync_columns(first_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[0])
+
+    stats = first_course_db_api.get_stats()
+    assert stats == {'task_0_0': 0, 'task_0_1': 0, 'task_0_2': 0,
+                     'task_0_3': 0, 'task_1_0': 0, 'task_1_1': 0,
+                     'task_1_2': 0, 'task_1_3': 0, 'task_1_4': 0,
+                     'task_2_1': 0, 'task_2_2': 0, 'task_2_3': 0,
+                     'task_3_0': 0, 'task_3_1': 0, 'task_3_2': 0,
+                     'task_4_0': 0, 'task_4_1': 0, 'task_4_2': 0}
+
+    assert session.query(TaskGroup).count() == 5
+    assert session.query(Task).count() == 18
+
+    tasks = session.query(Task).all()
+    for task in tasks:
+        assert task.group.name == 'group_' + task.name[len('task_')]
+
+
+def test_resync_columns(first_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[0])
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[1])
+
+    stats = first_course_db_api.get_stats()
+    assert stats == {'task_0_0': 0, 'task_0_1': 0, 'task_0_2': 0,
+                     'task_0_3': 0, 'task_0_4': 0, 'task_0_5': 0,
+                     'task_1_0': 0, 'task_1_1': 0, 'task_1_2': 0,
+                     'task_1_3': 0, 'task_1_4': 0, 'task_2_1': 0,
+                     'task_2_2': 0, 'task_2_3': 0, 'task_2_0': 0,
+                     'task_3_0': 0, 'task_3_1': 0, 'task_3_2': 0,
+                     'task_3_3': 0, 'task_4_0': 0, 'task_4_1': 0,
+                     'task_4_2': 0, 'task_5_0': 0, 'task_5_1': 0,
+                     'task_5_2': 0}
+
+    assert session.query(TaskGroup).count() == 6
+    assert session.query(Task).count() == 25
+
+    tasks = session.query(Task).all()
+    for task in tasks:
+        assert task.group.name == 'group_' + task.name[len('task_')]
+
+
+def test_store_score(first_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[1])
+
+    student = Student(0, 'user1', 'username1', False, 'repo1')
+
+    assert session.query(User).count() == 0
+    assert session.query(UserOnCourse).count() == 0
+
+    assert first_course_db_api.store_score(student, 'not_exist_task', update_func(1)) == 0
+
+    assert session.query(User).count() == 1
+    assert session.query(UserOnCourse).count() == 1
+
+    user = session.query(User).one()
+    assert user.username == student.username
+    assert user.gitlab_instance_host == 'gitlab.test.com'
+
+    user_on_course = session.query(UserOnCourse).one()
+    assert user_on_course.user_id == user.id
+    assert user_on_course.course.name == 'Test Course'
+    assert user_on_course.repo_name == student.repo
+
+    assert session.query(Grade).count() == 0
+
+    assert first_course_db_api.store_score(student, 'task_0_0', update_func(1)) == 1
+
+    assert session.query(User).count() == 1
+    assert session.query(UserOnCourse).count() == 1
+    assert session.query(Grade).count() == 1
+
+    grade = session.query(Grade).one()
+    assert grade.user_on_course_id == user_on_course.id
+    assert grade.task.name == 'task_0_0'
+    assert grade.score == 1
+
+    stats = first_course_db_api.get_stats()
+    all_scores = first_course_db_api.get_all_scores()
+    bonus_score = first_course_db_api.get_bonus_score('user1')
+    scores = first_course_db_api.get_scores('user1')
+
+    assert stats == {'task_0_0': 1.0, 'task_0_1': 0.0, 'task_0_2': 0.0,
+                     'task_0_3': 0.0, 'task_0_4': 0.0, 'task_0_5': 0.0,
+                     'task_1_0': 0.0, 'task_1_1': 0.0, 'task_1_2': 0.0,
+                     'task_1_3': 0.0, 'task_1_4': 0.0, 'task_2_1': 0.0,
+                     'task_2_2': 0.0, 'task_2_3': 0.0, 'task_2_0': 0.0,
+                     'task_3_0': 0.0, 'task_3_1': 0.0, 'task_3_2': 0.0,
+                     'task_3_3': 0.0, 'task_4_0': 0.0, 'task_4_1': 0.0,
+                     'task_4_2': 0.0, 'task_5_0': 0.0, 'task_5_1': 0.0,
+                     'task_5_2': 0.0}
+    assert all_scores == {'user1': {'task_0_0': 1}}
+    assert bonus_score == 0
+    assert scores == {'task_0_0': 1}
+
+
+def test_store_score_bonus_task(first_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[1])
+
+    student = Student(0, 'user1', 'username1', False, 'repo1')
+
+    assert first_course_db_api.store_score(student, 'task_1_3', update_func(22)) == 22
+
+    assert session.query(User).count() == 1
+    assert session.query(UserOnCourse).count() == 1
+    assert session.query(Grade).count() == 1
+
+    grade = session.query(Grade).join(Task).filter(Task.name == 'task_1_3').one()
+    assert grade.task.name == 'task_1_3'
+    assert grade.score == 22
+
+    stats = first_course_db_api.get_stats()
+    all_scores = first_course_db_api.get_all_scores()
+    bonus_score = first_course_db_api.get_bonus_score('user1')
+    scores = first_course_db_api.get_scores('user1')
+
+    assert stats == {'task_0_0': 0.0, 'task_0_1': 0.0, 'task_0_2': 0.0,
+                     'task_0_3': 0.0, 'task_0_4': 0.0, 'task_0_5': 0.0,
+                     'task_1_0': 0.0, 'task_1_1': 0.0, 'task_1_2': 0.0,
+                     'task_1_3': 1.0, 'task_1_4': 0.0, 'task_2_1': 0.0,
+                     'task_2_2': 0.0, 'task_2_3': 0.0, 'task_2_0': 0.0,
+                     'task_3_0': 0.0, 'task_3_1': 0.0, 'task_3_2': 0.0,
+                     'task_3_3': 0.0, 'task_4_0': 0.0, 'task_4_1': 0.0,
+                     'task_4_2': 0.0, 'task_5_0': 0.0, 'task_5_1': 0.0,
+                     'task_5_2': 0.0}
+    assert all_scores == {'user1': {'task_1_3': 22}}
+    assert bonus_score == 22
+    assert scores == {'task_1_3': 22}
+
+
+def test_many_users(first_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[1])
+
+    student1 = Student(0, 'user1', 'username1', False, 'repo1')
+    first_course_db_api.store_score(student1, 'task_0_0', update_func(1))
+    first_course_db_api.store_score(student1, 'task_1_3', update_func(22))
+
+    student2 = Student(1, 'user2', 'username2', False, 'repo2')
+
+    assert first_course_db_api.store_score(student2, 'task_0_0', update_func(15)) == 15
+
+    assert session.query(User).count() == 2
+    assert session.query(UserOnCourse).count() == 2
+    assert session.query(Grade).count() == 3
+
+    stats = first_course_db_api.get_stats()
+    all_scores = first_course_db_api.get_all_scores()
+    bonus_score_user1 = first_course_db_api.get_bonus_score('user1')
+    scores_user1 = first_course_db_api.get_scores('user1')
+    bonus_score_user2 = first_course_db_api.get_bonus_score('user2')
+    scores_user2 = first_course_db_api.get_scores('user2')
+
+    assert stats == {'task_0_0': 1.0, 'task_0_1': 0.0, 'task_0_2': 0.0,
+                     'task_0_3': 0.0, 'task_0_4': 0.0, 'task_0_5': 0.0,
+                     'task_1_0': 0.0, 'task_1_1': 0.0, 'task_1_2': 0.0,
+                     'task_1_3': 0.5, 'task_1_4': 0.0, 'task_2_1': 0.0,
+                     'task_2_2': 0.0, 'task_2_3': 0.0, 'task_2_0': 0.0,
+                     'task_3_0': 0.0, 'task_3_1': 0.0, 'task_3_2': 0.0,
+                     'task_3_3': 0.0, 'task_4_0': 0.0, 'task_4_1': 0.0,
+                     'task_4_2': 0.0, 'task_5_0': 0.0, 'task_5_1': 0.0,
+                     'task_5_2': 0.0}
+
+    assert all_scores == {'user1': {'task_0_0': 1, 'task_1_3': 22}, 'user2': {'task_0_0': 15}}
+    assert bonus_score_user1 == 22
+    assert scores_user1 == {'task_0_0': 1, 'task_1_3': 22}
+    assert bonus_score_user2 == 0
+    assert scores_user2 == {'task_0_0': 15}
+
+
+def test_many_courses(first_course_db_api, second_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[0])
+    load_deadlines_config_and_sync_columns(second_course_db_api, DEADLINES_CONFIG_FILES[1])
+
+    student = Student(0, 'user1', 'username1', False, 'repo1')
+    first_course_db_api.store_score(student, 'task_0_0', update_func(30))
+    second_course_db_api.store_score(student, 'task_1_3', update_func(40))
+
+    assert session.query(User).count() == 1
+    assert session.query(UserOnCourse).count() == 2
+    assert session.query(Grade).count() == 2
+
+    stats1 = first_course_db_api.get_stats()
+    all_scores1 = first_course_db_api.get_all_scores()
+    bonus_score_user1 = first_course_db_api.get_bonus_score('user1')
+    scores_user1 = first_course_db_api.get_scores('user1')
+
+    assert stats1 == {'task_0_0': 1.0, 'task_0_1': 0, 'task_0_2': 0,
+                      'task_0_3': 0, 'task_1_0': 0, 'task_1_1': 0,
+                      'task_1_2': 0, 'task_1_3': 0, 'task_1_4': 0,
+                      'task_2_1': 0, 'task_2_2': 0, 'task_2_3': 0,
+                      'task_3_0': 0, 'task_3_1': 0, 'task_3_2': 0,
+                      'task_4_0': 0, 'task_4_1': 0, 'task_4_2': 0}
+
+    assert all_scores1 == {'user1': {'task_0_0': 30}}
+    assert bonus_score_user1 == 0
+    assert scores_user1 == {'task_0_0': 30}
+
+    stats2 = second_course_db_api.get_stats()
+    all_scores2 = second_course_db_api.get_all_scores()
+    bonus_score_user2 = second_course_db_api.get_bonus_score('user1')
+    scores_user2 = second_course_db_api.get_scores('user1')
+
+    assert stats2 == {'task_0_0': 0.0, 'task_0_1': 0.0, 'task_0_2': 0.0,
+                      'task_0_3': 0.0, 'task_0_4': 0.0, 'task_0_5': 0.0,
+                      'task_1_0': 0.0, 'task_1_1': 0.0, 'task_1_2': 0.0,
+                      'task_1_3': 1.0, 'task_1_4': 0.0, 'task_2_1': 0.0,
+                      'task_2_2': 0.0, 'task_2_3': 0.0, 'task_2_0': 0.0,
+                      'task_3_0': 0.0, 'task_3_1': 0.0, 'task_3_2': 0.0,
+                      'task_3_3': 0.0, 'task_4_0': 0.0, 'task_4_1': 0.0,
+                      'task_4_2': 0.0, 'task_5_0': 0.0, 'task_5_1': 0.0,
+                      'task_5_2': 0.0}
+
+    assert all_scores2 == {'user1': {'task_1_3': 40}}
+    assert bonus_score_user2 == 40
+    assert scores_user2 == {'task_1_3': 40}
+
+
+def test_many_users_and_courses(first_course_db_api, second_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[0])
+    load_deadlines_config_and_sync_columns(second_course_db_api, DEADLINES_CONFIG_FILES[1])
+
+    student1 = Student(0, 'user1', 'username1', False, 'repo1')
+    student2 = Student(1, 'user2', 'username2', False, 'repo2')
+
+    first_course_db_api.store_score(student1, 'task_0_0', update_func(1))
+    first_course_db_api.store_score(student1, 'task_1_3', update_func(22))
+    first_course_db_api.store_score(student2, 'task_0_0', update_func(15))
+
+    second_course_db_api.store_score(student1, 'task_1_0', update_func(99))
+    second_course_db_api.store_score(student2, 'task_1_1', update_func(7))
+
+    assert session.query(User).count() == 2
+    assert session.query(UserOnCourse).count() == 4
+    assert session.query(Grade).count() == 5
+
+    stats1 = first_course_db_api.get_stats()
+    all_scores1 = first_course_db_api.get_all_scores()
+    bonus_score1_user1 = first_course_db_api.get_bonus_score('user1')
+    scores1_user1 = first_course_db_api.get_scores('user1')
+    bonus_score1_user2 = first_course_db_api.get_bonus_score('user2')
+    scores1_user2 = first_course_db_api.get_scores('user2')
+
+    assert stats1 == {'task_0_0': 1.0, 'task_0_1': 0, 'task_0_2': 0,
+                      'task_0_3': 0, 'task_1_0': 0, 'task_1_1': 0,
+                      'task_1_2': 0, 'task_1_3': 0.5, 'task_1_4': 0,
+                      'task_2_1': 0, 'task_2_2': 0, 'task_2_3': 0,
+                      'task_3_0': 0, 'task_3_1': 0, 'task_3_2': 0,
+                      'task_4_0': 0, 'task_4_1': 0, 'task_4_2': 0}
+
+    assert all_scores1 == {'user1': {'task_0_0': 1, 'task_1_3': 22}, 'user2': {'task_0_0': 15}}
+    assert bonus_score1_user1 == 22
+    assert scores1_user1 == {'task_0_0': 1, 'task_1_3': 22}
+    assert bonus_score1_user2 == 0
+    assert scores1_user2 == {'task_0_0': 15}
+
+    stats2 = second_course_db_api.get_stats()
+    all_scores2 = second_course_db_api.get_all_scores()
+    bonus_score2_user1 = second_course_db_api.get_bonus_score('user1')
+    scores2_user1 = second_course_db_api.get_scores('user1')
+    bonus_score2_user2 = second_course_db_api.get_bonus_score('user2')
+    scores2_user2 = second_course_db_api.get_scores('user2')
+
+    assert stats2 == {'task_0_0': 0.0, 'task_0_1': 0.0, 'task_0_2': 0.0,
+                      'task_0_3': 0.0, 'task_0_4': 0.0, 'task_0_5': 0.0,
+                      'task_1_0': 0.5, 'task_1_1': 0.5, 'task_1_2': 0.0,
+                      'task_1_3': 0.0, 'task_1_4': 0.0, 'task_2_1': 0.0,
+                      'task_2_2': 0.0, 'task_2_3': 0.0, 'task_2_0': 0.0,
+                      'task_3_0': 0.0, 'task_3_1': 0.0, 'task_3_2': 0.0,
+                      'task_3_3': 0.0, 'task_4_0': 0.0, 'task_4_1': 0.0,
+                      'task_4_2': 0.0, 'task_5_0': 0.0, 'task_5_1': 0.0,
+                      'task_5_2': 0.0}
+
+    assert all_scores2 == {'user1': {'task_1_0': 99}, 'user2': {'task_1_1': 7}}
+    assert bonus_score2_user1 == 0
+    assert scores2_user1 == {'task_1_0': 99}
+    assert bonus_score2_user2 == 0
+    assert scores2_user2 == {'task_1_1': 7}
+
+
+def test_deadlines(first_course_db_api, second_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[1])
+    load_deadlines_config_and_sync_columns(second_course_db_api, DEADLINES_CONFIG_FILES[0])
+
+    deadline1 = session.query(Deadline).join(TaskGroup).filter(
+        TaskGroup.name == 'group_1').join(Course).filter(Course.name == 'Test Course').one()
+
+    assert deadline1.data == {'start': '2000-01-01T18:00:00+01:00',
+                              'steps': {'0.5': '2000-02-01T23:59:00+01:00'},
+                              'end': '2000-02-01T23:59:00+01:00'}
+
+    deadline2 = session.query(Deadline).join(TaskGroup).filter(
+        TaskGroup.name == 'group_1').join(Course).filter(Course.name == 'Another Test Course').one()
+
+    assert deadline2.data == {'start': '2000-01-02T18:00:00+01:00',
+                              'steps': {'0.5': '2000-02-02T23:59:00+01:00'},
+                              'end': '2000-02-02T23:59:00+01:00'}
+
+
+def test_course_change_params(first_course_db_api):
+    with pytest.raises(AttributeError):
+        db_api = DataBaseApi(
+            database_url=SQLALCHEMY_DATABASE_URL,
+            course_name="Test Course",
+            gitlab_instance_host="gitlab.another_test.com",
+            registration_secret="secret",
+            show_allscores=True
+        )
+
+    db_api = DataBaseApi(
+        database_url=SQLALCHEMY_DATABASE_URL,
+        course_name="Test Course",
+        gitlab_instance_host="gitlab.test.com",
+        registration_secret="another_secret",
+        show_allscores=False
+    )
+
+
+def test_bad_requests(first_course_db_api, session):
+    load_deadlines_config_and_sync_columns(first_course_db_api, DEADLINES_CONFIG_FILES[1])
+
+    bonus_score = first_course_db_api.get_bonus_score('random_user')
+    scores = first_course_db_api.get_scores('random_user')
+
+    assert bonus_score == 0
+    assert scores == {}
+
+    assert session.query(User).count() == 0
+    assert session.query(UserOnCourse).count() == 0
+    assert session.query(Grade).count() == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timezone
+from datetime import datetime
 
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, StatementError
 from sqlalchemy.orm import Session
 
 from manytask.models import Base, Course, Deadline, Grade, Task, TaskGroup, User, UserOnCourse
@@ -27,6 +27,11 @@ def tables(engine):
 def session(engine, tables):
     with Session(engine) as session:
         yield session
+
+
+@pytest.fixture
+def fixed_current_time():
+    return datetime(2024, 12, 23, 12, 30, 10)
 
 
 def test_user_simple(session):
@@ -171,6 +176,44 @@ def test_task_group(session):
     assert retrieved.deadline is None
 
 
+def test_deadline_data(session, fixed_current_time):
+    course = Course(name="course0003", registration_secret="secret",
+                    gitlab_instance_host='gitlab.inst.org')
+    session.add(course)
+    session.commit()
+
+    deadline1 = Deadline(id=1001)
+    deadline2 = Deadline(id=1002, data={})
+    deadline3 = Deadline(id=1003, data=[])
+    deadline4 = Deadline(id=1004, data=12345)
+    deadline5 = Deadline(id=1005, data="some_data")
+    session.add_all([deadline1, deadline2, deadline3, deadline4, deadline5])
+    session.commit()
+
+    assert session.query(Deadline).filter_by(id=1001).one().data == {}
+    assert session.query(Deadline).filter_by(id=1002).one().data == {}
+    assert session.query(Deadline).filter_by(id=1003).one().data == []
+    assert session.query(Deadline).filter_by(id=1004).one().data == 12345
+    assert session.query(Deadline).filter_by(id=1005).one().data == "some_data"
+
+    class MyObject:
+        def __init__(self, value):
+            self.value = value
+
+    deadlines = [
+        Deadline(id=1006, data=b"binary_data"),
+        Deadline(id=1007, data=MyObject(10)),
+        Deadline(id=1008, data={1, 2, 3}),
+        Deadline(id=1009, data=fixed_current_time)
+    ]
+
+    for deadline in deadlines:
+        with pytest.raises(StatementError):
+            session.add(deadline)
+            session.commit()
+        session.rollback()
+
+
 def test_task(session):
     course = Course(name="course3", registration_secret="secret3",
                     gitlab_instance_host='gitlab.inst.org')
@@ -187,7 +230,7 @@ def test_task(session):
     assert retrieved_task.group.name == "group3"
 
 
-def test_grade(session):
+def test_grade(session, fixed_current_time):
     user = User(username="user2", gitlab_instance_host='gitlab.inst.org')
     course = Course(name="course4", registration_secret="secret4",
                     gitlab_instance_host='gitlab.inst.org')
@@ -205,7 +248,7 @@ def test_grade(session):
         user_on_course=user_on_course,
         task=task,
         score=77,
-        last_submit_date=datetime.now(timezone.utc)
+        last_submit_date=fixed_current_time
     )
     session.add(grade)
     session.commit()
@@ -213,9 +256,10 @@ def test_grade(session):
     retrieved_grade = session.query(Grade).first()
     assert retrieved_grade.user_on_course.user.username == "user2"
     assert retrieved_grade.score == 77
+    assert retrieved_grade.last_submit_date == fixed_current_time
 
 
-def test_grade_unique_ids(session):
+def test_grade_unique_ids(session, fixed_current_time):
     course = Course(name="course101", registration_secret="secret101",
                     gitlab_instance_host='gitlab.inst.org')
     task_group = TaskGroup(name="group101", course=course)
@@ -241,25 +285,25 @@ def test_grade_unique_ids(session):
         user_on_course=user_on_course1,
         task=task1,
         score=11,
-        last_submit_date=datetime.now(timezone.utc)
+        last_submit_date=fixed_current_time
     )
     grade2 = Grade(
         user_on_course=user_on_course1,
         task=task2,
         score=11,
-        last_submit_date=datetime.now(timezone.utc)
+        last_submit_date=fixed_current_time
     )
     grade3 = Grade(
         user_on_course=user_on_course2,
         task=task1,
         score=11,
-        last_submit_date=datetime.now(timezone.utc)
+        last_submit_date=fixed_current_time
     )
     grade4 = Grade(
         user_on_course=user_on_course2,
         task=task2,
         score=11,
-        last_submit_date=datetime.now(timezone.utc)
+        last_submit_date=fixed_current_time
     )
 
     session.add_all([grade1, grade2, grade3, grade4])
@@ -269,7 +313,7 @@ def test_grade_unique_ids(session):
         user_on_course=user_on_course1,
         task=task1,
         score=11,
-        last_submit_date=datetime.now(timezone.utc)
+        last_submit_date=fixed_current_time
     )
     session.add(grade5)
     with pytest.raises(IntegrityError):
@@ -323,3 +367,148 @@ def test_users_on_course_validate_gitlab_instance(session):
     session.add_all([user, course, user_on_course])
     with pytest.raises(ValueError):
         session.commit()
+
+
+def test_cascade_delete_course(session):
+    course = Course(name="cascade_course", registration_secret="secret",
+                    gitlab_instance_host='gitlab.inst.org')
+    task_group1 = TaskGroup(name="cascade_group1", course=course)
+    task_group2 = TaskGroup(name="cascade_group2", course=course)
+    user1 = User(username="cascade_user1", gitlab_instance_host='gitlab.inst.org')
+    user2 = User(username="cascade_user2", gitlab_instance_host='gitlab.inst.org')
+    user_on_course1 = UserOnCourse(user=user1, course=course, repo_name="cascade_repo1")
+    user_on_course2 = UserOnCourse(user=user2, course=course, repo_name="cascade_repo2")
+    session.add_all([course, task_group1, task_group2, user1,
+                    user2, user_on_course1, user_on_course2])
+    session.commit()
+
+    task1 = Task(name="cascade_task1", group=task_group1)
+    task2 = Task(name="cascade_task2", group=task_group2)
+    task3 = Task(name="cascade_task3", group=task_group2)
+    session.add_all([task1, task2, task3])
+    session.commit()
+
+    grade1 = Grade(user_on_course=user_on_course1, task=task1, score=12345)
+    grade2 = Grade(user_on_course=user_on_course2, task=task1, score=12345)
+    grade3 = Grade(user_on_course=user_on_course2, task=task2, score=12345)
+    grade4 = Grade(user_on_course=user_on_course2, task=task3, score=12345)
+    session.add_all([grade1, grade2, grade3, grade4])
+    session.commit()
+
+    assert session.query(Course).filter_by(name="cascade_course").first() is not None
+    assert session.query(TaskGroup).filter(TaskGroup.name.in_(
+        ["cascade_group1", "cascade_group2"])).count() == 2
+    assert session.query(Task).filter(Task.name.in_(
+        ["cascade_task1", "cascade_task2", "cascade_task3"])).count() == 3
+    assert session.query(UserOnCourse).filter(UserOnCourse.repo_name.in_(
+        ["cascade_repo1", "cascade_repo2"])).count() == 2
+    assert session.query(Grade).filter_by(score=12345).count() == 4
+
+    session.delete(course)
+    session.commit()
+
+    assert session.query(Course).filter_by(name="cascade_course").first() is None
+    assert session.query(TaskGroup).filter(TaskGroup.name.in_(
+        ["cascade_group1", "cascade_group2"])).count() == 0
+    assert session.query(Task).filter(Task.name.in_(
+        ["cascade_task1", "cascade_task2", "cascade_task3"])).count() == 0
+    assert session.query(UserOnCourse).filter(UserOnCourse.repo_name.in_(
+        ["cascade_repo1", "cascade_repo2"])).count() == 0
+    assert session.query(Grade).filter_by(score=12345).count() == 0
+
+    assert session.query(User).filter(User.username.in_(
+        ["cascade_user1", "cascade_user2"])).count() == 2
+
+
+def test_cascade_delete_task_group(session):
+    course = Course(name="cascade_course2", registration_secret="secret",
+                    gitlab_instance_host='gitlab.inst.org')
+    deadline = Deadline(id=12345, data={"test_key": "test_value"})
+    task_group = TaskGroup(name="cascade_group3", course=course, deadline=deadline)
+    task1 = Task(name="cascade_task4", group=task_group)
+    task2 = Task(name="cascade_task5", group=task_group)
+    session.add_all([course, deadline, task_group, task1, task2])
+    session.commit()
+
+    user = User(username="cascade_user3", gitlab_instance_host='gitlab.inst.org')
+    user_on_course = UserOnCourse(user=user, course=course, repo_name="cascade_repo3")
+    grade1 = Grade(user_on_course=user_on_course, task=task1, score=123456)
+    grade2 = Grade(user_on_course=user_on_course, task=task2, score=123456)
+    session.add_all([user, user_on_course, grade1, grade2])
+    session.commit()
+
+    assert session.query(TaskGroup).filter_by(name="cascade_group3").first() is not None
+    assert session.query(Task).filter(Task.name.in_(
+        ["cascade_task4", "cascade_task5"])).count() == 2
+    assert session.query(Grade).filter_by(score=123456).count() == 2
+    assert session.query(Deadline).filter_by(id=12345).count() == 1
+
+    session.delete(task_group)
+    session.commit()
+
+    assert session.query(TaskGroup).filter_by(name="cascade_group3").first() is None
+    assert session.query(Task).filter(Task.name.in_(
+        ["cascade_task4", "cascade_task5"])).count() == 0
+    assert session.query(Grade).filter_by(score=123456).count() == 0
+    assert session.query(Deadline).filter_by(id=12345).count() == 0
+
+    retrieved_user = session.query(User).filter_by(username="cascade_user3").first()
+    assert retrieved_user is not None
+    assert len(retrieved_user.users_on_courses.all()) == 1
+
+    retrieved_course = session.query(Course).filter_by(name="cascade_course2").first()
+    assert retrieved_course is not None
+    assert len(retrieved_course.users_on_courses.all()) == 1
+
+
+def test_cascade_delete_user(session):
+    user = User(username="cascade_user4", gitlab_instance_host='gitlab.inst.org')
+    course = Course(name="cascade_course3", registration_secret="secret",
+                    gitlab_instance_host='gitlab.inst.org')
+    user_on_course = UserOnCourse(user=user, course=course, repo_name="cascade_repo4")
+    task_group = TaskGroup(name="cascade_group4", course=course)
+    task = Task(name="cascade_task6", group=task_group)
+    grade = Grade(user_on_course=user_on_course, task=task, score=1234567)
+    session.add_all([user, course, user_on_course, task_group, task, grade])
+    session.commit()
+
+    assert session.query(User).filter_by(username="cascade_user4").first() is not None
+    assert session.query(UserOnCourse).filter_by(repo_name="cascade_repo4").first() is not None
+    assert session.query(Grade).filter_by(score=1234567).count() == 1
+
+    session.delete(user)
+    session.commit()
+
+    assert session.query(User).filter_by(username="cascade_user4").first() is None
+    assert session.query(UserOnCourse).filter_by(repo_name="cascade_repo4").first() is None
+    assert session.query(Grade).filter_by(score=1234567).count() == 0
+
+    assert session.query(Course).filter_by(name="cascade_course3").first() is not None
+    assert session.query(TaskGroup).filter_by(name="cascade_group4").first() is not None
+
+
+def test_cascade_delete_user_on_course(session):
+    user = User(username="cascade_user5", gitlab_instance_host='gitlab.inst.org')
+    course = Course(name="cascade_course4", registration_secret="secret",
+                    gitlab_instance_host='gitlab.inst.org')
+    user_on_course = UserOnCourse(user=user, course=course, repo_name="cascade_repo5")
+    task_group = TaskGroup(name="cascade_group5", course=course)
+    task = Task(name="cascade_task7", group=task_group)
+    grade = Grade(user_on_course=user_on_course, task=task, score=12345678)
+    session.add_all([user, course, user_on_course, task_group, task, grade])
+    session.commit()
+
+    assert session.query(UserOnCourse).filter_by(repo_name="cascade_repo5").first() is not None
+    assert session.query(Grade).filter_by(score=12345678).count() == 1
+
+    session.delete(user_on_course)
+    session.commit()
+
+    assert session.query(UserOnCourse).filter_by(repo_name="cascade_repo5").first() is None
+    assert session.query(Grade).filter_by(score=12345678).count() == 0
+
+    assert session.query(User).filter_by(username="cascade_user5").first() is not None
+    assert session.query(Course).filter_by(name="cascade_course4").first() is not None
+
+    assert session.query(TaskGroup).filter_by(name="cascade_group5").first() is not None
+    assert session.query(Task).filter_by(name="cascade_task7").first() is not None


### PR DESCRIPTION
Changed lazy='dynamic' to DynamicMapped, it is the same thing but more convenient.
In Grade instead of User relationship using UserOnCourse.
Swapped TaskGroup and Task for convenience(link to course now in TaskGroup instead of Task).
Removed unused fields: is_manytask_admin, is_course_admin.
Add gitlab_instance_host field to course and validation gitlab_instance_host equal when creating UserOnCourse.
Also edited test_models.py

Current scheme:
https://drawsql.app/teams/gagarinkomar/diagrams/copy-of-copy-of-manytask