### PR TITLE
feat: add supporting many courses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,8 @@
 FLASK_SECRET_KEY=
 
-# tokens
-REGISTRATION_SECRET=
-MANYTASK_COURSE_TOKEN=
-
 # gitlab
 GITLAB_URL=https://gitlab.manytask.org
 GITLAB_ADMIN_TOKEN=
-GITLAB_COURSE_GROUP=[course-name]
-GITLAB_COURSE_PUBLIC_REPO=[course-name]/public-[year]-[fall/spring]
-GITLAB_COURSE_STUDENTS_GROUP=[course-name]/students-[fall/spring]-[year]
-GITLAB_DEFAULT_BRANCH=main
 GITLAB_CLIENT_ID=
 GITLAB_CLIENT_SECRET=
 

--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -133,3 +133,9 @@ class StorageApi(ABC):
 
     @abstractmethod
     def create_user_if_not_exist(self, student: Student, course_name: str) -> None: ...
+
+    @abstractmethod
+    def get_user_courses_names(self, student: Student) -> list[str]: ...
+
+    @abstractmethod
+    def get_all_courses_names(self) -> list[str]: ...

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -1,5 +1,6 @@
 import logging
 from functools import wraps
+from http import HTTPStatus
 from typing import Any, Callable
 
 from authlib.integrations.flask_client import OAuth
@@ -54,29 +55,29 @@ def handle_course_membership(app: CustomFlask, course: Course, student: Student)
             logger.info(f"No user {student.username} on course {course.course_name} asking secret")
             return False
     except NoResultFound:
-        logger.info(f"Creating User: {student.username} that we already have in gitlab")
-        app.storage_api.create_user_if_not_exist(student, course.course_name)
-        return redirect(url_for("root.login", course_name=course.course_name))
-
+        logger.info(f"User: {student.username} not in the database")
+        return False
     except Exception:
         logger.error("Failed login while working with db", exc_info=True)
-        return redirect(url_for("root.login", course_name=course.course_name))
+        return False
 
 
 def handle_oauth_callback(oauth: OAuth, app: CustomFlask) -> Response:
     """Process oauth2 callback with code for auth, if success set auth session and sync user's data to database"""
+
+    redirect_url = request.args.get("state") or url_for("root.index")
 
     try:
         gitlab_oauth_token = oauth.gitlab.authorize_access_token()
         student = app.gitlab_api.get_authenticated_student(gitlab_oauth_token["access_token"])
     except Exception:
         logger.error("Gitlab authorization failed", exc_info=True)
-        return redirect(url_for("root.login"))
+        return redirect(redirect_url)
 
     session.setdefault("gitlab", {}).update(set_oauth_session(student, gitlab_oauth_token))
     session.permanent = True
 
-    return redirect(url_for("root.login"))
+    return redirect(redirect_url)
 
 
 def get_authenticate_student(oauth: OAuth, app: CustomFlask) -> Student | Response:
@@ -91,7 +92,7 @@ def get_authenticate_student(oauth: OAuth, app: CustomFlask) -> Student | Respon
         logger.error("Failed login in gitlab, redirect to login", exc_info=True)
         session.pop("gitlab", None)
         redirect_uri = url_for("root.login", _external=True)
-        return oauth.gitlab.authorize_redirect(redirect_uri)
+        return oauth.gitlab.authorize_redirect(redirect_uri, state=request.url)
 
 
 def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
@@ -117,7 +118,7 @@ def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
         else:
             logger.info("Redirect to login in Gitlab")
             redirect_uri = url_for("root.login", _external=True)
-            return oauth.gitlab.authorize_redirect(redirect_uri)
+            return oauth.gitlab.authorize_redirect(redirect_uri, state=request.url)
 
         return f(*args, **kwargs)
 
@@ -174,6 +175,26 @@ def requires_course_access(f: Callable[..., Any]) -> Callable[..., Any]:
             app.gitlab_api.get_url_for_repo(student.username, course.gitlab_course_students_group),
             app.gitlab_api.check_is_course_admin(student.id, course.gitlab_course_group),
         )
