### PR TITLE
fix: avoid division by zero

### DIFF
--- a/manytask/templates/layout.html
+++ b/manytask/templates/layout.html
@@ -6,7 +6,7 @@
 {% set solved_score = scores.values() | sum() %}
 {% set bonus_score_string = "+" ~ bonus_score if bonus_score > 0 else "" %}
 {% set solved_score_string = solved_score ~ bonus_score_string %}
-{% set solved_percent = (solved_score / current_course.storage_api.max_score_started * 100) | round(1, 'common') %}
+{% set solved_percent = "0 %" if current_course.storage_api.max_score_started  == 0 else (solved_score / current_course.storage_api.max_score_started * 100) | round(1, 'common') %}
 
 
     <style>


### PR DESCRIPTION
If course is not initialized, or initialized with zero tasks, the
sum of the points is zero. This causes division by zero in layout,
when the percentage of completion is computed. This change conditionaly
sets the percentage to zeor is such cases.