### PR TITLE
feat: pass course name in url and edit auth path

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -41,6 +41,8 @@ class StorageApi(ABC):
     def sync_stored_user(
         self,
         student: Student,
+        repo_name: str,
+        course_admin: bool,
     ) -> StoredUser: ...
 
     @abstractmethod
@@ -59,6 +61,7 @@ class StorageApi(ABC):
     def store_score(
         self,
         student: Student,
+        repo_name: str,
         task_name: str,
         update_fn: Callable[..., Any],
     ) -> int: ...
@@ -109,7 +112,7 @@ class StorageApi(ABC):
     def max_score_started(self) -> int: ...
 
     @abstractmethod
-    def sync_and_get_admin_status(self, course_name: str, student: Student) -> bool: ...
+    def sync_and_get_admin_status(self, course_name: str, student: Student, course_admin: bool) -> bool: ...
 
     @abstractmethod
     def check_user_on_course(self, course_name: str, student: Student) -> bool: ...

--- a/manytask/course.py
+++ b/manytask/course.py
@@ -36,6 +36,8 @@ def validate_submit_time(commit_time: datetime | None, current_time: datetime) -
 class CourseConfig:
     """Configuration for Course settings."""
 
+    course_name: str
+
     gitlab_course_group: str
     gitlab_course_public_repo: str
     gitlab_course_students_group: str