+
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def requires_admin(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Check user authentication and manytask admin access"""
+
+    @requires_auth
+    @wraps(f)
+    def decorated(*args: Any, **kwargs: Any) -> Any:
+        app: CustomFlask = current_app  # type: ignore
+
+        if app.debug:
+            return f(*args, **kwargs)
+
+        user_id = session["gitlab"]["user_id"]
+        if not app.gitlab_api.check_is_gitlab_admin(user_id):
+            abort(HTTPStatus.FORBIDDEN)
 
         return f(*args, **kwargs)
 

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -673,6 +673,29 @@ class DataBaseApi(StorageApi):
             session.commit()
             session.refresh(user)
 
+    def get_user_courses_names(self, student: Student) -> list[str]:
+        """Get a list of courses names that the user participates in"""
+
+        with Session(self.engine) as session:
+            try:
+                user = self._get(session, models.User, username=student.username)
+            except NoResultFound:
+                return []
+
+            user_on_courses = user.users_on_courses.all()
+
+            result = [user_on_course.course.name for user_on_course in user_on_courses]
+            return result
+
+    def get_all_courses_names(self) -> list[str]:
+        """Get a list of all courses names"""
+
+        with Session(self.engine) as session:
+            courses = session.query(models.Course).all()
+
+            result = [course.name for course in courses]
+            return result
+
     def _check_pending_migrations(self, database_url: str) -> bool:
         alembic_cfg = Config(self.DEFAULT_ALEMBIC_PATH, config_args={"sqlalchemy.url": database_url})
 

--- a/manytask/glab.py
+++ b/manytask/glab.py
@@ -265,6 +265,10 @@ class GitLabApi:
 
         return True
 
+    def check_is_gitlab_admin(self, user_id: int) -> bool:
+        user = self._gitlab.users.get(user_id)
+        return user.is_admin
+
     def _parse_user_to_student(
         self,
         user: dict[str, Any],

--- a/manytask/local_config.py
+++ b/manytask/local_config.py
@@ -6,58 +6,32 @@ from dataclasses import dataclass
 
 @dataclass
 class LocalConfig:
-    # tokens
-    registration_secret: str
-    course_token: str
     # gitlab
     gitlab_url: str
     gitlab_admin_token: str
-    # gitlab course repos
-    gitlab_course_group: str
-    gitlab_course_public_repo: str
-    gitlab_course_students_group: str
-    gitlab_default_branch: str
+
     # gitlab oauth2
     gitlab_client_id: str
     gitlab_client_secret: str
-    # show link to all scores
-    show_allscores: bool
 
     @classmethod
     def from_env(cls) -> LocalConfig:
         return cls(
-            # tokens
-            registration_secret=os.environ["REGISTRATION_SECRET"],
-            course_token=os.environ["MANYTASK_COURSE_TOKEN"],
             # gitlab
             gitlab_url=os.environ.get("GITLAB_URL", "https://gitlab.manytask.org"),
             gitlab_admin_token=os.environ["GITLAB_ADMIN_TOKEN"],
-            # gitlab course repos
-            gitlab_course_group=os.environ["GITLAB_COURSE_GROUP"],
-            gitlab_course_public_repo=os.environ["GITLAB_COURSE_PUBLIC_REPO"],
-            gitlab_course_students_group=os.environ["GITLAB_COURSE_STUDENTS_GROUP"],
-            gitlab_default_branch=os.environ.get("GITLAB_DEFAULT_BRANCH", "main"),
             # gitlab oauth2
             gitlab_client_id=os.environ["GITLAB_CLIENT_ID"],
             gitlab_client_secret=os.environ["GITLAB_CLIENT_SECRET"],
-            # show link to all scores
-            show_allscores=os.environ.get("SHOW_ALLSCORES", "True").lower() in ("true", "1", "yes"),
         )
 
 
 @dataclass
 class DebugLocalConfig(LocalConfig):
-    # tokens
-    registration_secret: str = "registration_secret"
-    course_token: str = "token"
     # gitlab
     gitlab_url: str = "https://gitlab.manytask.org"
     gitlab_admin_token: str = ""
-    # gitlab course repos
-    gitlab_course_group: str = ""
-    gitlab_course_public_repo: str = ""
-    gitlab_course_students_group: str = ""
-    gitlab_default_branch: str = "main"
+
     # gitlab oauth2
     gitlab_client_id: str = ""
     gitlab_client_secret: str = ""
@@ -66,9 +40,7 @@ class DebugLocalConfig(LocalConfig):
 
     @classmethod
     def from_env(cls) -> LocalConfig:
-        return cls(
-            show_allscores=os.environ.get("SHOW_ALLSCORES", "True").lower() in ("true", "1", "yes"),
-        )
+        return cls()
 
 
 @dataclass

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -17,7 +17,6 @@ load_dotenv("../.env")  # take environment variables from .env.
 
 
 class CustomFlask(Flask):
-    course_name: str  # will be removed in next PRs
     oauth: OAuth
     app_config: local_config.LocalConfig  # TODO: check if we need it
     gitlab_api: glab.GitLabApi
@@ -69,15 +68,7 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
     except FileNotFoundError:
         pass
 
-    # create course
-    course_name = os.environ.get("UNIQUE_COURSE_NAME", None)
-    if course_name is None:
-        raise EnvironmentError("Unable to find UNIQUE_COURSE_NAME env")
-    app.course_name = course_name
-
     app.storage_api = _database_storage_setup(app)
-
-    _create_course(app)
 
     # for https support
     _wsgi_app = ProxyFix(app.wsgi_app, x_proto=1)
@@ -89,30 +80,33 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
     app.register_blueprint(api.bp)
     app.register_blueprint(web.root_bp)
     app.register_blueprint(web.course_bp)
+    app.register_blueprint(web.admin_bp)
 
     logger = logging.getLogger(__name__)
 
     # debug updates
     if app.debug:
+        _create_debug_course(app)
+
         with open(".manytask.example.yml", "r") as f:
             debug_manytask_config_data = yaml.load(f, Loader=yaml.SafeLoader)
-        app.store_config(app.course_name, debug_manytask_config_data)
+        app.store_config("python2025", debug_manytask_config_data)
 
     logger.info("Init success")
 
     return app
 
 
-def _create_course(app: CustomFlask) -> None:
+def _create_debug_course(app: CustomFlask) -> None:
     course_config = course.CourseConfig(
-        course_name=app.course_name,
-        gitlab_course_group=app.app_config.gitlab_course_group,
-        gitlab_course_public_repo=app.app_config.gitlab_course_public_repo,
-        gitlab_course_students_group=app.app_config.gitlab_course_students_group,
-        gitlab_default_branch=app.app_config.gitlab_default_branch,
-        registration_secret=app.app_config.registration_secret,
-        token=app.app_config.course_token,
-        show_allscores=app.app_config.show_allscores,
+        course_name="python2025",
+        gitlab_course_group="",
+        gitlab_course_public_repo="",
+        gitlab_course_students_group="",
+        gitlab_default_branch="main",
+        registration_secret="registration_secret",
+        token="token",
+        show_allscores=True,
         is_ready=False,
         task_url_template="",
         links={},

--- a/manytask/templates/courses.html
+++ b/manytask/templates/courses.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<style>
+    .course-list {
+        list-style: none;
+        padding: 0;
+        margin: 20px 0;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+        align-items: flex-start;
+        min-width: 10vw;
+    }
+
+    .course-item {
+        border: 1px solid var(--bs-body-color);
+        border-radius: 5px;
+        padding: 10px 20px;
+        background-color: transparent;
+        transition: background-color 0.3s ease;
+        display: inline-block;
+        width: 100%;
+    }
+    .course-item:hover {
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    .course-item a {
+        text-decoration: none;
+        color: inherit;
+        font-size: 1.2rem;
+        display: block;
+    }
+</style>
+
+<div class="container-fluid d-flex flex-column justify-content-center align-items-center">
+    <h1 class="mt-4 mb-3">Список курсов</h1>
+    <ul class="course-list">
+        {% for course in courses %}
+            <li class="course-item">
+                <a href="{{ course.url }}">{{ course.name }}</a>
+            </li>
+        {% else %}
+            К сожалению, курсов пока нет.
+        {% endfor %}
+    </ul>
+</div>
+
+{% endblock %}

--- a/manytask/templates/create_course.html
+++ b/manytask/templates/create_course.html
@@ -1,0 +1,80 @@
+{% extends "base.html" %}
+
+{% block title %}Create New Course{% endblock %}
+
+{% block body %}
+<div class="container mt-4">
+    <h2>Create New Course</h2>
+    {% if error_message %}
+    <div class="alert alert-danger" role="alert">
+        {{ error_message }}
+    </div>
+    {% endif %}
+
+    <form method="POST" action="{{ url_for('admin.create_course') }}" class="needs-validation" novalidate>
+        <div class="row">
+            <div class="col-md-6 mb-4">
+                <h4>Basic Course Information</h4>
+                <div class="mb-3">
+                    <label for="unique_course_name" class="form-label">Unique Course Name</label>
+                    <input type="text" class="form-control" id="unique_course_name" name="unique_course_name" required>
+                    <div class="form-text">Used to separate data when multiple courses share a database</div>
+                </div>
+                <div class="mb-3">
+                    <label for="registration_secret" class="form-label">Registration Secret</label>
+                    <input type="text" class="form-control" id="registration_secret" name="registration_secret" required>
+                </div>
+                <div class="mb-3">
+                    <label for="token" class="form-label">Course Token</label>
+                    <input type="text" class="form-control" id="token" name="token" value="{% if generated_token %}{{ generated_token }}{% endif %}" required>
+                </div>
+                <div class="mb-3 form-check">
+                    <input type="checkbox" class="form-check-input" id="show_allscores" name="show_allscores">
+                    <label class="form-check-label" for="show_allscores">Show All Scores</label>
+                </div>
+            </div>
+
+            <div class="col-md-6 mb-4">
+                <h4>GitLab Configuration</h4>
+                <div class="mb-3">
+                    <label for="gitlab_course_group" class="form-label">GitLab Course Group</label>
+                    <input type="text" class="form-control" id="gitlab_course_group" name="gitlab_course_group" required>
+                </div>
+                <div class="mb-3">
+                    <label for="gitlab_course_public_repo" class="form-label">GitLab Public Repo</label>
+                    <input type="text" class="form-control" id="gitlab_course_public_repo" name="gitlab_course_public_repo" required>
+                </div>
+                <div class="mb-3">
+                    <label for="gitlab_course_students_group" class="form-label">GitLab Students Group</label>
+                    <input type="text" class="form-control" id="gitlab_course_students_group" name="gitlab_course_students_group" required>
+                </div>
+                <div class="mb-3">
+                    <label for="gitlab_default_branch" class="form-label">GitLab Default Branch</label>
+                    <input type="text" class="form-control" id="gitlab_default_branch" name="gitlab_default_branch" value="main" required>
+                </div>
+            </div>
+        </div>
+
+        <div class="mb-4">
+            <button type="submit" class="btn btn-primary">Create Course</button>
+        </div>
+    </form>
+</div>
+
+<script>
+(function () {
+    'use strict'
+    var forms = document.querySelectorAll('.needs-validation')
+    Array.prototype.slice.call(forms)
+        .forEach(function (form) {
+            form.addEventListener('submit', function (event) {
+                if (!form.checkValidity()) {
+                    event.preventDefault()
+                    event.stopPropagation()
+                }
+                form.classList.add('was-validated')
+            }, false)
+        })
+})()
+</script>
+{% endblock %} 

--- a/manytask/templates/layout.html
+++ b/manytask/templates/layout.html
@@ -55,7 +55,7 @@
             <div class="collapse navbar-collapse ms-2" id="navbar">
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link px-3 {% if active_page == 'tasks' %}active{% endif %}" aria-current="{% if active_page == 'tasks' %}page{% endif %}" href="/">Assignments</a>
+                        <a class="nav-link px-3 {% if active_page == 'tasks' %}active{% endif %}" aria-current="{% if active_page == 'tasks' %}page{% endif %}" href="{{ url_for('course.course_page', course_name=course_name) }}">Assignments</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link px-3" target="_blank" href="{{ student_repo_url }}">My&nbsp;Repo</a>

--- a/manytask/templates/signup.html
+++ b/manytask/templates/signup.html
@@ -4,7 +4,7 @@
 
     <div class="d-flex align-items-center justify-content-center bg-body-tertiary container-fluid p-3">
         <div class="d-flex flex-column align-items-center justify-content-center form-signin px-4 py-4 rounded m-auto container-sm" style="background-color: var(--bs-body-bg); max-width: 400px;">
-            <a href="{{ url_for('root.login') }}" class="btn btn-primary p-3">
+            <a href="{{ url_for('course.create_project', course_name=course_name) }}" class="btn btn-primary p-3">
                 <span class="fs-2">Login</span>
                 <br>
                 with {{ base_url }}

--- a/manytask/utils.py
+++ b/manytask/utils.py
@@ -1,0 +1,5 @@
+import secrets
+
+
+def generate_token_hex(bytes_count: int = 24) -> str:
+    return secrets.token_hex(nbytes=bytes_count)

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -8,10 +8,11 @@ from flask import Blueprint, current_app, redirect, render_template, request, se
 from flask.typing import ResponseReturnValue
 
 from . import glab
-from .auth import requires_auth, requires_course_access, requires_ready
-from .course import Course, get_current_time
+from .auth import requires_admin, requires_auth, requires_course_access, requires_ready
+from .course import Course, CourseConfig, get_current_time
 from .database_utils import get_database_table_data
 from .main import CustomFlask
+from .utils import generate_token_hex
 
 SESSION_VERSION = 1.5
 
@@ -19,6 +20,7 @@ SESSION_VERSION = 1.5
 logger = logging.getLogger(__name__)
 root_bp = Blueprint("root", __name__)
 course_bp = Blueprint("course", __name__, url_prefix="/<course_name>")
+admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
 @root_bp.get("/healthcheck")
@@ -27,10 +29,33 @@ def healthcheck() -> ResponseReturnValue:
 
 
 @root_bp.route("/", methods=["GET"])
+@requires_auth
 def index() -> ResponseReturnValue:
     app: CustomFlask = current_app  # type: ignore
 
-    return redirect(url_for("course.course_page", course_name=app.course_name))
+    if app.debug:
+        courses_names = app.storage_api.get_all_courses_names()
+
+    else:
+        student_id = session["gitlab"]["user_id"]
+        student = app.gitlab_api.get_student(student_id)
+
+        courses_names = app.storage_api.get_user_courses_names(student)
+
+    courses = [
+        {
+            "name": course_name,
+            "url": url_for("course.course_page", course_name=course_name),
+        }
+        for course_name in courses_names
+    ]
+
+    return render_template(
+        "courses.html",
+        course_favicon=app.favicon,
+        manytask_version=app.manytask_version,
+        courses=courses,
+    )
 
 
 @root_bp.route("/login", methods=["GET", "POST"])
@@ -41,10 +66,8 @@ def login() -> ResponseReturnValue:
 
 @root_bp.route("/logout")
 def logout() -> ResponseReturnValue:
-    app: CustomFlask = current_app  # type: ignore
-
     session.pop("gitlab", None)
-    return redirect(url_for("course.signup", course_name=app.course_name))
+    return redirect(url_for("root.index"))
 
 
 @course_bp.route("/", methods=["GET", "POST"])
@@ -168,7 +191,7 @@ def signup(course_name: str) -> ResponseReturnValue:
             base_url=app.gitlab_api.base_url,
         )
 
-    return redirect(url_for("root.login"))
+    return redirect(url_for("course.create_project", course_name=course.course_name))
 
 
 @course_bp.route("/create_project", methods=["GET", "POST"])
@@ -197,6 +220,14 @@ def create_project(course_name: str) -> ResponseReturnValue:
 
     gitlab_access_token: str = session["gitlab"]["access_token"]
     student = app.gitlab_api.get_authenticated_student(gitlab_access_token)
+    app.storage_api.create_user_if_not_exist(student, course.course_name)
+
+    app.storage_api.sync_stored_user(
+        course.course_name,
+        student,
+        app.gitlab_api.get_url_for_repo(student.username, course.gitlab_course_students_group),
+        app.gitlab_api.check_is_course_admin(student.id, course.gitlab_course_group),
+    )
 
     # Create use if needed
     try:
@@ -222,6 +253,7 @@ def not_ready(course_name: str) -> ResponseReturnValue:
 
     return render_template(
         "not_ready.html",
+        course_name=course.course_name,
         manytask_version=app.manytask_version,
     )
 
@@ -277,4 +309,39 @@ def show_database(course_name: str) -> ResponseReturnValue:
         show_allscores=course.show_allscores,
         student_repo_url=student_repo,
         student_ci_url=f"{student_repo}/pipelines",
+    )
+
+
+@admin_bp.route("/courses/new", methods=["GET", "POST"])
+@requires_admin
+def create_course() -> ResponseReturnValue:
+    app: CustomFlask = current_app  # type: ignore
+
+    if request.method == "POST":
+        settings = CourseConfig(
+            course_name=request.form["unique_course_name"],
+            gitlab_course_group=request.form["gitlab_course_group"],
+            gitlab_course_public_repo=request.form["gitlab_course_public_repo"],
+            gitlab_course_students_group=request.form["gitlab_course_students_group"],
+            gitlab_default_branch=request.form["gitlab_default_branch"],
+            registration_secret=request.form["registration_secret"],
+            token=request.form["token"],
+            show_allscores=request.form.get("show_allscores", "off") == "on",
+            is_ready=False,
+            task_url_template="",
+            links={},
+        )
+
+        if app.storage_api.create_course(settings):
+            return redirect(url_for("course.course_page", course_name=settings.course_name))
+
+        return render_template(
+            "create_course.html",
+            generated_token=generate_token_hex(24),
+            error_message=f"Курс с названием {settings.course_name} уже существует",
+        )
+
+    return render_template(
+        "create_course.html",
+        generated_token=generate_token_hex(24),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,9 +93,9 @@ def mock_gitlab_oauth():
                 return {"access_token": "", "refresh_token": ""}
 
             @staticmethod
-            def authorize_redirect(redirect_uri: str):
+            def authorize_redirect(redirect_uri: str, state: str | None = None):
                 resp = Response(status=302)
-                resp.location = url_for("root.login")
+                resp.location = state or url_for("root.index")
                 return resp
 
     return MockGitlabOauth()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ INVALID_TASK_NAME = "invalid_task"
 TASK_NAME_WITH_DISABLED_TASK_OR_GROUP = "disabled_task"
 TEST_TASK_NAME = "test_task"
 TEST_SECRET_KEY = "test_key"
-TEST_COURSE_NAME = "Test Course"
+TEST_COURSE_NAME = "Test_Course"
 
 
 @pytest.fixture(autouse=True)
@@ -42,7 +42,6 @@ def app(mock_storage_api, mock_gitlab_api):
     app = Flask(__name__)
     app.config["DEBUG"] = False
     app.config["TESTING"] = True
-    app.course_name = TEST_COURSE_NAME
     app.secret_key = TEST_SECRET_KEY
     app.register_blueprint(root_bp)
     app.register_blueprint(course_bp)
@@ -373,7 +372,7 @@ def test_update_database_unauthorized(app, mock_gitlab_oauth):
     response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/database/update", json=test_data)
     # Signup
     assert response.status_code == HTTPStatus.FOUND
-    assert response.location == "/login"
+    assert response.location == f"http://localhost/api/{TEST_COURSE_NAME}/database/update"
 
 
 def test_update_database_not_ready(app, authenticated_client):
@@ -581,7 +580,6 @@ def test_no_course_in_db(app):
     """Test the decorator when no course information is present in the database, leading to an abort."""
 
     app.storage_api = MagicMock(DataBaseApi)
-    app.course_name = "NoSuchCourse"
     app.storage_api.get_course.return_value = None
     headers = {"Authorization": f"Bearer {os.environ['MANYTASK_COURSE_TOKEN']}"}
     client = app.test_client()

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -21,7 +21,6 @@ SCORES = {STUDENT_1: {TASK_1: 100, TASK_2: 90, "total": 190}, STUDENT_2: {TASK_1
 @pytest.fixture
 def app():
     app = Flask(__name__)
-    app.course_name = "test_course"
 
     class MockStorageApi:
         class MockGroup:
@@ -87,7 +86,7 @@ def test_get_database_table_data(app):
     expected_students_count = 2
 
     with app.test_request_context():
-        result = get_database_table_data(app, app.course_name)
+        result = get_database_table_data(app, "test_course")
 
         assert "tasks" in result
         assert "students" in result
@@ -114,7 +113,7 @@ def test_get_database_table_data_no_scores(app):
 
     with app.test_request_context():
         app.storage_api.get_all_scores = lambda _course_name: {}
-        result = get_database_table_data(app, app.course_name)
+        result = get_database_table_data(app, "test_course")
 
         assert "tasks" in result
         assert "students" in result

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -112,7 +112,6 @@ def test_create_app_production_with_db(mock_env, mock_gitlab, monkeypatch):
     assert hasattr(app, "oauth")
     assert "gitlab" in app.oauth._clients
 
-    assert hasattr(app, "course_name")
     assert hasattr(app, "storage_api")
     assert hasattr(app, "gitlab_api")
 


### PR DESCRIPTION
Removed course_name from app object. Also removed extra course params from .env.
Added supporting many courses.
Added admin endpoint with creating course.
Added list of courses to main page.
Slightly changed the authentication logic. Added state while gitlab login. This allows you to return to the same page where you was.
Edited tests.

