### PR TITLE
feat: secret check

### DIFF
--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -44,7 +44,7 @@ def requires_ready(f: Callable[..., Any]) -> Callable[..., Any]:
 
 
 def requires_secret(template: str) -> Callable[..., Any]:
-    def decorator(f: Callable[..., Any]):
+    def decorator(f: Callable[..., Any]) -> Callable[..., Any]:
         @wraps(f)
         def decorated(*args: Any, **kwargs: Any) -> Any:
             course = current_app.course  # type: ignore

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -52,13 +52,9 @@ def requires_secret(template: str) -> Callable[..., Any]:
             try:
                 student = course.gitlab_api.get_authenticated_student(session["gitlab"]["oauth_access_token"])
                 # if user already have fork we let him in with out secret
+                #TODO change on checking user->course in db
                 if course.gitlab_api.check_project_exists(student):
                     ...
-
-                # secret already in session
-                elif "course" in session:
-                    if not secrets.compare_digest(session["course"]["secret"], course.registration_secret):
-                        raise Exception("Invalid registration secret")
 
                 # secret was entered in form
                 elif "secret" in request.form:

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -1,7 +1,8 @@
+import secrets
 from functools import wraps
 from typing import Any, Callable
 
-from flask import current_app, redirect, session, url_for
+from flask import current_app, redirect, render_template, request, session, url_for
 from flask.sessions import SessionMixin
 
 
@@ -23,10 +24,11 @@ def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
     def decorated(*args: Any, **kwargs: Any) -> Any:
         if current_app.debug:
             return f(*args, **kwargs)
-            
+
         if not valid_session(session):
             return redirect(url_for("web.signup"))
         return f(*args, **kwargs)
+
     return decorated
 
 
@@ -37,4 +39,51 @@ def requires_ready(f: Callable[..., Any]) -> Callable[..., Any]:
         if not course.config:
             return redirect(url_for("web.not_ready"))
         return f(*args, **kwargs)
-    return decorated 
+
+    return decorated
+
+
+def requires_secret(template: str) -> Callable[..., Any]:
+    def decorator(f: Callable[..., Any]):
+        @wraps(f)
+        def decorated(*args: Any, **kwargs: Any) -> Any:
+            course = current_app.course  # type: ignore
+
+            try:
+                student = course.gitlab_api.get_authenticated_student(session["gitlab"]["oauth_access_token"])
+                # if user already have fork we let him in with out secret
+                if course.gitlab_api.check_project_exists(student):
+                    ...
+
+                # secret already in session
+                elif "course" in session:
+                    if not secrets.compare_digest(session["course"]["secret"], course.registration_secret):
+                        raise Exception("Invalid registration secret")
+
+                # secret was entered in form
+                elif "secret" in request.form:
+                    if not secrets.compare_digest(request.form["secret"], course.registration_secret):
+                        raise Exception("Invalid registration secret")
+
+                # gently asking for a secret
+                else:
+                    return render_template(
+                        template,
+                        course_name=course.name,
+                        course_favicon=course.favicon,
+                        base_url=course.gitlab_api.base_url,
+                    )
+
+            except Exception as e:
+                return render_template(
+                    template,
+                    error_message=str(e),
+                    course_name=course.name,
+                    course_favicon=course.favicon,
+                    base_url=course.gitlab_api.base_url,
+                )
+            return f(*args, **kwargs)
+
+        return decorated
+
+    return decorator

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -9,7 +9,7 @@ from flask import Blueprint, Response, current_app, redirect, render_template, r
 from flask.typing import ResponseReturnValue
 
 from . import abstract, glab
-from .auth import requires_auth, requires_ready
+from .auth import requires_auth, requires_ready, requires_secret
 from .course import Course, get_current_time
 from .database_utils import get_database_table_data
 
@@ -20,31 +20,38 @@ SESSION_VERSION = 1.5
 logger = logging.getLogger(__name__)
 bp = Blueprint("web", __name__)
 
-def get_allscores_url(viewer_api: abstract.ViewerApi) -> str :
+
+def get_allscores_url(viewer_api: abstract.ViewerApi) -> str:
     """Function to get URL for viewing the scores
 
      :param viewer_api: The viewer API that may hold the URL
-    
+
     :return: String with an URL
     """
     if viewer_api.get_scoreboard_url() == "":
-        return url_for('web.show_database')
+        return url_for("web.show_database")
     else:
         return viewer_api.get_scoreboard_url()
 
-@bp.route("/")
+
+@bp.route("/", methods=["GET", "POST"])
 @requires_ready
 @requires_auth
+@requires_secret(template="create_project.html")
 def course_page() -> ResponseReturnValue:
     course: Course = current_app.course  # type: ignore
 
     storage_api = course.storage_api
 
+    # it is redirect flow after entering secret token
+    if request.method == "POST":
+        session["course"] = {"secret": request.form["secret"]}
+
     if current_app.debug:
         student_username = "guest"
         student_repo = course.gitlab_api.get_url_for_repo(student_username)
 
-        if request.args.get('admin', None) in ('true', '1', 'yes', None):
+        if request.args.get("admin", None) in ("true", "1", "yes", None):
             student_course_admin = True
         else:
             student_course_admin = False
@@ -104,7 +111,7 @@ def get_solutions() -> ResponseReturnValue:
     course: Course = current_app.course  # type: ignore
 
     if current_app.debug:
-        if request.args.get('admin', None) in ('true', '1', 'yes', None):
+        if request.args.get("admin", None) in ("true", "1", "yes", None):
             student_course_admin = True
         else:
             student_course_admin = False
