### PR TITLE
fix: Catch exception when user is deleted from gitlab

### DIFF
--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from flask import current_app
 
+from manytask.glab import GitLabApiException
+
 from .course import Course
 
 
@@ -23,7 +25,10 @@ def get_database_table_data() -> dict[str, Any]:
 
     for username, student_scores in all_scores.items():
         total_score = sum(student_scores.values())
-        student_name = course.gitlab_api.get_student_by_username(username).name
+        try:
+            student_name = course.gitlab_api.get_student_by_username(username).name
+        except GitLabApiException:
+            student_name = ""
         table_data["students"].append(
             {"username": username, "student_name": student_name, "scores": student_scores, "total_score": total_score}
         )


### PR DESCRIPTION
If user deletes an account from gitlab, their data remains in Manytask. But when we request their name via GitLab API, exception is thrown. In this change the exception is caught and empty name is assigned to the user.