### PR TITLE
fix: add naming convention for database

### DIFF
--- a/manytask/models.py
+++ b/manytask/models.py
@@ -2,15 +2,23 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import JSON, ForeignKey, UniqueConstraint, event, func
+from sqlalchemy import JSON, ForeignKey, MetaData, UniqueConstraint, event, func
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import DeclarativeBase, DynamicMapped, Mapped, Mapper, Session, mapped_column, relationship
 
 logger = logging.getLogger(__name__)
 
+convention = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
 
 class Base(DeclarativeBase):
-    pass
+    metadata = MetaData(naming_convention=convention)
 
 
 class User(Base):


### PR DESCRIPTION
# Added naming convention for database models.
With this change, indexes, unique constraints, check constraints, foreign keys, and primary keys will be automatically named following a consistent pattern.

For example, if we add new field like this:
```
new_field: Mapped[str] = mapped_column(unique=True, nullable=True)
```

Alembic create migration:
```
def upgrade() -> None:
    op.add_column('some_model', sa.Column('new_field', sa.String(), nullable=True))
    op.create_unique_constraint(None, 'some_model', ['token'])

def downgrade() -> None:
    op.drop_constraint(None, 'some_model', type_='unique')
    op.drop_column('some_model', 'new_field')
```

In this case, there is a problem without manually changing migrations. If we call downgrade after migration we get an error:
```
sqlalchemy.exc.CompileError: Can't emit DROP CONSTRAINT for constraint UniqueConstraint(); it has no name
```

After this commit instead of `null` using template name based on an convention.