### PR TITLE
feat: add synchronization course_admin from gitlab to manytask

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -1,8 +1,19 @@
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Callable
 
 from .config import ManytaskDeadlinesConfig
 from .glab import Student
+
+
+@dataclass
+class StoredUser:
+    username: str
+    course_admin: bool = False
+    # we can add more fields that we store
+
+    def __repr__(self) -> str:
+        return f"StoredUser(username={self.username})"
 
 
 class ViewerApi(ABC):
@@ -24,6 +35,20 @@ class StorageApi(ABC):
         self,
         username: str,
     ) -> int:
+        ...
+
+    @abstractmethod
+    def get_stored_user(
+        self,
+        student: Student,
+    ) -> StoredUser:
+        ...
+
+    @abstractmethod
+    def sync_stored_user(
+        self,
+        student: Student,
+    ) -> StoredUser:
         ...
 
     @abstractmethod

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.sql.functions import func
 
 from . import models
-from .abstract import StorageApi
+from .abstract import StorageApi, StoredUser
 from .config import ManytaskDeadlinesConfig
 from .glab import Student
 
@@ -109,6 +109,50 @@ class DataBaseApi(StorageApi):
 
         return sum([grade.score for grade in grades])
 
+    def get_stored_user(
+        self,
+        student: Student,
+    ) -> StoredUser:
+        """Method for getting user's stored data
+
+        :param student: Student object
+
+        :return: created or received StoredUser object
+        """
+
+        with Session(self.engine) as session:
+            course = self._get(session, models.Course, name=self.course_name)
+            user_on_course = self._get_or_create_user_on_course(session, student, course)
+
+            return StoredUser(
+                username=user_on_course.user.username,
+                course_admin=user_on_course.is_course_admin
+            )
+
+    def sync_stored_user(
+        self,
+        student: Student,
+    ) -> StoredUser:
+        """Method for sync user's gitlab and stored data
+
+        :param student: Student object
+
+        :return: created or updated StoredUser object
+        """
+
+        with Session(self.engine) as session:
+            course = self._get(session, models.Course, name=self.course_name)
+            user_on_course = self._get_or_create_user_on_course(session, student, course)
+
+            user_on_course.is_course_admin = user_on_course.is_course_admin or student.course_admin
+
+            session.commit()
+
+            return StoredUser(
+                username=user_on_course.user.username,
+                course_admin=user_on_course.is_course_admin
+            )
+
     def get_all_scores(self) -> dict[str, dict[str, int]]:
         """Method for getting all scores for all users
 
@@ -177,22 +221,7 @@ class DataBaseApi(StorageApi):
 
         with Session(self.engine) as session:
             course = self._get(session, models.Course, name=self.course_name)
-            user = self._get_or_create(
-                session,
-                models.User,
-                username=student.username,
-                gitlab_instance_host=course.gitlab_instance_host
-            )
-
-            user_on_course = self._get_or_create(
-                session,
-                models.UserOnCourse,
-                defaults={
-                    'repo_name': student.repo
-                },
-                user_id=user.id,
-                course_id=course.id
-            )
+            user_on_course = self._get_or_create_user_on_course(session, student, course)
 
             try:
                 task = self._get_task_by_name_and_course_id(session, task_name, course.id)
@@ -272,6 +301,31 @@ class DataBaseApi(StorageApi):
         except IntegrityError as e:  # if tables are created concurrently
             if not isinstance(e.orig, UniqueViolation):
                 raise
+
+    def _get_or_create_user_on_course(
+        self,
+        session: Session,
+        student: Student,
+        course: models.Course
+    ) -> models.UserOnCourse:
+        user = self._get_or_create(
+            session,
+            models.User,
+            username=student.username,
+            gitlab_instance_host=course.gitlab_instance_host
+        )
+
+        user_on_course = self._get_or_create(
+            session,
+            models.UserOnCourse,
+            defaults={
+                'repo_name': student.repo
+            },
+            user_id=user.id,
+            course_id=course.id
+        )
+
+        return user_on_course
 
     def _get_scores(
         self,

--- a/manytask/gdoc.py
+++ b/manytask/gdoc.py
@@ -93,6 +93,7 @@ class GoogleDocApi(ViewerApi, StorageApi):
         public_worksheet_id: str,
         public_scoreboard_sheet: int,
         cache: BaseCache,
+        testing: bool = False
     ):
         """
         :param base_url:
