### PR TITLE
refactor: @requires_ready and @requires_auth in web requests

### DIFF
--- a/manytask/web.py
+++ b/manytask/web.py
@@ -169,7 +169,7 @@ def login() -> ResponseReturnValue:
 
     redirect_uri = url_for("web.login_finish", _external=True)
 
-    return oauth.gitlab.authorize_redirect(redirect_uri) # type: ignore
+    return oauth.gitlab.authorize_redirect(redirect_uri)
 
 
 @bp.route("/login_finish")

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -7,6 +7,7 @@ from authlib.integrations.base_client import OAuthError
 from authlib.integrations.flask_client import OAuth
 from flask import Blueprint, Response, current_app, redirect, render_template, request, session, url_for
 from flask.typing import ResponseReturnValue
+from toolz import get_in
 
 from . import glab
 from .auth import requires_auth, requires_ready
@@ -67,7 +68,7 @@ def course_page() -> ResponseReturnValue:
         student_repo_url=student_repo,
         student_ci_url=f"{student_repo}/pipelines",
         manytask_version=course.manytask_version,
-        links=course.config.ui.links if course.config else dict(),
+        links=get_in(["config", "ui", "links"], course, dict()),
         scores=tasks_scores,
         bonus_score=storage_api.get_bonus_score(student_username),
         now=get_current_time(),

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -67,7 +67,7 @@ def course_page() -> ResponseReturnValue:
         student_repo_url=student_repo,
         student_ci_url=f"{student_repo}/pipelines",
         manytask_version=course.manytask_version,
-        links=course.config.ui.links or dict(),
+        links=course.config.ui.links if course.config else dict(),
         scores=tasks_scores,
         bonus_score=storage_api.get_bonus_score(student_username),
         now=get_current_time(),
@@ -169,7 +169,7 @@ def login() -> ResponseReturnValue:
 
     redirect_uri = url_for("web.login_finish", _external=True)
 
-    return oauth.gitlab.authorize_redirect(redirect_uri)
+    return oauth.gitlab.authorize_redirect(redirect_uri) # type: ignore
 
 
 @bp.route("/login_finish")

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ PyYAML==6.0.1
 requests==2.32.3
 pydantic==2.10.3
 pytz >=2022.0,<2023.4; python_version < '3.9'
+toolz==1.0.0


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
Feel free to set Draft status if you need help or want to discuss. -->

## Description
In web.py, most of the requests handle authorization with their own logic. They should use @requires_auth
@requires_ready decorators instead.

<!-- Which changes sre suggested? How specific behaviour will change? -->


## Motivation and Context
Closes https://github.com/manytask/manytask/issues/232


## Contribution Checklist

- [x] I have read and agreed on the [CONTRIBUTING](../CONTRIBUTING.md) and [CODE OF CONDUCT](../CODE_OF_CONDUCT.md) documents.
- [x] I have run linters, type checks, import sorting and tests locally.
- [x] I have added comments to code in hard-to-understand areas.
- [x] I have added 100% coverage tests for the new code (or aren't needed).
- [x] I have added docs for the new code (or aren't needed).
- [x] I have used [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) title: `tag(scope): description`. 


## [optional] Screenshots
<!-- If the changes are visual, including screenshots or GIFs can 
help reviewers understand them more easily. -->


## [optional] Special notes
<!-- If there are any specific instructions or considerations you 
want to highlight for the reviewer, include them in this section. -->


## [optional] What gif best describes this PR or how it makes you feel?
<!-- You can use this one if you want: https://media.giphy.com/media/3o7aDcz6Y0fzWYvU5a/giphy.gif -->
<!-- ![](https://media.giphy.com/media/3o7aDcz6Y0fzWYvU5a/giphy.gif) -->