@@ -184,6 +191,7 @@ def signup() -> ResponseReturnValue:
             base_url=course.gitlab_api.base_url,
         )
 
+    session["course"]["secret"] = request.form["secret"]
     return redirect(url_for("web.login"))
 
 
@@ -198,7 +206,7 @@ def login() -> ResponseReturnValue:
     return oauth.gitlab.authorize_redirect(redirect_uri)
 
 
-@bp.route("/login_finish")
+@bp.route("/login_finish", methods=["GET", "POST"])
 @requires_ready
 def login_finish() -> ResponseReturnValue:
     """Callback for gitlab oauth"""
@@ -236,7 +244,7 @@ def login_finish() -> ResponseReturnValue:
     }
     session.permanent = True
 
-    if (course.gitlab_api.check_project_exists(student)):
+    if course.gitlab_api.check_project_exists(student):
         return redirect(url_for("web.course_page"))
     else:
         return redirect(url_for("web.create_project"))
@@ -283,6 +291,8 @@ def create_project() -> ResponseReturnValue:
 @bp.route("/logout")
 def logout() -> ResponseReturnValue:
     session.pop("gitlab", None)
+    session.pop("course", None)
+    session.clear()
     return redirect(url_for("web.course_page"))
 
 
@@ -311,7 +321,7 @@ def show_database() -> ResponseReturnValue:
         student_username = "guest"
         student_repo = course.gitlab_api.get_url_for_repo(student_username)
 
-        if request.args.get('admin', None) in ('true', '1', 'yes', None):
+        if request.args.get("admin", None) in ("true", "1", "yes", None):
             student_course_admin = True
         else:
             student_course_admin = False
@@ -338,7 +348,7 @@ def show_database() -> ResponseReturnValue:
         is_course_admin=student_course_admin,
         current_course=course,
         course_favicon=course.favicon,
-        readonly_fields=['username', 'total_score'],  # Cannot be edited in database web viewer
+        readonly_fields=["username", "total_score"],  # Cannot be edited in database web viewer
         links=(course.config.ui.links if course.config else {}),
         gitlab_url=course.gitlab_api.base_url,
         show_allscores=course.show_allscores,

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -43,10 +43,6 @@ def course_page() -> ResponseReturnValue:
 
     storage_api = course.storage_api
 
-    # it is redirect flow after entering secret token
-    if request.method == "POST":
-        session["course"] = {"secret": request.form["secret"]}
-
     if current_app.debug:
         student_username = "guest"
         student_repo = course.gitlab_api.get_url_for_repo(student_username)
@@ -191,7 +187,6 @@ def signup() -> ResponseReturnValue:
             base_url=course.gitlab_api.base_url,
         )
 
-    session["course"]["secret"] = request.form["secret"]
     return redirect(url_for("web.login"))
 
 
@@ -291,8 +286,6 @@ def create_project() -> ResponseReturnValue:
 @bp.route("/logout")
 def logout() -> ResponseReturnValue:
     session.pop("gitlab", None)
-    session.pop("course", None)
-    session.clear()
     return redirect(url_for("web.course_page"))
 
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -204,7 +204,8 @@ def test_course_page_valid_session(app, mock_course):
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "repo": TEST_REPO,
-                    "course_admin": False
+                    "course_admin": False,
+                    "oauth_access_token": TEST_TOKEN,
                 }
             app.course = mock_course
             response = client.get('/')
@@ -322,7 +323,11 @@ def test_course_page_user_sync(app, mock_course, path_and_func, debug, get_param
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "repo": TEST_REPO,
-                    "course_admin": False
+                    "course_admin": False,
+                    "oauth_access_token": TEST_TOKEN,
+                }
+                sess['course'] = {
+                    "secret": TEST_SECRET,
                 }
             app.course = mock_course
             app.debug = debug
@@ -342,7 +347,11 @@ def test_course_page_user_sync(app, mock_course, path_and_func, debug, get_param
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "repo": TEST_REPO,
-                    "course_admin": True
+                    "course_admin": True,
+                    "oauth_access_token": TEST_TOKEN,
+                }
+                sess['course'] = {
+                    "secret": TEST_SECRET,
                 }
 
             # admin in gitlab, not admin in manytask
@@ -360,7 +369,11 @@ def test_course_page_user_sync(app, mock_course, path_and_func, debug, get_param
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "repo": TEST_REPO,
-                    "course_admin": False
+                    "course_admin": False,
+                    "oauth_access_token": TEST_TOKEN,
+                }
+                sess['course'] = {
+                    "secret": TEST_SECRET,
                 }
 
             app.course.storage_api.stored_user.course_admin = True
@@ -380,7 +393,11 @@ def test_course_page_user_sync(app, mock_course, path_and_func, debug, get_param
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "repo": TEST_REPO,
-                    "course_admin": False
+                    "course_admin": False,
+                    "oauth_access_token": TEST_TOKEN,
+                }
+                sess['course'] = {
+                    "secret": TEST_SECRET,
                 }
 
             # admin in gitlab, admin in manytask


### PR DESCRIPTION
<!-- Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. 
Feel free to set Draft status if you need help or want to discuss. -->

## Description
Fix requiring secret word for each course
[#237](https://github.com/manytask/manytask/issues/237)


future tasks:
  - accord check to db user->course record
  - extract secret check from signup and create_project handlers to decorator
  - develop more clean logic for signup and logic flow 

## Motivation and Context
**Login button flow**
1. if you don't have fork
    - ask secret
    - create fork
    - redirect on main
2. you have already got fork
    - check if you have fork
    - redirect on main