### PR TITLE
feat: Show the list of students names only when requested

### DIFF
--- a/manytask/api.py
+++ b/manytask/api.py
@@ -342,7 +342,7 @@ def get_solutions() -> ResponseReturnValue:
 @requires_auth
 @requires_ready
 def get_database() -> ResponseReturnValue:
-    table_data = get_database_table_data()
+    table_data = get_database_table_data(False)
     return jsonify(table_data)
 
 

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -72,7 +72,7 @@ def requires_secret(template: str = "create_project.html") -> Callable[..., Any]
                         base_url=course.gitlab_api.base_url,
                     )
 
-            except Exception as e:
+            except Exception:
                 return redirect(url_for("web.signup"))
             return f(*args, **kwargs)
 

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -31,6 +31,8 @@ def get_database_table_data(get_full_names: bool = False) -> dict[str, Any]:
                 student_name = course.gitlab_api.get_student_by_username(username).name
             except GitLabApiException:
                 student_name = "x"
-        table_data["students"].append({"username": username, "student_name": student_name, "scores": student_scores, "total_score": total_score})
+        table_data["students"].append(
+            {"username": username, "student_name": student_name, "scores": student_scores, "total_score": total_score}
+        )
 
     return table_data

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -25,20 +25,12 @@ def get_database_table_data(get_full_names: bool = False) -> dict[str, Any]:
 
     for username, student_scores in all_scores.items():
         total_score = sum(student_scores.values())
+        student_name = "-"
         if get_full_names:
             try:
                 student_name = course.gitlab_api.get_student_by_username(username).name
             except GitLabApiException:
-                student_name = ""
-            table_data["students"].append(
-                {
-                    "username": username,
-                    "student_name": student_name,
-                    "scores": student_scores,
-                    "total_score": total_score,
-                }
-            )
-        else:
-            table_data["students"].append({"username": username, "scores": student_scores, "total_score": total_score})
+                student_name = "x"
+        table_data["students"].append({"username": username, "student_name": student_name, "scores": student_scores, "total_score": total_score})
 
     return table_data

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from flask import current_app
 
+from manytask.glab import GitLabApiException
+
 from .course import Course
 
 
@@ -23,7 +25,10 @@ def get_database_table_data() -> dict[str, Any]:
 
     for username, student_scores in all_scores.items():
         total_score = sum(student_scores.values())
-        student_name = course.gitlab_api.get_student_by_username(username).name
+        try:
+            student_name = course.gitlab_api.get_student_by_username(username).name
+        except GitLabApiException:
+            student_name = ""
         table_data["students"].append(
             {"username": username, "student_name": student_name, "scores": student_scores, "total_score": total_score}
         )

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -35,7 +35,7 @@ def get_database_table_data(get_full_names: bool = False) -> dict[str, Any]:
                     "username": username,
                     "student_name": student_name,
                     "scores": student_scores,
-                    "total_score": total_score
+                    "total_score": total_score,
                 }
             )
         else:

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -7,7 +7,7 @@ from manytask.glab import GitLabApiException
 from .course import Course
 
 
-def get_database_table_data() -> dict[str, Any]:
+def get_database_table_data(get_full_names: bool = False) -> dict[str, Any]:
     """Get the database table data structure used by both web and API endpoints."""
     course: Course = current_app.course  # type: ignore
 
@@ -25,12 +25,20 @@ def get_database_table_data() -> dict[str, Any]:
 
     for username, student_scores in all_scores.items():
         total_score = sum(student_scores.values())
-        try:
-            student_name = course.gitlab_api.get_student_by_username(username).name
-        except GitLabApiException:
-            student_name = ""
-        table_data["students"].append(
-            {"username": username, "student_name": student_name, "scores": student_scores, "total_score": total_score}
-        )
+        if get_full_names:
+            try:
+                student_name = course.gitlab_api.get_student_by_username(username).name
+            except GitLabApiException:
+                student_name = ""
+            table_data["students"].append(
+                {
+                    "username": username,
+                    "student_name": student_name,
+                    "scores": student_scores,
+                    "total_score": total_score,
+                }
+            )
+        else:
+            table_data["students"].append({"username": username, "scores": student_scores, "total_score": total_score})
 
     return table_data

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -236,6 +236,7 @@
                             width: 120,
                             headerTooltip: "Username"
                         },
+                        {% if show_full_names %}
                         {
                             title: "Name",
                             field: "student_name",
@@ -244,6 +245,7 @@
                             width: 200,
                             headerTooltip: "Full name"
                         },
