### PR TITLE
fix: Redirect to signup page when oath token might need updating

### DIFF
--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -73,13 +73,7 @@ def requires_secret(template: str = "create_project.html") -> Callable[..., Any]
                     )
 
             except Exception as e:
-                return render_template(
-                    template,
-                    error_message=str(e),
-                    course_name=course.name,
-                    course_favicon=course.favicon,
-                    base_url=course.gitlab_api.base_url,
-                )
+                return redirect(url_for("web.signup"))
             return f(*args, **kwargs)
 
         return decorated


### PR DESCRIPTION
When exception was raised in create_project, user was redirected to the page that asks secret. This page can not update the token and hence user was stuck on it. This change redirects user to signup page, which can update token.wq

Fixes #308 


## [optional] What gif best describes this PR or how it makes you feel?
<!-- You can use this one if you want: https://media.giphy.com/media/3o7aDcz6Y0fzWYvU5a/giphy.gif -->
<!-- ![](https://media.giphy.com/media/3o7aDcz6Y0fzWYvU5a/giphy.gif) -->