@@ -60,6 +62,9 @@ class Course:
 
         :param config: CourseConfig instance containing all necessary settings
         """
+
+        self.course_name = config.course_name
+
         self.__gitlab_course_group = config.gitlab_course_group
         self.__gitlab_course_public_repo = config.gitlab_course_public_repo
         self.__gitlab_course_students_group = config.gitlab_course_students_group

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -1,15 +1,10 @@
 from typing import Any
 
-from flask import current_app
-
-from .course import Course
 from .main import CustomFlask
 
 
-def get_database_table_data() -> dict[str, Any]:
+def get_database_table_data(app: CustomFlask) -> dict[str, Any]:
     """Get the database table data structure used by both web and API endpoints."""
-    app: CustomFlask = current_app  # type: ignore
-    course: Course = app.storage_api.get_course(app.course_name)  # type: ignore
 
     storage_api = app.storage_api
     all_scores = storage_api.get_all_scores()
@@ -24,9 +19,7 @@ def get_database_table_data() -> dict[str, Any]:
 
     for username, student_scores in all_scores.items():
         total_score = sum(student_scores.values())
-        student_name = app.gitlab_api.get_student_by_username(
-            username, course.gitlab_course_group, course.gitlab_course_students_group
-        ).name
+        student_name = app.gitlab_api.get_student_by_username(username).name
         table_data["students"].append(
             {"username": username, "student_name": student_name, "scores": student_scores, "total_score": total_score}
         )

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -85,7 +85,8 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
     from . import api, web
 
     app.register_blueprint(api.bp)
-    app.register_blueprint(web.bp)
+    app.register_blueprint(web.root_bp)
+    app.register_blueprint(web.course_bp)
 
     logger = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def mock_gitlab_oauth():
             @staticmethod
             def authorize_redirect(redirect_uri: str):
                 resp = Response(status=302)
-                resp.location = url_for("web.login")
+                resp.location = url_for("root.login")
                 return resp
 
     return MockGitlabOauth()

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -69,13 +69,11 @@ def app():
         def __init__(self):
             pass
 
-        def get_student_by_username(self, username: str, course_group: str, course_student_group: str) -> Student:
+        def get_student_by_username(self, username: str) -> Student:
             return Student(
                 id=1,
                 username=username,
                 name=STUDENT_NAMES[username],
-                course_admin=False,
-                repo="my repo",
             )
 
     app.storage_api = MockStorageApi()
@@ -89,7 +87,7 @@ def test_get_database_table_data(app):
     expected_students_count = 2
 
     with app.test_request_context():
-        result = get_database_table_data()
+        result = get_database_table_data(app)
 
         assert "tasks" in result
         assert "students" in result
@@ -116,7 +114,7 @@ def test_get_database_table_data_no_scores(app):
 
     with app.test_request_context():
         app.storage_api.get_all_scores = lambda: {}
-        result = get_database_table_data()
+        result = get_database_table_data(app)
 
         assert "tasks" in result
         assert "students" in result

--- a/tests/test_glab.py
+++ b/tests/test_glab.py
@@ -84,8 +84,6 @@ def mock_student() -> Student:
         id=TEST_USER_ID,
         username=TEST_USERNAME,
         name=TEST_USERNAME,
-        course_admin=False,
-        repo=TEST_USER_URL,
     )
 
 
@@ -363,7 +361,7 @@ def test_check_is_course_admin(gitlab):
     mock_member = MagicMock()
     mock_group.members_all.get.return_value = mock_member
 
-    is_admin = gitlab_api._check_is_course_admin(TEST_USER_ID, TEST_GROUP_NAME)
+    is_admin = gitlab_api.check_is_course_admin(TEST_USER_ID, TEST_GROUP_NAME)
 
     assert is_admin is True
 
@@ -374,7 +372,7 @@ def test_check_is_course_admin_not_found(gitlab):
     gitlab_api._get_group_by_name = MagicMock(return_value=mock_group)
     mock_group.members_all.get.return_value = None
 
-    is_admin = gitlab_api._check_is_course_admin(TEST_USER_ID, TEST_GROUP_NAME)
+    is_admin = gitlab_api.check_is_course_admin(TEST_USER_ID, TEST_GROUP_NAME)
 
     assert is_admin is False
 
@@ -386,24 +384,19 @@ def test_parse_user_to_student(gitlab, mock_student):
         "username": TEST_USERNAME,
         "name": TEST_USERNAME,
     }
-    gitlab_api.get_url_for_repo = MagicMock(return_value=TEST_USER_URL)
-    gitlab_api._check_is_course_admin = MagicMock(return_value=False)
-
-    student = gitlab_api._parse_user_to_student(user_dict, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+    student = gitlab_api._parse_user_to_student(user_dict)
 
     assert student == mock_student
-    gitlab_api.get_url_for_repo.assert_called_once_with(mock_student.username, TEST_GROUP_STUDENT_NAME)
-    gitlab_api._check_is_course_admin.assert_called_once_with(TEST_USER_ID, TEST_GROUP_NAME)
 
 
 def test_get_student_by_username_found(gitlab, mock_student):
     gitlab_api, _ = gitlab
     gitlab_api.get_students_by_username = MagicMock(return_value=[mock_student])
 
-    result_student = gitlab_api.get_student_by_username(TEST_USERNAME, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+    result_student = gitlab_api.get_student_by_username(TEST_USERNAME)
 
     assert result_student == mock_student
-    gitlab_api.get_students_by_username.assert_called_once_with(TEST_USERNAME, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+    gitlab_api.get_students_by_username.assert_called_once_with(TEST_USERNAME)
 
 
 def test_get_student_by_username_not_found(gitlab):
@@ -411,7 +404,7 @@ def test_get_student_by_username_not_found(gitlab):
     mock_gitlab_instance.users.list.return_value = []
 
     with pytest.raises(GitLabApiException, match=f"No students found for username {TEST_USERNAME}"):
-        gitlab_api.get_student_by_username(TEST_USERNAME, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+        gitlab_api.get_student_by_username(TEST_USERNAME)
 
 
 def test_get_student_found(gitlab, mock_user, mock_student):
@@ -427,11 +420,11 @@ def test_get_student_found(gitlab, mock_user, mock_student):
     mock_gitlab_instance.users.get = MagicMock(return_value=mock_user)
     gitlab_api._parse_user_to_student = MagicMock(return_value=mock_student)
 
-    student = gitlab_api.get_student(TEST_USER_ID, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+    student = gitlab_api.get_student(TEST_USER_ID)
 
     assert student == mock_student
     mock_gitlab_instance.users.get.assert_called_once_with(TEST_USER_ID)
-    gitlab_api._parse_user_to_student.assert_called_once_with(user_attrs, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+    gitlab_api._parse_user_to_student.assert_called_once_with(user_attrs)
 
 
 def test_get_student_not_found(gitlab):
@@ -439,7 +432,7 @@ def test_get_student_not_found(gitlab):
     mock_gitlab_instance.users.get = MagicMock(side_effect=GitlabGetError("User not found"))
 
     with pytest.raises(GitlabGetError, match="User not found"):
-        gitlab_api.get_student(TEST_USER_ID, "", "")
+        gitlab_api.get_student(TEST_USER_ID)
 
     mock_gitlab_instance.users.get.assert_called_once_with(TEST_USER_ID)
 
@@ -462,11 +455,11 @@ def test_get_authenticated_student_success(mock_get, gitlab, mock_student):
     mock_get.return_value = mock_response
     gitlab_api._parse_user_to_student = MagicMock(return_value=mock_student)
 
-    student = gitlab_api.get_authenticated_student(oauth_token, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+    student = gitlab_api.get_authenticated_student(oauth_token)
 
     assert student == mock_student
     mock_get.assert_called_once_with(f"{gitlab_api.base_url}/api/v4/user", headers=headers)
-    gitlab_api._parse_user_to_student.assert_called_once_with(user_data, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+    gitlab_api._parse_user_to_student.assert_called_once_with(user_data)
 
 
 @patch("requests.get")
@@ -481,7 +474,7 @@ def test_get_authenticated_student_failure(mock_get, gitlab):
     mock_get.return_value = mock_response
 
     with pytest.raises(HTTPError, match="401 Unauthorized"):
-        gitlab_api.get_authenticated_student(oauth_token, TEST_GROUP_NAME, TEST_GROUP_STUDENT_NAME)
+        gitlab_api.get_authenticated_student(oauth_token)
 
     mock_get.assert_called_once_with(f"{gitlab_api.base_url}/api/v4/user", headers=headers)
 
@@ -505,4 +498,3 @@ def test_map_gitlab_user_to_student(gitlab, mock_gitlab_user):
 
     assert student.username == TEST_USERNAME
     assert student.name == TEST_USERNAME
-    assert student.repo == TEST_USER_URL

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,7 +105,8 @@ def test_create_app_production_with_db(mock_env, mock_gitlab, monkeypatch):
     assert app.testing == os.getenv("TESTING")
     assert app.secret_key == os.getenv("FLASK_SECRET_KEY")
 
-    assert "web" in app.blueprints
+    assert "root" in app.blueprints
+    assert "course" in app.blueprints
     assert "api" in app.blueprints
 
     assert hasattr(app, "oauth")


### PR DESCRIPTION
Added course_name for url paths. Used course_name of url instead of app.course_name.
Edited login path: requires_auth only checks login, requires_ready only checks course ready, requires_course_access checks previous two and user participation in the course.
Removed course_admin and repo from session.
Edited tests.
