### PR TITLE
Move the envvar definition earlier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,10 @@ RUN apk update && apk add --no-cache \
 
 WORKDIR /app
 
-COPY --from=builder ${POETRY_VENV} ${POETRY_VENV}
+COPY --from=builder /opt/poetry-venv /opt/poetry-venv
 COPY pyproject.toml poetry.lock ./
 
+ENV PATH="/opt/poetry-venv/bin:$PATH"
 ENV CACHE_DIR=/cache SOLUTIONS_DIR=/solutions PYTHONPATH="${PYTHONPATH}:/app:/app/manytask"
 
 RUN poetry config virtualenvs.create false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ RUN apk update && apk add --no-cache \
 
 WORKDIR /app
 
-COPY --from=builder /opt/poetry-venv /opt/poetry-venv
+COPY --from=builder ${POETRY_VENV} ${POETRY_VENV}
 COPY pyproject.toml poetry.lock ./
 
-ENV PATH="/opt/poetry-venv/bin:$PATH"
+ENV CACHE_DIR=/cache SOLUTIONS_DIR=/solutions PYTHONPATH="${PYTHONPATH}:/app:/app/manytask"
 
 RUN poetry config virtualenvs.create false \
     && poetry install --no-interaction --no-ansi --no-root
@@ -45,7 +45,6 @@ RUN poetry config virtualenvs.create false \
 COPY ./manytask/ /app/manytask
 COPY VERSION /app/VERSION
 
-ENV CACHE_DIR=/cache SOLUTIONS_DIR=/solutions PYTHONPATH="${PYTHONPATH}:/app:/app/manytask"
 VOLUME ["/cache", "/solutions"]
 
 EXPOSE 5050


### PR DESCRIPTION
In #359 the env var is defined after it is used. This moves it to before.