### PR TITLE
fix: Redirect to signup page if auth was forgotten

### DIFF
--- a/manytask/web.py
+++ b/manytask/web.py
@@ -3,6 +3,7 @@ import secrets
 from datetime import datetime, timedelta
 
 import gitlab
+import requests
 from authlib.integrations.base_client import OAuthError
 from authlib.integrations.flask_client import OAuth
 from flask import Blueprint, Response, current_app, redirect, render_template, request, session, url_for
@@ -271,7 +272,11 @@ def create_project() -> ResponseReturnValue:
         )
 
     gitlab_access_token: str = session["gitlab"]["oauth_access_token"]
-    student = course.gitlab_api.get_authenticated_student(gitlab_access_token)
+    try:
+        student = course.gitlab_api.get_authenticated_student(gitlab_access_token)
+    except requests.exceptions.HTTPError as ex:
+        logger.error(f"Authorization error: {ex.args[0]}")
+        return render_template("signup.html", error_message=ex.args[0], course_name=course.name)
 
     # Create use if needed
     try:


### PR DESCRIPTION
When HTTP error can be returned when information on authorized student is requested, which was not properly handled.

Fixes #308