@@ -100,7 +101,12 @@ class GoogleDocApi(ViewerApi, StorageApi):
         :param public_worksheet_id:
         :param public_scoreboard_sheet:
         :param cache:
+        :param testing:
         """
+
+        if testing:
+            return  # TODO: cover all methods
+
         self._url = base_url
         self._gdoc_credentials = gdoc_credentials
         self._public_worksheet_id = public_worksheet_id

--- a/manytask/gdoc.py
+++ b/manytask/gdoc.py
@@ -14,7 +14,7 @@ from google.auth.credentials import AnonymousCredentials
 from gspread import Cell as GCell
 from gspread.utils import ValueInputOption, ValueRenderOption, a1_to_rowcol, rowcol_to_a1
 
-from .abstract import StorageApi, ViewerApi
+from .abstract import StorageApi, StoredUser, ViewerApi
 from .config import ManytaskConfig, ManytaskDeadlinesConfig
 from .course import get_current_time
 from .glab import Student
@@ -171,6 +171,21 @@ class GoogleDocApi(ViewerApi, StorageApi):
         if bonus_scores is None:
             return 0
         return bonus_scores.get(username, 0)
+
+    def get_stored_user(
+        self,
+        student: Student,
+    ) -> StoredUser:
+        return StoredUser(
+            username=student.username,
+            course_admin=False
+        )
+
+    def sync_stored_user(
+        self,
+        student: Student,
+    ) -> StoredUser:
+        return self.get_stored_user(student)
 
     def get_all_scores(self) -> dict[str, dict[str, int]]:
         all_scores = self._cache.get(f"{self.ws.id}:scores")

--- a/manytask/models.py
+++ b/manytask/models.py
@@ -64,6 +64,7 @@ class UserOnCourse(Base):
     course_id: Mapped[int] = mapped_column(ForeignKey(Course.id))
     repo_name: Mapped[str]
     join_date: Mapped[datetime] = mapped_column(server_default=func.now())
+    is_course_admin: Mapped[bool] = mapped_column(default=False)
 
     __table_args__ = (
         UniqueConstraint('user_id', 'course_id', name='_user_course_uc'),

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -33,7 +33,11 @@ def course_page() -> ResponseReturnValue:
     if current_app.debug:
         student_username = "guest"
         student_repo = course.gitlab_api.get_url_for_repo(student_username)
-        student_course_admin = True
+
+        if request.args.get('admin', None) in ('true', '1', 'yes', None):
+            student_course_admin = True
+        else:
+            student_course_admin = False
     else:
         student_username = session["gitlab"]["username"]
         student_repo = session["gitlab"]["repo"]
@@ -89,7 +93,10 @@ def get_solutions() -> ResponseReturnValue:
     course: Course = current_app.course  # type: ignore
 
     if current_app.debug:
-        student_course_admin = True
+        if request.args.get('admin', None) in ('true', '1', 'yes', None):
+            student_course_admin = True
+        else:
+            student_course_admin = False
     else:
         student = course.gitlab_api.get_student(session["gitlab"]["user_id"])
         stored_user = course.storage_api.get_stored_user(student)
@@ -220,8 +227,9 @@ def login_finish() -> ResponseReturnValue:
 
     if (course.gitlab_api.check_project_exists(student)):
         return redirect(url_for("web.course_page"))
-    else :
+    else:
         return redirect(url_for("web.create_project"))
+
 
 @bp.route("/create_project", methods=["GET", "POST"])
 @requires_ready
@@ -290,7 +298,11 @@ def show_database() -> ResponseReturnValue:
 
     if current_app.debug:
         student_username = "guest"
-        student_course_admin = True
+
+        if request.args.get('admin', None) in ('true', '1', 'yes', None):
+            student_course_admin = True
+        else:
+            student_course_admin = False
     else:
         student_username = session["gitlab"]["username"]
 

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -1,0 +1,15 @@
+import pytest
+
+from manytask.abstract import StoredUser
+
+
+def test_stored_user():
+    stored_user1 = StoredUser('user1')
+
+    assert stored_user1.course_admin == False
+    assert repr(stored_user1) == 'StoredUser(username=user1)'
+
+    stored_user2 = StoredUser('user2', True)
+
+    assert stored_user2.course_admin == True
+    assert repr(stored_user2) == 'StoredUser(username=user2)'

--- a/tests/test_gdoc.py
+++ b/tests/test_gdoc.py
@@ -1,0 +1,41 @@
+import pytest
+from cachelib import BaseCache
+
+from manytask.gdoc import GoogleDocApi
+from manytask.glab import Student
+
+
+@pytest.fixture
+def empty_google_doc_api():
+    return GoogleDocApi(
+        base_url="",
+        gdoc_credentials={},
+        public_worksheet_id="",
+        public_scoreboard_sheet=0,
+        cache=BaseCache(),
+        testing=True
+    )
+
+
+def test_get_stored_user(empty_google_doc_api):
+    student1 = Student(id=0, username='user1', name='', course_admin=False)
+    stored_user1 = empty_google_doc_api.get_stored_user(student1)
+
+    assert stored_user1.username == 'user1'
+    assert stored_user1.course_admin == False
+
+    student2 = Student(id=0, username='user2', name='', course_admin=True)
+    stored_user2 = empty_google_doc_api.get_stored_user(student2)
+
+    assert stored_user2.username == 'user2'
+    assert stored_user2.course_admin == False
+
+
+def test_sync_stored_user(empty_google_doc_api):
+    student1 = Student(id=0, username='user1', name='', course_admin=False)
+
+    assert empty_google_doc_api.sync_stored_user(student1) == empty_google_doc_api.get_stored_user(student1)
+
+    student2 = Student(id=0, username='user2', name='', course_admin=True)
+
+    assert empty_google_doc_api.sync_stored_user(student2) == empty_google_doc_api.get_stored_user(student2)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,6 +104,15 @@ def test_user_on_course(session):
     assert len(retrieved_course.users_on_courses.all()) == 1
     assert retrieved_course.users_on_courses[0].user.username == "user1"
 
+    retrieved_user_on_course = session.query(UserOnCourse).filter_by(repo_name="user1_repo").first()
+    assert retrieved_user_on_course.is_course_admin == False
+
+    retrieved_user_on_course.is_course_admin = True
+    session.commit()
+
+    retrieved_user_on_course = session.query(UserOnCourse).filter_by(repo_name="user1_repo").first()
+    assert retrieved_user_on_course.is_course_admin == True
+
 
 def test_user_on_course_unique_ids(session):
     user1 = User(username="user001", gitlab_instance_host='gitlab.inst.org')

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -81,6 +81,9 @@ def mock_course():
                 return 100  # Mock value for testing
 
         class gitlab_api:
+            def __init__(self):
+                self.course_admin = False
+
             @staticmethod
             def get_url_for_repo(username):
                 return f"{GITLAB_BASE_URL}/{username}/repo"
@@ -98,6 +101,13 @@ def mock_course():
             @staticmethod
             def get_student(_user_id):
                 return Student(id=TEST_USER_ID, username=TEST_USERNAME, name='')
+
+            def get_authenticated_student(self, _gitlab_access_token):
+                return Student(id=TEST_USER_ID, username=TEST_USERNAME, name='', course_admin=self.course_admin)
+
+            @staticmethod
+            def check_project_exists(_student):
+                return True
 
             base_url = GITLAB_BASE_URL
 
@@ -125,6 +135,10 @@ def mock_course():
             def get_bonus_score(_username):
                 return 10
 
+            def sync_stored_user(self, student):
+                if student.course_admin:
+                    self.stored_user.course_admin = True
+
             def get_stored_user(self, _student):
                 return self.stored_user
 
@@ -142,6 +156,17 @@ def mock_course():
                 pass
 
     return MockCourse()
+
+
+@pytest.fixture
+def mock_gitlab_oauth():
+    class MockGitlabOauth:
+        class gitlab:
+            @staticmethod
+            def authorize_access_token():
+                return {"access_token": "", "refresh_token": ""}
+
+    return MockGitlabOauth()
 
 
 @pytest.fixture(autouse=True)
@@ -262,13 +287,18 @@ def check_admin_status_code(response, check_true):
         assert response.status_code == 403
 
 
-@pytest.mark.parametrize("param", [
+@pytest.mark.parametrize("path_and_func", [
     ['/', check_admin_in_data],
     ['/solutions', check_admin_status_code],
     ['/database', check_admin_in_data]
 ])
-def test_course_page_user_sync(app, mock_course, param):
-    path, check_func = param
+@pytest.mark.parametrize("debug", [False, True])
+@pytest.mark.parametrize("get_param_admin", ['true', '1', 'yes', None, 'false', '0', 'no', 'random_value'])
+def test_course_page_user_sync(app, mock_course, path_and_func, debug, get_param_admin):
+    path, check_func = path_and_func
+
+    if get_param_admin is not None:
+        path += f'?admin={get_param_admin}'
 
     with app.test_request_context():
         with app.test_client() as client:
@@ -281,10 +311,16 @@ def test_course_page_user_sync(app, mock_course, param):
                     "course_admin": False
                 }
             app.course = mock_course
+            app.debug = debug
 
             # not admin in gitlab, not admin in manytask
             response = client.get(path)
-            check_func(response, False)
+
+            if app.debug:
+                # in debug admin flag is the same as get param
+                check_func(response, get_param_admin in ('true', '1', 'yes', None))
+            else:
+                check_func(response, False)
 
             with client.session_transaction() as sess:
                 sess['gitlab'] = {
@@ -297,7 +333,12 @@ def test_course_page_user_sync(app, mock_course, param):
 
             # admin in gitlab, not admin in manytask
             response = client.get(path)
-            check_func(response, True)
+
+            if app.debug:
+                # in debug admin flag is the same as get param
+                check_func(response, get_param_admin in ('true', '1', 'yes', None))
+            else:
+                check_func(response, True)
 
             with client.session_transaction() as sess:
                 sess['gitlab'] = {
@@ -312,7 +353,12 @@ def test_course_page_user_sync(app, mock_course, param):
 
             # not admin in gitlab, admin in manytask
             response = client.get(path)
-            check_func(response, True)
+
+            if app.debug:
+                # in debug admin flag is the same as get param
+                check_func(response, get_param_admin in ('true', '1', 'yes', None))
+            else:
+                check_func(response, True)
 
             with client.session_transaction() as sess:
                 sess['gitlab'] = {
@@ -325,4 +371,49 @@ def test_course_page_user_sync(app, mock_course, param):
 
             # admin in gitlab, admin in manytask
             response = client.get(path)
-            check_func(response, True)
+
+            if app.debug:
+                # in debug admin flag is the same as get param
+                check_func(response, get_param_admin in ('true', '1', 'yes', None))
+            else:
+                check_func(response, True)
+
+
+def test_login_finish_sync(app, mock_course, mock_gitlab_oauth):
+    with app.test_request_context():
+        with app.test_client() as client:
+            app.course = mock_course
+            app.oauth = mock_gitlab_oauth
+
+            assert app.course.storage_api.stored_user.course_admin == False
+
+            # not admin in gitlab so stored value shouldn't change
+            response = client.get('/login_finish')
+
+            with client.session_transaction() as sess:
+                assert 'gitlab' in sess
+                assert sess["gitlab"]["course_admin"] == False
+
+            assert app.course.storage_api.stored_user.course_admin == False
+
+            app.course.gitlab_api.course_admin = True
+
+            # admin in gitlab so stored value should change
+            response = client.get('/login_finish')
+
+            with client.session_transaction() as sess:
+                assert 'gitlab' in sess
+                assert sess["gitlab"]["course_admin"] == True
+
+            assert app.course.storage_api.stored_user.course_admin == True
+
+            app.course.gitlab_api.course_admin = False
+
+            # not admin in gitlab but also stored that admin
+            response = client.get('/login_finish')
+
+            with client.session_transaction() as sess:
+                assert 'gitlab' in sess
+                assert sess["gitlab"]["course_admin"] == False
+
+            assert app.course.storage_api.stored_user.course_admin == True


### PR DESCRIPTION
Added is_course_admin field for UserOnCourse model.
Added get_stored_user(get user data from storage) and sync_stored_user(sync user data to storage) methods to abstract StorageApi class.
Edited web views to support stored user data. Now user is considered an admin when he admin in gitlab or manytask.
In login_finish view syncing course_admin flag from gitlab to storage.
Added tests for models, views and DB api.