+                        {% endif %}
                         {
                             title: "Total Score",
                             field: "total_score",

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -330,7 +330,8 @@ def show_database() -> ResponseReturnValue:
 
     scores = storage_api.get_scores(student_username)
     bonus_score = storage_api.get_bonus_score(student_username)
-    table_data = get_database_table_data()
+    show_full_names = "show_full_names" in request.args
+    table_data = get_database_table_data(show_full_names)
 
     return render_template(
         "database.html",

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -330,7 +330,7 @@ def show_database() -> ResponseReturnValue:
 
     scores = storage_api.get_scores(student_username)
     bonus_score = storage_api.get_bonus_score(student_username)
-    show_full_names = "show_full_names" in request.args
+    show_full_names = request.args.get("show_full_names", default=False, type=bool)
     table_data = get_database_table_data(show_full_names)
 
     return render_template(

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -330,7 +330,10 @@ def show_database() -> ResponseReturnValue:
 
     scores = storage_api.get_scores(student_username)
     bonus_score = storage_api.get_bonus_score(student_username)
-    show_full_names = request.args.get("show_full_names", default=False, type=bool)
+    if "show_full_names" in request.args:
+        show_full_names = True
+    else:
+        show_full_names = False
     table_data = get_database_table_data(show_full_names)
 
     return render_template(

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -336,6 +336,7 @@ def show_database() -> ResponseReturnValue:
     return render_template(
         "database.html",
         table_data=table_data,
+        show_full_names=show_full_names,
         course_name=course.config.settings.course_name if course.config else "",
         scores=scores,
         bonus_score=bonus_score,
@@ -343,7 +344,7 @@ def show_database() -> ResponseReturnValue:
         is_course_admin=student_course_admin,
         current_course=course,
         course_favicon=course.favicon,
-        readonly_fields=["username", "total_score"],  # Cannot be edited in database web viewer
+        readonly_fields=["username", "total_score", "student_name"],  # Cannot be edited in database web viewer
         links=(course.config.ui.links if course.config else {}),
         gitlab_url=course.gitlab_api.base_url,
         show_allscores=course.show_allscores,

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -123,7 +123,8 @@ def test_get_database_table_data_without_student_names(app, mock_course):
         result = get_database_table_data(False)
         students = result["students"]
         for student in students:
-            assert "student_name" not in student
+            assert "student_name" in student
+            assert student["student_name"] == "-"
 
 
 def test_get_database_table_data_no_deadlines(app, mock_course):

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -86,7 +86,7 @@ def mock_course():
 def test_get_database_table_data(app, mock_course):
     with app.test_request_context():
         app.course = mock_course
-        result = get_database_table_data()
+        result = get_database_table_data(True)
 
         assert "tasks" in result
         assert "students" in result
@@ -108,11 +108,29 @@ def test_get_database_table_data(app, mock_course):
             assert student["scores"] == {TASK_1: SCORES[student_id][TASK_1], TASK_2: SCORES[student_id][TASK_2]}
 
 
+def test_get_database_table_data_with_student_names(app, mock_course):
+    with app.test_request_context():
+        app.course = mock_course
+        result = get_database_table_data(True)
+        students = result["students"]
+        for student in students:
+            assert "student_name" in student
+
+
+def test_get_database_table_data_without_student_names(app, mock_course):
+    with app.test_request_context():
+        app.course = mock_course
+        result = get_database_table_data(False)
+        students = result["students"]
+        for student in students:
+            assert "student_name" not in student
+
+
 def test_get_database_table_data_no_deadlines(app, mock_course):
     with app.test_request_context():
         mock_course.deadlines = None
         app.course = mock_course
-        result = get_database_table_data()
+        result = get_database_table_data(False)
 
         assert "tasks" in result
         assert "students" in result
@@ -124,7 +142,7 @@ def test_get_database_table_data_no_scores(app, mock_course):
     with app.test_request_context():
         mock_course.storage_api.get_all_scores = lambda: {}
         app.course = mock_course
-        result = get_database_table_data()
+        result = get_database_table_data(False)
 
         assert "tasks" in result
         assert "students" in result
@@ -146,7 +164,7 @@ def test_get_database_table_data_disabled_tasks_and_groups(app, mock_course):
         mock_course.deadlines.groups = [group_enabled, group_disabled]
         app.course = mock_course
 
-        result = get_database_table_data()
+        result = get_database_table_data(False)
 
         assert "tasks" in result
         tasks = result["tasks"]


### PR DESCRIPTION
Fetching the names one by one takes time, which delays the table rendering. This adds and option to the request that enforces showing names, but does not show them by default. When needed one can add "show_full_names" oprion to the request which will result in the table with names. Later can than be exported.