### PR TITLE
feat: remove link to the course in DataBaseApi

### DIFF
--- a/.manytask.example.yml
+++ b/.manytask.example.yml
@@ -1,9 +1,6 @@
 version: 1
 
 
-course_name: python  # will be removed in next PRs
-
-
 ui:
   task_url_template: https://gitlab.manytask.org/test/$GROUP_NAME/$TASK_NAME
 

--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from typing import Any, Callable
 
 from .config import ManytaskDeadlinesConfig, ManytaskGroupConfig, ManytaskTaskConfig, ManytaskUiConfig
-from .course import Course
+from .course import Course, CourseConfig
 from .glab import Student
 
 
@@ -22,44 +22,49 @@ class StorageApi(ABC):
     @abstractmethod
     def get_scores(
         self,
+        course_name: str,
         username: str,
     ) -> dict[str, int]: ...
 
     @abstractmethod
     def get_bonus_score(
         self,
+        course_name: str,
         username: str,
     ) -> int: ...
 
     @abstractmethod
     def get_stored_user(
         self,
+        course_name: str,
         student: Student,
     ) -> StoredUser: ...
 
     @abstractmethod
     def sync_stored_user(
         self,
+        course_name: str,
         student: Student,
         repo_name: str,
         course_admin: bool,
     ) -> StoredUser: ...
 
     @abstractmethod
-    def get_all_scores(self) -> dict[str, dict[str, int]]: ...
+    def get_all_scores(self, course_name: str) -> dict[str, dict[str, int]]: ...
 
     @abstractmethod
-    def get_stats(self) -> dict[str, float]: ...
+    def get_stats(self, course_name: str) -> dict[str, float]: ...
 
     @abstractmethod
-    def get_scores_update_timestamp(self) -> str: ...
+    def get_scores_update_timestamp(self, course_name: str) -> str: ...
 
     @abstractmethod
-    def update_cached_scores(self) -> None: ...
+    def update_cached_scores(self, course_name: str) -> None: ...
 
     @abstractmethod
     def store_score(
         self,
+        course_name: str,
         student: Student,
         repo_name: str,
         task_name: str,
@@ -69,18 +74,27 @@ class StorageApi(ABC):
     @abstractmethod
     def sync_columns(
         self,
+        course_name: str,
         deadlines_config: ManytaskDeadlinesConfig,
     ) -> None: ...
 
     @abstractmethod
     def update_task_groups_from_config(
         self,
+        course_name: str,
         deadlines_config: ManytaskDeadlinesConfig,
     ) -> None: ...
 
     @abstractmethod
+    def create_course(
+        self,
+        settings_config: CourseConfig,
+    ) -> bool: ...
+
+    @abstractmethod
     def update_course(
         self,
+        course_name: str,
         ui_config: ManytaskUiConfig,
     ) -> None: ...
 
@@ -91,25 +105,25 @@ class StorageApi(ABC):
     ) -> Course | None: ...
 
     @abstractmethod
-    def find_task(self, task_name: str) -> tuple[ManytaskGroupConfig, ManytaskTaskConfig]: ...
+    def find_task(self, course_name: str, task_name: str) -> tuple[ManytaskGroupConfig, ManytaskTaskConfig]: ...
 
     @abstractmethod
     def get_groups(
         self,
+        course_name: str,
         enabled: bool | None = None,
         started: bool | None = None,
         now: datetime | None = None,
     ) -> list[ManytaskGroupConfig]: ...
 
     @abstractmethod
-    def get_now_with_timezone(self) -> datetime: ...
+    def get_now_with_timezone(self, course_name: str) -> datetime: ...
 
     @abstractmethod
-    def max_score(self, started: bool | None = True) -> int: ...
+    def max_score(self, course_name: str, started: bool | None = True) -> int: ...
 
-    @property
     @abstractmethod
-    def max_score_started(self) -> int: ...
+    def max_score_started(self, course_name: str) -> int: ...
 
     @abstractmethod
     def sync_and_get_admin_status(self, course_name: str, student: Student, course_admin: bool) -> bool: ...

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -169,6 +169,7 @@ def requires_course_access(f: Callable[..., Any]) -> Callable[..., Any]:
 
         # sync user's data from gitlab to database  TODO: optimize it
         app.storage_api.sync_stored_user(
+            course.course_name,
             student,
             app.gitlab_api.get_url_for_repo(student.username, course.gitlab_course_students_group),
             app.gitlab_api.check_is_course_admin(student.id, course.gitlab_course_group),

--- a/manytask/config.py
+++ b/manytask/config.py
@@ -192,7 +192,6 @@ class ManytaskConfig(BaseModel):
 
     version: int  # if config exists, version is always present
 
-    course_name: str  # will be removed in next PRs
     ui: ManytaskUiConfig
     deadlines: ManytaskDeadlinesConfig
 

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -3,14 +3,14 @@ from typing import Any
 from .main import CustomFlask
 
 
-def get_database_table_data(app: CustomFlask) -> dict[str, Any]:
+def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any]:
     """Get the database table data structure used by both web and API endpoints."""
 
     storage_api = app.storage_api
-    all_scores = storage_api.get_all_scores()
+    all_scores = storage_api.get_all_scores(course_name)
 
     all_tasks = []
-    for group in storage_api.get_groups():
+    for group in storage_api.get_groups(course_name):
         for task in group.tasks:
             if task.enabled:
                 all_tasks.append({"name": task.name, "score": 0, "group": group.name})

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -147,7 +147,7 @@
             // Update database
             const scores = {};
             scores[taskName] = newScore;
-            fetch('/api/database/update', {
+            fetch('{{ url_for("api.update_database", course_name=course_name) }}', {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -224,7 +224,7 @@
                 attributeFilter: ['data-bs-theme']
             });
 
-            fetch('/api/database')
+            fetch('{{ url_for("api.get_database", course_name=course_name) }}')
                 .then(response => response.json())
                 .then(data => {
                     let columns = [

--- a/manytask/templates/layout.html
+++ b/manytask/templates/layout.html
@@ -6,7 +6,7 @@
 {% set solved_score = scores.values() | sum() %}
 {% set bonus_score_string = "+" ~ bonus_score if bonus_score > 0 else "" %}
 {% set solved_score_string = solved_score ~ bonus_score_string %}
-{% set solved_percent = "0.0" if app.storage_api.max_score_started  == 0 else (solved_score / app.storage_api.max_score_started * 100) | round(1, 'common') %}
+{% set solved_percent = "0.0" if app.storage_api.max_score_started(course_name)  == 0 else (solved_score / app.storage_api.max_score_started(course_name) * 100) | round(1, 'common') %}
 
 
     <style>
@@ -67,7 +67,7 @@
                     <li class="nav-item">
                         <a class="nav-link px-3 {% if active_page == 'database' %}active{% endif %}" 
                            aria-current="{% if active_page == 'database' %}page{% endif %}"
-                           href="/database">
+                           href="{{ url_for('course.show_database', course_name=course_name) }}">
                             All&nbsp;Scores
                         </a>
                     </li>
@@ -88,7 +88,7 @@
 
             <div class="dropdown text-end d-flex align-items-center justify-content-center">
                 <div class="total_score round d-flex flex-column align-items-center justify-content-center ms-2 me-2">
-                    <span class="fs-7">{{ solved_score_string }}/{{ app.storage_api.max_score_started }}</span>
+                    <span class="fs-7">{{ solved_score_string }}/{{ app.storage_api.max_score_started(course_name) }}</span>
                     <span class="fs-7">{{ solved_percent }}%</span>
                 </div>
 
@@ -103,7 +103,7 @@
                     <li><a class="dropdown-item" href="#" data-bs-theme-value="dark"><i class="fa-fw fa-solid fa-moon"></i>&nbsp;Dark Theme</a></li>
                     <li><a class="dropdown-item" href="#" data-bs-theme-value="auto"><i class="fa-fw fa-solid fa-wand-magic-sparkles"></i>&nbsp;Auto Theme</a></li>
                     <li><hr class="dropdown-divider"></li>
-                    <li><a class="dropdown-item" href="/logout">Sign out</a></li>
+                    <li><a class="dropdown-item" href="{{ url_for('root.logout') }}">Sign out</a></li>
                 </ul>
             </div>
 

--- a/manytask/templates/not_ready.html
+++ b/manytask/templates/not_ready.html
@@ -6,7 +6,7 @@
     <h3>You need configure it first with api request</h3>
     <hr>
     <p>You can update the page once it ready</p>
-    <button onClick="window.location.reload()" class="btn btn-warning">Refresh</button>
+    <a href="{{ url_for('course.course_page', course_name=course_name) }}" class="btn btn-warning">Refresh</a>
 </div>
 {% endblock %}
 

--- a/manytask/templates/signup.html
+++ b/manytask/templates/signup.html
@@ -4,7 +4,7 @@
 
     <div class="d-flex align-items-center justify-content-center bg-body-tertiary container-fluid p-3">
         <div class="d-flex flex-column align-items-center justify-content-center form-signin px-4 py-4 rounded m-auto container-sm" style="background-color: var(--bs-body-bg); max-width: 400px;">
-            <a href="/login" class="btn btn-primary p-3">
+            <a href="{{ url_for('root.login') }}" class="btn btn-primary p-3">
                 <span class="fs-2">Login</span>
                 <br>
                 with {{ base_url }}

--- a/manytask/templates/tasks.html
+++ b/manytask/templates/tasks.html
@@ -135,7 +135,7 @@
     }
 </style>
 
-{% for group in app.storage_api.get_groups(enabled=True, started=True)[::-1] %}
+{% for group in app.storage_api.get_groups(course_name, enabled=True, started=True)[::-1] %}
     {% set total_group_score = group.tasks | rejectattr('is_bonus') | map(attribute='score') | sum %}
     {% set solved_group_scores = [] %}
     {% for task in group.tasks %}
@@ -163,7 +163,7 @@
                 {% if task.url %}
                   {% set task_link = task.url %}
                 {% else %}
-                  {% set task_link = app.config.ui.task_url_template | replace('$GROUP_NAME', group.name) | replace('$TASK_NAME', task.name) %}
+                  {% set task_link = task_url_template | replace('$GROUP_NAME', group.name) | replace('$TASK_NAME', task.name) %}
                 {% endif %}
 
                 {% if scores.get(task.name, 0) == task.score %}

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -46,11 +46,11 @@ def app():
                 )
             ]
 
-        def get_groups(self):
+        def get_groups(self, _course_name):
             return self.groups
 
         @staticmethod
-        def get_all_scores():
+        def get_all_scores(_course_name):
             return {
                 STUDENT_1: {TASK_1: SCORES[STUDENT_1][TASK_1], TASK_2: SCORES[STUDENT_1][TASK_2]},
                 STUDENT_2: {TASK_1: SCORES[STUDENT_2][TASK_1], TASK_2: SCORES[STUDENT_2][TASK_2]},
@@ -87,7 +87,7 @@ def test_get_database_table_data(app):
     expected_students_count = 2
 
     with app.test_request_context():
-        result = get_database_table_data(app)
+        result = get_database_table_data(app, app.course_name)
 
         assert "tasks" in result
         assert "students" in result
@@ -113,8 +113,8 @@ def test_get_database_table_data_no_scores(app):
     expected_tasks_count = 2
 
     with app.test_request_context():
-        app.storage_api.get_all_scores = lambda: {}
-        result = get_database_table_data(app)
+        app.storage_api.get_all_scores = lambda _course_name: {}
+        result = get_database_table_data(app, app.course_name)
 
         assert "tasks" in result
         assert "students" in result

--- a/tests/test_db_api.py
+++ b/tests/test_db_api.py
@@ -12,7 +12,7 @@ from psycopg2.errors import DuplicateColumn, DuplicateTable, UndefinedTable, Uni
 from sqlalchemy.exc import IntegrityError, ProgrammingError
 from sqlalchemy.orm import Session
 
-from manytask.config import ManytaskDeadlinesConfig, ManytaskGroupConfig
+from manytask.config import ManytaskDeadlinesConfig, ManytaskGroupConfig, ManytaskUiConfig
 from manytask.course import Course as ManytaskCourse
 from manytask.course import CourseConfig
 from manytask.database import DataBaseApi, DatabaseConfig, StoredUser, TaskDisabledError
@@ -25,6 +25,8 @@ DEADLINES_CONFIG_FILES = [  # part of manytask config file
 ]
 
 FIXED_CURRENT_TIME = datetime(2025, 4, 1, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+FIRST_COURSE_NAME = "Test Course"
+SECOND_COURSE_NAME = "Another Test Course"
 
 FIRST_COURSE_EXPECTED_STATS_KEYS = {
     "task_0_0",
@@ -84,46 +86,59 @@ def mock_current_time():
         yield mock
 
 
-def first_db_config(db_url):
+def db_config(db_url):
     return DatabaseConfig(
         database_url=db_url,
-        course_name="Test Course",
         gitlab_instance_host="gitlab.test.com",
+        apply_migrations=True,
+    )
+
+
+@pytest.fixture
+def db_api(tables, postgres_container):
+    return DataBaseApi(db_config(postgres_container.get_connection_url()))
+
+
+@pytest.fixture
+def first_course_config():
+    return CourseConfig(
+        course_name=FIRST_COURSE_NAME,
+        gitlab_course_group="test_course_group",
+        gitlab_course_public_repo="test_course_public_repo",
+        gitlab_course_students_group="test_course_students_group",
+        gitlab_default_branch="test_default_branch",
         registration_secret="secret",
         token="test_token",
         show_allscores=True,
-        apply_migrations=True,
+        is_ready=False,
+        task_url_template="https://gitlab.test.com/test/$GROUP_NAME/$TASK_NAME",
+        links={"TG Channel": "https://t.me/joinchat/", "TG Chat": "https://t.me/joinchat/"},
+    )
+
+
+@pytest.fixture
+def first_course_updated_ui_config():
+    return ManytaskUiConfig(
+        task_url_template="https://gitlab.test.com/test_updated/$GROUP_NAME/$TASK_NAME",
+        links={"TG Channel": "https://t.me/joinchat_updated/", "TG Chat": "https://t.me/joinchat_updated/"},
+    )
+
+
+@pytest.fixture
+def second_course_config():
+    return CourseConfig(
+        course_name=SECOND_COURSE_NAME,
         gitlab_course_group="test_course_group",
         gitlab_course_public_repo="test_course_public_repo",
         gitlab_course_students_group="test_course_students_group",
         gitlab_default_branch="test_default_branch",
-    )
-
-
-def second_db_config(db_url):
-    return DatabaseConfig(
-        database_url=db_url,
-        course_name="Another Test Course",
-        gitlab_instance_host="gitlab.test.com",
-        token="another_test_token",
         registration_secret="secret",
+        token="another_test_token",
         show_allscores=True,
-        apply_migrations=True,
-        gitlab_course_group="test_course_group",
-        gitlab_course_public_repo="test_course_public_repo",
-        gitlab_course_students_group="test_course_students_group",
-        gitlab_default_branch="test_default_branch",
+        is_ready=False,
+        task_url_template="https://gitlab.test.com/another_test/$GROUP_NAME/$TASK_NAME",
+        links={"TG Chat": "https://t.me/joinchat2/"},
     )
-
-
-@pytest.fixture
-def first_course_db_api(tables, postgres_container):
-    return DataBaseApi(first_db_config(postgres_container.get_connection_url()))
-
-
-@pytest.fixture
-def second_course_db_api(tables, postgres_container):
-    return DataBaseApi(second_db_config(postgres_container.get_connection_url()))
 
 
 @pytest.fixture
@@ -175,16 +190,45 @@ def first_course_deadlines_config_with_changed_order_of_tasks():
     return ManytaskDeadlinesConfig(**deadlines_config_data["deadlines"])
 
 
-@pytest.fixture
-def first_course_with_deadlines(first_course_db_api, first_course_deadlines_config, session):
-    first_course_db_api.sync_columns(first_course_deadlines_config)
-    return first_course_db_api
+def update_course(
+    db_api: DataBaseApi, course_name: str, ui_config: ManytaskUiConfig, deadlines_config: ManytaskDeadlinesConfig
+) -> None:
+    """Update created course"""
+
+    db_api.update_course(course_name=course_name, ui_config=ui_config)
+
+    db_api.update_task_groups_from_config(course_name=course_name, deadlines_config=deadlines_config)
+    db_api.sync_columns(course_name=course_name, deadlines_config=deadlines_config)
+
+
+def create_course(db_api: DataBaseApi, course_config: CourseConfig, deadlines_config: ManytaskDeadlinesConfig) -> None:
+    """Create and update course"""
+    db_api.create_course(settings_config=course_config)
+
+    update_course(
+        db_api,
+        course_config.course_name,
+        ManytaskUiConfig(
+            task_url_template=course_config.task_url_template,
+            links=course_config.links,
+        ),
+        deadlines_config,
+    )
 
 
 @pytest.fixture
-def second_course_with_deadlines(second_course_db_api, second_course_deadlines_config, session):
-    second_course_db_api.sync_columns(second_course_deadlines_config)
-    return second_course_db_api
+def db_api_with_initialized_first_course(db_api, first_course_config, first_course_deadlines_config):
+    create_course(db_api, first_course_config, first_course_deadlines_config)
+    return db_api
+
+
+@pytest.fixture
+def db_api_with_two_initialized_courses(
+    db_api, first_course_config, first_course_deadlines_config, second_course_config, second_course_deadlines_config
+):
+    create_course(db_api, first_course_config, first_course_deadlines_config)
+    create_course(db_api, second_course_config, second_course_deadlines_config)
+    return db_api
 
 
 @pytest.fixture(autouse=True)
@@ -204,24 +248,37 @@ def update_func(add: int):
     return _update_func
 
 
-def test_empty_course(first_course_db_api, session):
+def test_not_initialized_course(session, db_api, first_course_config):
+    db_api.create_course(settings_config=first_course_config)
+    course_name = first_course_config.course_name
+
     assert session.query(Course).count() == 1
     course = session.query(Course).one()
 
-    assert course.name == "Test Course"
+    assert course.name == FIRST_COURSE_NAME
     assert course.gitlab_instance_host == "gitlab.test.com"
     assert course.registration_secret == "secret"
     assert course.token == "test_token"
     assert course.show_allscores
+    assert not course.is_ready
+
+    assert course.gitlab_course_group == "test_course_group"
+    assert course.gitlab_course_public_repo == "test_course_public_repo"
+    assert course.gitlab_course_students_group == "test_course_students_group"
+    assert course.gitlab_default_branch == "test_default_branch"
+
+    assert course.task_url_template == "https://gitlab.test.com/test/$GROUP_NAME/$TASK_NAME"
+    assert course.links == {"TG Channel": "https://t.me/joinchat/", "TG Chat": "https://t.me/joinchat/"}
+
     assert course.timezone == "UTC"
     assert course.max_submissions is None
     assert course.submission_penalty == 0
 
-    stats = first_course_db_api.get_stats()
-    all_scores = first_course_db_api.get_all_scores()
-    bonus_score = first_course_db_api.get_bonus_score("some_user")
-    scores = first_course_db_api.get_scores("some_user")
-    max_score_started = first_course_db_api.max_score_started
+    stats = db_api.get_stats(course_name)
+    all_scores = db_api.get_all_scores(course_name)
+    bonus_score = db_api.get_bonus_score(course_name, "some_user")
+    scores = db_api.get_scores(course_name, "some_user")
+    max_score_started = db_api.max_score_started(course_name)
 
     assert stats == {}
     assert all_scores == {}
@@ -230,7 +287,7 @@ def test_empty_course(first_course_db_api, session):
     assert max_score_started == 0
 
 
-def test_sync_columns(first_course_with_deadlines, session):
+def test_initialized_course(db_api_with_initialized_first_course, session):
     expected_task_groups = 5
     expected_tasks = 18
     bonus_tasks = ("task_0_2", "task_1_3")
@@ -241,19 +298,32 @@ def test_sync_columns(first_course_with_deadlines, session):
     assert session.query(Course).count() == 1
     course = session.query(Course).one()
 
-    assert course.name == "Test Course"
+    assert course.name == FIRST_COURSE_NAME
     assert course.gitlab_instance_host == "gitlab.test.com"
     assert course.registration_secret == "secret"
     assert course.token == "test_token"
     assert course.show_allscores
+    assert course.is_ready
+
+    assert course.gitlab_course_group == "test_course_group"
+    assert course.gitlab_course_public_repo == "test_course_public_repo"
+    assert course.gitlab_course_students_group == "test_course_students_group"
+    assert course.gitlab_default_branch == "test_default_branch"
+
+    assert course.task_url_template == "https://gitlab.test.com/test/$GROUP_NAME/$TASK_NAME"
+    assert course.links == {"TG Channel": "https://t.me/joinchat/", "TG Chat": "https://t.me/joinchat/"}
+
     assert course.timezone == "Europe/Berlin"
     assert course.max_submissions == 10  # noqa: PLR2004
     assert course.submission_penalty == 0.1  # noqa: PLR2004
 
-    stats = first_course_with_deadlines.get_stats()
+    stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
     assert set(stats.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS
     assert all(v == 0 for v in stats.values())
-    assert first_course_with_deadlines.max_score_started == FIRST_COURSE_EXPECTED_MAX_SCORE_STARTED
+    assert (
+        db_api_with_initialized_first_course.max_score_started(FIRST_COURSE_NAME)
+        == FIRST_COURSE_EXPECTED_MAX_SCORE_STARTED
+    )
 
     assert session.query(TaskGroup).count() == expected_task_groups
     assert session.query(Task).count() == expected_tasks
@@ -276,7 +346,14 @@ def test_sync_columns(first_course_with_deadlines, session):
         assert task.score == expected_task_score
 
 
-def test_resync_columns(first_course_db_api, first_course_deadlines_config, second_course_deadlines_config, session):
+def test_updating_course(
+    db_api,
+    first_course_config,
+    first_course_deadlines_config,
+    second_course_deadlines_config,
+    first_course_updated_ui_config,
+    session,
+):
     expected_task_groups = 8
     expected_tasks = 28
     bonus_tasks = ("task_0_2", "task_1_3", "task_6_0")
@@ -284,25 +361,35 @@ def test_resync_columns(first_course_db_api, first_course_deadlines_config, seco
     disabled_groups = ("group_6",)
     disabled_tasks = ("task_2_2",)
 
-    first_course_db_api.sync_columns(first_course_deadlines_config)
-    first_course_db_api.sync_columns(second_course_deadlines_config)
+    create_course(db_api, first_course_config, first_course_deadlines_config)
+    update_course(db_api, FIRST_COURSE_NAME, first_course_updated_ui_config, second_course_deadlines_config)
 
     assert session.query(Course).count() == 1
     course = session.query(Course).one()
 
-    assert course.name == "Test Course"
+    assert course.name == FIRST_COURSE_NAME
     assert course.gitlab_instance_host == "gitlab.test.com"
     assert course.registration_secret == "secret"
     assert course.token == "test_token"
     assert course.show_allscores
+    assert course.is_ready
+
+    assert course.gitlab_course_group == "test_course_group"
+    assert course.gitlab_course_public_repo == "test_course_public_repo"
+    assert course.gitlab_course_students_group == "test_course_students_group"
+    assert course.gitlab_default_branch == "test_default_branch"
+
+    assert course.task_url_template == "https://gitlab.test.com/test_updated/$GROUP_NAME/$TASK_NAME"
+    assert course.links == {"TG Channel": "https://t.me/joinchat_updated/", "TG Chat": "https://t.me/joinchat_updated/"}
+
     assert course.timezone == "Europe/Moscow"
     assert course.max_submissions == 20  # noqa: PLR2004
     assert course.submission_penalty == 0.2  # noqa: PLR2004
 
-    stats = first_course_db_api.get_stats()
+    stats = db_api.get_stats(FIRST_COURSE_NAME)
     assert set(stats.keys()) == SECOND_COURSE_EXPECTED_STATS_KEYS
     assert all(v == 0 for v in stats.values())
-    assert first_course_db_api.max_score_started == SECOND_COURSE_EXPECTED_MAX_SCORE_STARTED
+    assert db_api.max_score_started(FIRST_COURSE_NAME) == SECOND_COURSE_EXPECTED_MAX_SCORE_STARTED
 
     assert session.query(TaskGroup).count() == expected_task_groups
     assert session.query(Task).count() == expected_tasks
@@ -326,19 +413,26 @@ def test_resync_columns(first_course_db_api, first_course_deadlines_config, seco
 
 
 def test_resync_with_changed_task_name(
-    first_course_db_api, first_course_deadlines_config, first_course_deadlines_config_with_changed_task_name, session
+    db_api,
+    first_course_config,
+    first_course_deadlines_config,
+    first_course_deadlines_config_with_changed_task_name,
+    first_course_updated_ui_config,
+    session,
 ):
     expected_task_groups = 5
     expected_tasks = 19
     disabled_tasks = ("task_0_0", "task_2_1")
 
-    first_course_db_api.sync_columns(first_course_deadlines_config)
-    first_course_db_api.sync_columns(first_course_deadlines_config_with_changed_task_name)
+    create_course(db_api, first_course_config, first_course_deadlines_config)
+    update_course(
+        db_api, FIRST_COURSE_NAME, first_course_updated_ui_config, first_course_deadlines_config_with_changed_task_name
+    )
 
-    stats = first_course_db_api.get_stats()
+    stats = db_api.get_stats(FIRST_COURSE_NAME)
     assert set(stats.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS - {"task_0_0"} | {"task_0_0_changed"}
     assert all(v == 0 for v in stats.values())
-    assert first_course_db_api.max_score_started == FIRST_COURSE_EXPECTED_MAX_SCORE_STARTED
+    assert db_api.max_score_started(FIRST_COURSE_NAME) == FIRST_COURSE_EXPECTED_MAX_SCORE_STARTED
 
     assert session.query(TaskGroup).count() == expected_task_groups
     assert session.query(Task).count() == expected_tasks
@@ -350,13 +444,18 @@ def test_resync_with_changed_task_name(
         assert task.enabled != (task.name in disabled_tasks)
 
 
-def test_store_score(first_course_with_deadlines, session):
+def test_store_score(db_api_with_initialized_first_course, session):
     student = Student(0, "user1", "username1")
 
     assert session.query(User).count() == 0
     assert session.query(UserOnCourse).count() == 0
 
-    assert first_course_with_deadlines.store_score(student, "repo1", "not_exist_task", update_func(1)) == 0
+    assert (
+        db_api_with_initialized_first_course.store_score(
+            FIRST_COURSE_NAME, student, "repo1", "not_exist_task", update_func(1)
+        )
+        == 0
+    )
 
     assert session.query(User).count() == 1
     assert session.query(UserOnCourse).count() == 1
@@ -367,11 +466,16 @@ def test_store_score(first_course_with_deadlines, session):
 
     user_on_course = session.query(UserOnCourse).one()
     assert user_on_course.user_id == user.id
-    assert user_on_course.course.name == "Test Course"
+    assert user_on_course.course.name == FIRST_COURSE_NAME
 
     assert session.query(Grade).count() == 0
 
-    assert first_course_with_deadlines.store_score(student, "repo1", "task_0_0", update_func(1)) == 1
+    assert (
+        db_api_with_initialized_first_course.store_score(
+            FIRST_COURSE_NAME, student, "repo1", "task_0_0", update_func(1)
+        )
+        == 1
+    )
 
     assert session.query(User).count() == 1
     assert session.query(UserOnCourse).count() == 1
@@ -382,10 +486,10 @@ def test_store_score(first_course_with_deadlines, session):
     assert grade.task.name == "task_0_0"
     assert grade.score == 1
 
-    stats = first_course_with_deadlines.get_stats()
-    all_scores = first_course_with_deadlines.get_all_scores()
-    bonus_score = first_course_with_deadlines.get_bonus_score("user1")
-    scores = first_course_with_deadlines.get_scores("user1")
+    stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
+    all_scores = db_api_with_initialized_first_course.get_all_scores(FIRST_COURSE_NAME)
+    bonus_score = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, "user1")
+    scores = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, "user1")
 
     assert set(stats.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS
     assert stats["task_0_0"] == 1.0
@@ -396,12 +500,14 @@ def test_store_score(first_course_with_deadlines, session):
     assert scores == {"task_0_0": 1}
 
 
-def test_store_score_bonus_task(first_course_with_deadlines, session):
+def test_store_score_bonus_task(db_api_with_initialized_first_course, session):
     expected_score = 22
     student = Student(0, "user1", "username1")
 
     assert (
-        first_course_with_deadlines.store_score(student, "repo1", "task_1_3", update_func(expected_score))
+        db_api_with_initialized_first_course.store_score(
+            FIRST_COURSE_NAME, student, "repo1", "task_1_3", update_func(expected_score)
+        )
         == expected_score
     )
 
@@ -413,10 +519,10 @@ def test_store_score_bonus_task(first_course_with_deadlines, session):
     assert grade.task.name == "task_1_3"
     assert grade.score == expected_score
 
-    stats = first_course_with_deadlines.get_stats()
-    all_scores = first_course_with_deadlines.get_all_scores()
-    bonus_score = first_course_with_deadlines.get_bonus_score("user1")
-    scores = first_course_with_deadlines.get_scores("user1")
+    stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
+    all_scores = db_api_with_initialized_first_course.get_all_scores(FIRST_COURSE_NAME)
+    bonus_score = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, "user1")
+    scores = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, "user1")
 
     assert set(stats.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS
     assert stats["task_1_3"] == 1.0
@@ -428,19 +534,25 @@ def test_store_score_bonus_task(first_course_with_deadlines, session):
 
 
 def test_store_score_with_changed_task_name(
-    first_course_db_api, first_course_deadlines_config, first_course_deadlines_config_with_changed_task_name
+    db_api,
+    first_course_config,
+    first_course_deadlines_config,
+    first_course_deadlines_config_with_changed_task_name,
+    first_course_updated_ui_config,
 ):
-    first_course_db_api.sync_columns(first_course_deadlines_config)
+    create_course(db_api, first_course_config, first_course_deadlines_config)
 
     student = Student(0, "user1", "username1")
-    first_course_db_api.store_score(student, "repo1", "task_0_0", update_func(10))
+    db_api.store_score(FIRST_COURSE_NAME, student, "repo1", "task_0_0", update_func(10))
 
-    first_course_db_api.sync_columns(first_course_deadlines_config_with_changed_task_name)
+    update_course(
+        db_api, FIRST_COURSE_NAME, first_course_updated_ui_config, first_course_deadlines_config_with_changed_task_name
+    )
 
-    stats = first_course_db_api.get_stats()
-    all_scores = first_course_db_api.get_all_scores()
-    bonus_score = first_course_db_api.get_bonus_score("user1")
-    scores = first_course_db_api.get_scores("user1")
+    stats = db_api.get_stats(FIRST_COURSE_NAME)
+    all_scores = db_api.get_all_scores(FIRST_COURSE_NAME)
+    bonus_score = db_api.get_bonus_score(FIRST_COURSE_NAME, "user1")
+    scores = db_api.get_scores(FIRST_COURSE_NAME, "user1")
 
     assert set(stats.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS - {"task_0_0"} | {"task_0_0_changed"}
     assert all(v == 0.0 for k, v in stats.items())
@@ -450,13 +562,13 @@ def test_store_score_with_changed_task_name(
     assert scores == {}
 
 
-def test_get_and_sync_stored_user(first_course_with_deadlines, session):
+def test_get_and_sync_stored_user(db_api_with_initialized_first_course, session):
     student = Student(0, "user1", "username1")  # default student(not admin in gitlab)
 
     assert session.query(User).count() == 0
     assert session.query(UserOnCourse).count() == 0
 
-    stored_user = first_course_with_deadlines.get_stored_user(student)
+    stored_user = db_api_with_initialized_first_course.get_stored_user(FIRST_COURSE_NAME, student)
 
     assert stored_user == StoredUser(username="user1", course_admin=False)
 
@@ -464,12 +576,12 @@ def test_get_and_sync_stored_user(first_course_with_deadlines, session):
     assert session.query(UserOnCourse).count() == 1
 
     # admin in gitlab
-    stored_user = first_course_with_deadlines.sync_stored_user(student, "repo1", True)
+    stored_user = db_api_with_initialized_first_course.sync_stored_user(FIRST_COURSE_NAME, student, "repo1", True)
 
     assert stored_user == StoredUser(username="user1", course_admin=True)
 
     # lost admin rules in gitlab, but in database stored that user is admin
-    stored_user = first_course_with_deadlines.sync_stored_user(student, "repo1", False)
+    stored_user = db_api_with_initialized_first_course.sync_stored_user(FIRST_COURSE_NAME, student, "repo1", False)
 
     assert stored_user == StoredUser(username="user1", course_admin=True)
 
@@ -477,7 +589,7 @@ def test_get_and_sync_stored_user(first_course_with_deadlines, session):
     assert session.query(UserOnCourse).count() == 1
 
 
-def test_many_users(first_course_with_deadlines, session):
+def test_many_users(db_api_with_initialized_first_course, session):
     expected_score_1 = 22
     expected_score_2 = 15
     expected_users = 2
@@ -486,13 +598,17 @@ def test_many_users(first_course_with_deadlines, session):
     expected_stats_ratio = 0.5
 
     student1 = Student(0, "user1", "username1")
-    first_course_with_deadlines.store_score(student1, "repo1", "task_0_0", update_func(1))
-    first_course_with_deadlines.store_score(student1, "repo1", "task_1_3", update_func(expected_score_1))
+    db_api_with_initialized_first_course.store_score(FIRST_COURSE_NAME, student1, "repo1", "task_0_0", update_func(1))
+    db_api_with_initialized_first_course.store_score(
+        FIRST_COURSE_NAME, student1, "repo1", "task_1_3", update_func(expected_score_1)
+    )
 
     student2 = Student(1, "user2", "username2")
 
     assert (
-        first_course_with_deadlines.store_score(student2, "repo2", "task_0_0", update_func(expected_score_2))
+        db_api_with_initialized_first_course.store_score(
+            FIRST_COURSE_NAME, student2, "repo2", "task_0_0", update_func(expected_score_2)
+        )
         == expected_score_2
     )
 
@@ -500,12 +616,12 @@ def test_many_users(first_course_with_deadlines, session):
     assert session.query(UserOnCourse).count() == expected_user_on_course
     assert session.query(Grade).count() == expected_grades
 
-    stats = first_course_with_deadlines.get_stats()
-    all_scores = first_course_with_deadlines.get_all_scores()
-    bonus_score_user1 = first_course_with_deadlines.get_bonus_score("user1")
-    scores_user1 = first_course_with_deadlines.get_scores("user1")
-    bonus_score_user2 = first_course_with_deadlines.get_bonus_score("user2")
-    scores_user2 = first_course_with_deadlines.get_scores("user2")
+    stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
+    all_scores = db_api_with_initialized_first_course.get_all_scores(FIRST_COURSE_NAME)
+    bonus_score_user1 = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, "user1")
+    scores_user1 = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, "user1")
+    bonus_score_user2 = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, "user2")
+    scores_user2 = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, "user2")
 
     assert set(stats.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS
     assert stats["task_0_0"] == 1.0
@@ -522,10 +638,10 @@ def test_many_users(first_course_with_deadlines, session):
     assert scores_user2 == {"task_0_0": expected_score_2}
 
 
-def test_many_courses(first_course_with_deadlines, second_course_with_deadlines, session):
+def test_many_courses(db_api_with_two_initialized_courses, session):
     student = Student(0, "user1", "username1")
-    first_course_with_deadlines.store_score(student, "repo1", "task_0_0", update_func(30))
-    second_course_with_deadlines.store_score(student, "repo1", "task_1_3", update_func(40))
+    db_api_with_two_initialized_courses.store_score(FIRST_COURSE_NAME, student, "repo1", "task_0_0", update_func(30))
+    db_api_with_two_initialized_courses.store_score(SECOND_COURSE_NAME, student, "repo1", "task_1_3", update_func(40))
     expected_users = 1
     expected_user_on_course = 2
     expected_grades = 2
@@ -534,10 +650,10 @@ def test_many_courses(first_course_with_deadlines, second_course_with_deadlines,
     assert session.query(UserOnCourse).count() == expected_user_on_course
     assert session.query(Grade).count() == expected_grades
 
-    stats1 = first_course_with_deadlines.get_stats()
-    all_scores1 = first_course_with_deadlines.get_all_scores()
-    bonus_score_user1 = first_course_with_deadlines.get_bonus_score("user1")
-    scores_user1 = first_course_with_deadlines.get_scores("user1")
+    stats1 = db_api_with_two_initialized_courses.get_stats(FIRST_COURSE_NAME)
+    all_scores1 = db_api_with_two_initialized_courses.get_all_scores(FIRST_COURSE_NAME)
+    bonus_score_user1 = db_api_with_two_initialized_courses.get_bonus_score(FIRST_COURSE_NAME, "user1")
+    scores_user1 = db_api_with_two_initialized_courses.get_scores(FIRST_COURSE_NAME, "user1")
 
     assert set(stats1.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS
     assert stats1["task_0_0"] == 1.0
@@ -547,10 +663,10 @@ def test_many_courses(first_course_with_deadlines, second_course_with_deadlines,
     assert bonus_score_user1 == 0
     assert scores_user1 == {"task_0_0": 30}
 
-    stats2 = second_course_with_deadlines.get_stats()
-    all_scores2 = second_course_with_deadlines.get_all_scores()
-    bonus_score_user2 = second_course_with_deadlines.get_bonus_score("user1")
-    scores_user2 = second_course_with_deadlines.get_scores("user1")
+    stats2 = db_api_with_two_initialized_courses.get_stats(SECOND_COURSE_NAME)
+    all_scores2 = db_api_with_two_initialized_courses.get_all_scores(SECOND_COURSE_NAME)
+    bonus_score_user2 = db_api_with_two_initialized_courses.get_bonus_score(SECOND_COURSE_NAME, "user1")
+    scores_user2 = db_api_with_two_initialized_courses.get_scores(SECOND_COURSE_NAME, "user1")
 
     assert set(stats2.keys()) == SECOND_COURSE_EXPECTED_STATS_KEYS
     assert stats2["task_1_3"] == 1.0
@@ -562,7 +678,7 @@ def test_many_courses(first_course_with_deadlines, second_course_with_deadlines,
     assert scores_user2 == {"task_1_3": user2_score}
 
 
-def test_many_users_and_courses(first_course_with_deadlines, second_course_with_deadlines, session):
+def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     expected_score_1 = 22
     expected_score_2 = 15
     expected_users = 2
@@ -573,23 +689,27 @@ def test_many_users_and_courses(first_course_with_deadlines, second_course_with_
     student1 = Student(0, "user1", "username1")
     student2 = Student(1, "user2", "username2")
 
-    first_course_with_deadlines.store_score(student1, "repo1", "task_0_0", update_func(1))
-    first_course_with_deadlines.store_score(student1, "repo1", "task_1_3", update_func(expected_score_1))
-    first_course_with_deadlines.store_score(student2, "repo2", "task_0_0", update_func(expected_score_2))
+    db_api_with_two_initialized_courses.store_score(FIRST_COURSE_NAME, student1, "repo1", "task_0_0", update_func(1))
+    db_api_with_two_initialized_courses.store_score(
+        FIRST_COURSE_NAME, student1, "repo1", "task_1_3", update_func(expected_score_1)
+    )
+    db_api_with_two_initialized_courses.store_score(
+        FIRST_COURSE_NAME, student2, "repo2", "task_0_0", update_func(expected_score_2)
+    )
 
-    second_course_with_deadlines.store_score(student1, "repo1", "task_1_0", update_func(99))
-    second_course_with_deadlines.store_score(student2, "repo2", "task_1_1", update_func(7))
+    db_api_with_two_initialized_courses.store_score(SECOND_COURSE_NAME, student1, "repo1", "task_1_0", update_func(99))
+    db_api_with_two_initialized_courses.store_score(SECOND_COURSE_NAME, student2, "repo2", "task_1_1", update_func(7))
 
     assert session.query(User).count() == expected_users
     assert session.query(UserOnCourse).count() == expected_user_on_course
     assert session.query(Grade).count() == expected_grades
 
-    stats1 = first_course_with_deadlines.get_stats()
-    all_scores1 = first_course_with_deadlines.get_all_scores()
-    bonus_score1_user1 = first_course_with_deadlines.get_bonus_score("user1")
-    scores1_user1 = first_course_with_deadlines.get_scores("user1")
-    bonus_score1_user2 = first_course_with_deadlines.get_bonus_score("user2")
-    scores1_user2 = first_course_with_deadlines.get_scores("user2")
+    stats1 = db_api_with_two_initialized_courses.get_stats(FIRST_COURSE_NAME)
+    all_scores1 = db_api_with_two_initialized_courses.get_all_scores(FIRST_COURSE_NAME)
+    bonus_score1_user1 = db_api_with_two_initialized_courses.get_bonus_score(FIRST_COURSE_NAME, "user1")
+    scores1_user1 = db_api_with_two_initialized_courses.get_scores(FIRST_COURSE_NAME, "user1")
+    bonus_score1_user2 = db_api_with_two_initialized_courses.get_bonus_score(FIRST_COURSE_NAME, "user2")
+    scores1_user2 = db_api_with_two_initialized_courses.get_scores(FIRST_COURSE_NAME, "user2")
 
     assert set(stats1.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS
     assert stats1["task_0_0"] == 1.0
@@ -605,12 +725,12 @@ def test_many_users_and_courses(first_course_with_deadlines, second_course_with_
     assert bonus_score1_user2 == 0
     assert scores1_user2 == {"task_0_0": expected_score_2}
 
-    stats2 = second_course_with_deadlines.get_stats()
-    all_scores2 = second_course_with_deadlines.get_all_scores()
-    bonus_score2_user1 = second_course_with_deadlines.get_bonus_score("user1")
-    scores2_user1 = second_course_with_deadlines.get_scores("user1")
-    bonus_score2_user2 = second_course_with_deadlines.get_bonus_score("user2")
-    scores2_user2 = second_course_with_deadlines.get_scores("user2")
+    stats2 = db_api_with_two_initialized_courses.get_stats(SECOND_COURSE_NAME)
+    all_scores2 = db_api_with_two_initialized_courses.get_all_scores(SECOND_COURSE_NAME)
+    bonus_score2_user1 = db_api_with_two_initialized_courses.get_bonus_score(SECOND_COURSE_NAME, "user1")
+    scores2_user1 = db_api_with_two_initialized_courses.get_scores(SECOND_COURSE_NAME, "user1")
+    bonus_score2_user2 = db_api_with_two_initialized_courses.get_bonus_score(SECOND_COURSE_NAME, "user2")
+    scores2_user2 = db_api_with_two_initialized_courses.get_scores(SECOND_COURSE_NAME, "user2")
 
     assert set(stats2.keys()) == SECOND_COURSE_EXPECTED_STATS_KEYS
     assert stats2["task_1_0"] == expected_stats_ratio
@@ -624,13 +744,13 @@ def test_many_users_and_courses(first_course_with_deadlines, second_course_with_
     assert scores2_user2 == {"task_1_1": 7}
 
 
-def test_deadlines(first_course_with_deadlines, second_course_with_deadlines, session):
+def test_deadlines(db_api_with_two_initialized_courses, session):
     deadline1 = (
         session.query(Deadline)
         .join(TaskGroup)
         .filter(TaskGroup.name == "group_1")
         .join(Course)
-        .filter(Course.name == "Test Course")
+        .filter(Course.name == FIRST_COURSE_NAME)
         .one()
     )
 
@@ -643,7 +763,7 @@ def test_deadlines(first_course_with_deadlines, second_course_with_deadlines, se
         .join(TaskGroup)
         .filter(TaskGroup.name == "group_1")
         .join(Course)
-        .filter(Course.name == "Another Test Course")
+        .filter(Course.name == SECOND_COURSE_NAME)
         .one()
     )
 
@@ -652,42 +772,9 @@ def test_deadlines(first_course_with_deadlines, second_course_with_deadlines, se
     assert deadline2.end == datetime(2000, 2, 1, 23, 59, tzinfo=ZoneInfo("Europe/Moscow"))
 
 
-def test_course_change_params(first_course_db_api, postgres_container):
-    with pytest.raises(AttributeError):
-        DataBaseApi(
-            DatabaseConfig(
-                database_url=postgres_container.get_connection_url(),
-                course_name="Test Course",
-                gitlab_instance_host="another_gitlab.test.com",
-                registration_secret="another_secret",
-                token="another_token",
-                show_allscores=False,
-                gitlab_course_group="another_test_course_group",
-                gitlab_course_public_repo="another_test_course_public_repo",
-                gitlab_course_students_group="another_test_course_students_group",
-                gitlab_default_branch="another_test_default_branch",
-            )
-        )
-
-    DataBaseApi(
-        DatabaseConfig(
-            database_url=postgres_container.get_connection_url(),
-            course_name="Test Course",
-            gitlab_instance_host="gitlab.test.com",
-            registration_secret="another_secret",
-            token="another_token",
-            show_allscores=False,
-            gitlab_course_group="another_test_course_group",
-            gitlab_course_public_repo="another_test_course_public_repo",
-            gitlab_course_students_group="another_test_course_students_group",
-            gitlab_default_branch="another_test_default_branch",
-        )
-    )
-
-
-def test_bad_requests(first_course_with_deadlines, session):
-    bonus_score = first_course_with_deadlines.get_bonus_score("random_user")
-    scores = first_course_with_deadlines.get_scores("random_user")
+def test_bad_requests(db_api_with_two_initialized_courses, session):
+    bonus_score = db_api_with_two_initialized_courses.get_bonus_score(FIRST_COURSE_NAME, "random_user")
+    scores = db_api_with_two_initialized_courses.get_scores(FIRST_COURSE_NAME, "random_user")
 
     assert bonus_score == 0
     assert scores == {}
@@ -697,36 +784,32 @@ def test_bad_requests(first_course_with_deadlines, session):
     assert session.query(Grade).count() == 0
 
 
-def test_auto_tables_creation(engine, alembic_cfg, postgres_container):
+def test_auto_tables_creation(engine, alembic_cfg, postgres_container, first_course_config):
     with engine.begin() as connection:
         alembic_cfg.attributes["connection"] = connection
         command.downgrade(alembic_cfg, "base")  # Base.metadata.drop_all(engine)
 
     with pytest.raises(ProgrammingError) as exc_info:
-        DataBaseApi(
+        db_api = DataBaseApi(
             DatabaseConfig(
                 database_url=postgres_container.get_connection_url(),
-                course_name="Test Course",
                 gitlab_instance_host="gitlab.test.com",
-                registration_secret="secret",
-                token="test_token",
-                show_allscores=True,
-                gitlab_course_group="test_course_group",
-                gitlab_course_public_repo="test_course_public_repo",
-                gitlab_course_students_group="test_course_students_group",
-                gitlab_default_branch="test_default_branch",
+                apply_migrations=False,
             )
         )
 
+        with Session(engine) as session:
+            test_not_initialized_course(session, db_api, first_course_config)
+
     assert isinstance(exc_info.value.orig, UndefinedTable)
 
-    db_api = DataBaseApi(first_db_config(postgres_container.get_connection_url()))
+    db_api = DataBaseApi(db_config(postgres_container.get_connection_url()))  # apply_migrations=True
 
     with Session(engine) as session:
-        test_empty_course(db_api, session)
+        test_not_initialized_course(session, db_api, first_course_config)
 
 
-def test_auto_database_migration(engine, alembic_cfg, postgres_container):
+def test_auto_database_migration(engine, alembic_cfg, postgres_container, first_course_config):
     script = ScriptDirectory.from_config(alembic_cfg)
     revisions = list(script.walk_revisions("base", "head"))
     revisions.reverse()
@@ -738,20 +821,22 @@ def test_auto_database_migration(engine, alembic_cfg, postgres_container):
             command.downgrade(alembic_cfg, "base")
             command.upgrade(alembic_cfg, revision.revision)
 
-            db_api = DataBaseApi(first_db_config(postgres_container.get_connection_url()))
+            db_api = DataBaseApi(db_config(postgres_container.get_connection_url()))
 
             with Session(engine) as session:
-                test_empty_course(db_api, session)
+                test_not_initialized_course(session, db_api, first_course_config)
 
 
-def test_store_score_integrity_error(first_course_with_deadlines, session):
+def test_store_score_integrity_error(db_api_with_two_initialized_courses, session):
     student = Student(0, "user1", "username1")
 
     user = User(username=student.username, gitlab_instance_host="gitlab.test.com")
     session.add(user)
     session.commit()
 
-    score = first_course_with_deadlines.store_score(student, "repo1", "task_0_0", update_func(1))
+    score = db_api_with_two_initialized_courses.store_score(
+        FIRST_COURSE_NAME, student, "repo1", "task_0_0", update_func(1)
+    )
     assert score == 1
 
     assert session.query(User).count() == 1
@@ -759,75 +844,62 @@ def test_store_score_integrity_error(first_course_with_deadlines, session):
     assert session.query(Grade).count() == 1
 
 
-def test_store_score_update_error(first_course_with_deadlines, session):
+def test_store_score_update_error(db_api_with_two_initialized_courses, session):
     student = Student(0, "user1", "username1")
 
     def failing_update(_, score):
         raise ValueError("Update failed")
 
     with pytest.raises(ValueError) as exc_info:
-        first_course_with_deadlines.store_score(student, "repo1", "task_0_0", failing_update)
+        db_api_with_two_initialized_courses.store_score(FIRST_COURSE_NAME, student, "repo1", "task_0_0", failing_update)
     assert "Update failed" in str(exc_info.value)
 
     assert session.query(Grade).count() == 0
 
 
-def test_get_course_success(first_course_db_api):
-    course = first_course_db_api.get_course(first_db_config("").course_name)
-    assert (
-        course.__dict__
-        == ManytaskCourse(
-            CourseConfig(
-                course_name="Test Course",
-                gitlab_course_group="test_course_group",
-                gitlab_course_public_repo="test_course_public_repo",
-                gitlab_course_students_group="test_course_students_group",
-                gitlab_default_branch="test_default_branch",
-                registration_secret="secret",
-                token="test_token",
-                show_allscores=True,
-                is_ready=False,
-                task_url_template="",
-                links={},
-            )
-        ).__dict__
-    )
+def test_get_course_success(db_api_with_two_initialized_courses, first_course_config, second_course_config):
+    first_course_config.is_ready = True
+    course = db_api_with_two_initialized_courses.get_course(FIRST_COURSE_NAME)
+    assert course.__dict__ == ManytaskCourse(first_course_config).__dict__
+
+    second_course_config.is_ready = True
+    course = db_api_with_two_initialized_courses.get_course(SECOND_COURSE_NAME)
+    assert course.__dict__ == ManytaskCourse(second_course_config).__dict__
 
 
-def test_get_course_unknown(first_course_db_api):
-    course = first_course_db_api.get_course("Unknown course")
+def test_get_course_unknown(db_api_with_two_initialized_courses):
+    course = db_api_with_two_initialized_courses.get_course("Unknown course")
     assert course is None
 
 
-def test_apply_migrations_exceptions(first_course_db_api, postgres_container):
+def test_apply_migrations_exceptions(db_api_with_two_initialized_courses, postgres_container):
     with patch.object(command, "upgrade", side_effect=TestException()):
         with pytest.raises(TestException):
-            first_course_db_api._apply_migrations(postgres_container.get_connection_url())
+            db_api_with_two_initialized_courses._apply_migrations(postgres_container.get_connection_url())
 
     with patch.object(command, "upgrade", side_effect=IntegrityError(None, None, TestException())):
         with pytest.raises(IntegrityError) as exc_info:
-            first_course_db_api._apply_migrations(postgres_container.get_connection_url())
+            db_api_with_two_initialized_courses._apply_migrations(postgres_container.get_connection_url())
 
         assert isinstance(exc_info.value.orig, TestException)
 
     with patch.object(command, "upgrade", side_effect=IntegrityError(None, None, UniqueViolation())):
-        first_course_db_api._apply_migrations(postgres_container.get_connection_url())
+        db_api_with_two_initialized_courses._apply_migrations(postgres_container.get_connection_url())
 
     with patch.object(command, "upgrade", side_effect=ProgrammingError(None, None, TestException())):
         with pytest.raises(ProgrammingError) as exc_info:
-            first_course_db_api._apply_migrations(postgres_container.get_connection_url())
+            db_api_with_two_initialized_courses._apply_migrations(postgres_container.get_connection_url())
 
         assert isinstance(exc_info.value.orig, TestException)
 
     with patch.object(command, "upgrade", side_effect=ProgrammingError(None, None, DuplicateColumn())):
-        first_course_db_api._apply_migrations(postgres_container.get_connection_url())
+        db_api_with_two_initialized_courses._apply_migrations(postgres_container.get_connection_url())
 
     with patch.object(command, "upgrade", side_effect=DuplicateTable()):
-        first_course_db_api._apply_migrations(postgres_container.get_connection_url())
+        db_api_with_two_initialized_courses._apply_migrations(postgres_container.get_connection_url())
 
 
-def test_sync_and_get_admin_status_admin_update(first_course_db_api, session):
-    course_name = "Test Course"
+def test_sync_and_get_admin_status_admin_update(db_api_with_two_initialized_courses, session):
     student = Student(id=1, username="user1", name="username1")
     user = User(id=1, username="user1", gitlab_instance_host="gitlab.test.com")
     user_on_course = UserOnCourse(user_id=user.id, course_id=1, repo_name="repo1", is_course_admin=False)
@@ -836,14 +908,13 @@ def test_sync_and_get_admin_status_admin_update(first_course_db_api, session):
     session.add(user_on_course)
     session.commit()
 
-    first_course_db_api.sync_and_get_admin_status(course_name, student, True)
+    db_api_with_two_initialized_courses.sync_and_get_admin_status(FIRST_COURSE_NAME, student, True)
 
     updated_user_on_course = session.query(UserOnCourse).filter_by(user_id=user.id, course_id=1).one()
     assert updated_user_on_course.is_course_admin
 
 
-def test_sync_and_get_admin_status_admin_no_update(first_course_db_api, session):
-    course_name = "Test Course"
+def test_sync_and_get_admin_status_admin_no_update(db_api_with_two_initialized_courses, session):
     student = Student(id=1, username="user1", name="username1")
 
     user = User(id=1, username="user1", gitlab_instance_host="gitlab.test.com")
@@ -853,14 +924,13 @@ def test_sync_and_get_admin_status_admin_no_update(first_course_db_api, session)
     session.add(user_on_course)
     session.commit()
 
-    first_course_db_api.sync_and_get_admin_status(course_name, student, False)
+    db_api_with_two_initialized_courses.sync_and_get_admin_status(FIRST_COURSE_NAME, student, False)
 
     updated_user_on_course = session.query(UserOnCourse).filter_by(user_id=user.id, course_id=1).one()
     assert updated_user_on_course.is_course_admin
 
 
-def test_check_user_on_course(first_course_db_api, session):
-    course_name = "Test Course"
+def test_check_user_on_course(db_api_with_two_initialized_courses, session):
     student = Student(id=1, username="user1", name="username1")
 
     user = User(id=1, username="user1", gitlab_instance_host="gitlab.test.com")
@@ -870,27 +940,25 @@ def test_check_user_on_course(first_course_db_api, session):
     session.add(user_on_course)
     session.commit()
 
-    assert first_course_db_api.check_user_on_course(course_name, student)
+    assert db_api_with_two_initialized_courses.check_user_on_course(FIRST_COURSE_NAME, student)
 
 
-def test_create_user_if_not_exist_existing(first_course_db_api, session):
-    course_name = "Test Course"
+def test_create_user_if_not_exist_existing(db_api_with_two_initialized_courses, session):
     student = Student(id=2, username="user1", name="username1")
     user = User(id=1, username="user1", gitlab_instance_host="gitlab.test.com")
     session.add(user)
     session.commit()
 
     assert session.query(User).filter_by(username="user1").one().id == user.id
-    first_course_db_api.create_user_if_not_exist(student, course_name)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student, FIRST_COURSE_NAME)
     assert session.query(User).filter_by(username="user1").one().id == user.id
 
 
-def test_create_user_if_not_exist_nonexisting(first_course_db_api, session):
-    course_name = "Test Course"
+def test_create_user_if_not_exist_nonexisting(db_api_with_two_initialized_courses, session):
     student = Student(id=1, username="user1", name="username1")
 
     assert session.query(User).filter_by(username="user1").one_or_none() is None
-    first_course_db_api.create_user_if_not_exist(student, course_name)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student, FIRST_COURSE_NAME)
     assert session.query(User).filter_by(username="user1").one().id == student.id
 
 
@@ -911,7 +979,8 @@ def change_timedelta_to_datetime(group: ManytaskGroupConfig) -> ManytaskGroupCon
 
 
 def check_find_task(
-    course_with_deadlines,
+    db_api,
+    course_name,
     course_deadlines_config,
 ):
     for group in course_deadlines_config.groups:
@@ -920,16 +989,16 @@ def check_find_task(
         for task in group.tasks:
             if not task.enabled:
                 with pytest.raises(TaskDisabledError) as e:
-                    course_with_deadlines.find_task(task.name)
+                    db_api.find_task(course_name, task.name)
                 assert str(e.value) == f"Task {task.name} is disabled"
                 continue
             if not group.enabled:
                 with pytest.raises(TaskDisabledError) as e:
-                    course_with_deadlines.find_task(task.name)
+                    db_api.find_task(course_name, task.name)
                 assert str(e.value) == f"Task {task.name} group {group.name} is disabled"
                 continue
 
-            found_group, found_task = course_with_deadlines.find_task(task.name)
+            found_group, found_task = db_api.find_task(course_name, task.name)
 
             assert found_group == group
             assert found_task == task
@@ -937,24 +1006,24 @@ def check_find_task(
 
 @pytest.mark.parametrize("course_number", [1, 2])
 def test_find_task(
-    first_course_with_deadlines,
-    second_course_with_deadlines,
+    db_api_with_two_initialized_courses,
     first_course_deadlines_config,
     second_course_deadlines_config,
     course_number,
 ):
-    course_with_deadlines = (first_course_with_deadlines, second_course_with_deadlines)[course_number - 1]
+    course_name = (FIRST_COURSE_NAME, SECOND_COURSE_NAME)[course_number - 1]
     course_deadlines_config = (first_course_deadlines_config, second_course_deadlines_config)[course_number - 1]
 
-    check_find_task(course_with_deadlines, course_deadlines_config)
+    check_find_task(db_api_with_two_initialized_courses, course_name, course_deadlines_config)
 
 
 @pytest.mark.parametrize("config_number", [1, 2, 3])
 def test_find_task_with_resync(
-    first_course_with_deadlines,
+    db_api_with_two_initialized_courses,
     second_course_deadlines_config,
     first_course_deadlines_config_with_changed_order_of_groups,
     first_course_deadlines_config_with_changed_order_of_tasks,
+    first_course_updated_ui_config,
     config_number,
 ):
     course_deadlines_config = (
@@ -963,31 +1032,34 @@ def test_find_task_with_resync(
         first_course_deadlines_config_with_changed_order_of_tasks,
     )[config_number - 1]
 
-    first_course_with_deadlines.sync_columns(course_deadlines_config)
+    update_course(
+        db_api_with_two_initialized_courses, FIRST_COURSE_NAME, first_course_updated_ui_config, course_deadlines_config
+    )
 
-    check_find_task(first_course_with_deadlines, course_deadlines_config)
+    check_find_task(db_api_with_two_initialized_courses, FIRST_COURSE_NAME, course_deadlines_config)
 
 
-def test_find_task_not_found(first_course_with_deadlines, second_course_with_deadlines):
+def test_find_task_not_found(db_api_with_two_initialized_courses):
     task_name = "non-existent_task"
 
     with pytest.raises(KeyError) as e:
-        first_course_with_deadlines.find_task(task_name)
+        db_api_with_two_initialized_courses.find_task(FIRST_COURSE_NAME, task_name)
     assert e.value.args[0] == f"Task {task_name} not found"
 
     with pytest.raises(KeyError) as e:
-        second_course_with_deadlines.find_task(task_name)
+        db_api_with_two_initialized_courses.find_task(SECOND_COURSE_NAME, task_name)
     assert e.value.args[0] == f"Task {task_name} not found"
 
 
 def check_get_groups(
-    course_with_deadlines,
+    db_api,
+    course_name,
     course_deadlines_config,
     enabled,
     started,
     now,
 ):
-    result_groups = course_with_deadlines.get_groups(enabled=enabled, started=started, now=now)
+    result_groups = db_api.get_groups(course_name, enabled=enabled, started=started, now=now)
 
     assert len([group.name for group in result_groups]) == len(set([group.name for group in result_groups]))
 
@@ -1012,8 +1084,7 @@ def check_get_groups(
 @pytest.mark.parametrize("started", [None, True, False])
 @pytest.mark.parametrize("now", [FIXED_CURRENT_TIME, None])
 def test_get_groups(  # noqa: PLR0913
-    first_course_with_deadlines,
-    second_course_with_deadlines,
+    db_api_with_two_initialized_courses,
     first_course_deadlines_config,
     second_course_deadlines_config,
     course_number,
@@ -1021,10 +1092,10 @@ def test_get_groups(  # noqa: PLR0913
     started,
     now,
 ):
-    course_with_deadlines = (first_course_with_deadlines, second_course_with_deadlines)[course_number - 1]
+    course_name = (FIRST_COURSE_NAME, SECOND_COURSE_NAME)[course_number - 1]
     course_deadlines_config = (first_course_deadlines_config, second_course_deadlines_config)[course_number - 1]
 
-    check_get_groups(course_with_deadlines, course_deadlines_config, enabled, started, now)
+    check_get_groups(db_api_with_two_initialized_courses, course_name, course_deadlines_config, enabled, started, now)
 
 
 @pytest.mark.parametrize("config_number", [1, 2, 3])
@@ -1032,10 +1103,11 @@ def test_get_groups(  # noqa: PLR0913
 @pytest.mark.parametrize("started", [None, True, False])
 @pytest.mark.parametrize("now", [FIXED_CURRENT_TIME, None])
 def test_get_groups_with_resync(  # noqa: PLR0913
-    first_course_with_deadlines,
+    db_api_with_two_initialized_courses,
     second_course_deadlines_config,
     first_course_deadlines_config_with_changed_order_of_groups,
     first_course_deadlines_config_with_changed_order_of_tasks,
+    first_course_updated_ui_config,
     config_number,
     enabled,
     started,
@@ -1047,6 +1119,10 @@ def test_get_groups_with_resync(  # noqa: PLR0913
         first_course_deadlines_config_with_changed_order_of_tasks,
     )[config_number - 1]
 
-    first_course_with_deadlines.sync_columns(course_deadlines_config)
+    update_course(
+        db_api_with_two_initialized_courses, FIRST_COURSE_NAME, first_course_updated_ui_config, course_deadlines_config
+    )
 
-    check_get_groups(first_course_with_deadlines, course_deadlines_config, enabled, started, now)
+    check_get_groups(
+        db_api_with_two_initialized_courses, FIRST_COURSE_NAME, course_deadlines_config, enabled, started, now
+    )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -11,6 +11,7 @@ from authlib.integrations.base_client import OAuthError
 from flask import Flask, url_for
 
 from manytask.abstract import StoredUser
+from manytask.api import bp as api_bp
 from manytask.database import TaskDisabledError
 from manytask.glab import Student, User
 from manytask.web import course_bp, root_bp
@@ -41,6 +42,7 @@ def app(mock_gitlab_api, mock_storage_api):
     app.secret_key = "test_key"
     app.register_blueprint(root_bp)
     app.register_blueprint(course_bp)
+    app.register_blueprint(api_bp)
     app.gitlab_api = mock_gitlab_api
     app.storage_api = mock_storage_api
     app.manytask_version = "1.0.0"
@@ -105,26 +107,26 @@ def mock_storage_api(mock_course):  # noqa: C901
             self.course_name = TEST_COURSE_NAME
 
         @staticmethod
-        def get_scores_update_timestamp():
+        def get_scores_update_timestamp(_course_name):
             return datetime.now(tz=ZoneInfo("UTC"))
 
         @staticmethod
-        def get_scores(_username):
+        def get_scores(_course_name, _username):
             return {"task1": 100, "task2": 90}
 
         @staticmethod
-        def get_all_scores():
+        def get_all_scores(_course_name):
             return {TEST_USERNAME: {"task1": 100, "task2": 90}}
 
         @staticmethod
-        def get_stats():
+        def get_stats(_course_name):
             return {"task1": {"mean": 95}, "task2": {"mean": 85}}
 
         @staticmethod
-        def get_bonus_score(_username):
+        def get_bonus_score(_course_name, _username):
             return 10
 
-        def sync_stored_user(self, student, repo_name, course_admin):
+        def sync_stored_user(self, _course_name, student, repo_name, course_admin):
             self.stored_user.course_admin = self.stored_user.course_admin or course_admin
 
         @staticmethod
@@ -136,7 +138,7 @@ def mock_storage_api(mock_course):  # noqa: C901
             return mock_course
 
         @staticmethod
-        def find_task(task_name):
+        def find_task(_course_name, task_name):
             if task_name == INVALID_TASK_NAME:
                 raise KeyError("Task not found")
             if task_name == TASK_NAME_WITH_DISABLED_TASK_OR_GROUP:
@@ -144,14 +146,14 @@ def mock_storage_api(mock_course):  # noqa: C901
             return None, None
 
         @staticmethod
-        def get_now_with_timezone():
+        def get_now_with_timezone(_course_name):
             return datetime.now(tz=ZoneInfo("UTC"))
 
-        def get_stored_user(self, _student):
+        def get_stored_user(self, _course_name, _student):
             return self.stored_user
 
         @staticmethod
-        def update_cached_scores():
+        def update_cached_scores(_course_name):
             pass
 
         @staticmethod
@@ -162,8 +164,7 @@ def mock_storage_api(mock_course):  # noqa: C901
             self.stored_user.course_admin = self.stored_user.course_admin or course_admin
             return self.stored_user.course_admin
 
-        @property
-        def max_score_started(self):
+        def max_score_started(self, _course_name):
             return 100
 
     return MockStorageApi()
@@ -177,7 +178,6 @@ def mock_course():
             self.is_ready = True
             self.show_allscores = True
             self.registration_secret = TEST_SECRET
-            self.debug = False
             self.gitlab_course_group = "test_group"
             self.gitlab_course_public_repo = "public_2025_spring"
             self.gitlab_course_students_group = "students_2025_spring"


### PR DESCRIPTION
Removed storing course_name from DataBaseApi. Instead, passing course_name as a methods parameter. This removes the link to a single course and makes it possible to use multiple courses through one DataBaseApi.
Also removed course fields from DataBaseApi like registratin_secret etc...
Added method for course creation. It initializes the course and after that you can upload a config with deadlines to this course. We are currently initializing the course at startup, but in the future it will be easy to transfer the creation to the form.
Edited tests.

These are the final changes before moving to many courses