### PR TITLE
refactor: Do not use Student in storage API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,15 +20,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v4
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
-          
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
         
       - name: Run ruff format

--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -3,7 +3,14 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable
 
-from .config import ManytaskDeadlinesConfig, ManytaskGroupConfig, ManytaskTaskConfig
+from .config import (
+    ManytaskDeadlinesConfig,
+    ManytaskGroupConfig,
+    ManytaskSettingsConfig,
+    ManytaskTaskConfig,
+    ManytaskUiConfig,
+)
+from .course import Course
 from .glab import Student
 
 
@@ -21,32 +28,38 @@ class StorageApi(ABC):
     @abstractmethod
     def get_scores(
         self,
+        course_name: str,
         username: str,
     ) -> dict[str, int]: ...
 
     @abstractmethod
     def get_bonus_score(
         self,
+        course_name: str,
         username: str,
     ) -> int: ...
 
     @abstractmethod
     def get_stored_user(
         self,
+        course_name: str,
         student: Student,
     ) -> StoredUser: ...
 
     @abstractmethod
     def sync_stored_user(
         self,
+        course_name: str,
         student: Student,
+        repo_name: str,
+        course_admin: bool,
     ) -> StoredUser: ...
 
     @abstractmethod
-    def get_all_scores(self) -> dict[str, dict[str, int]]: ...
+    def get_all_scores(self, course_name: str) -> dict[str, dict[str, int]]: ...
 
     @abstractmethod
-    def get_stats(self) -> dict[str, float]: ...
+    def get_stats(self, course_name: str) -> dict[str, float]: ...
 
     @abstractmethod
     def get_scores_update_timestamp(self) -> str: ...
@@ -57,7 +70,9 @@ class StorageApi(ABC):
     @abstractmethod
     def store_score(
         self,
+        course_name: str,
         student: Student,
+        repo_name: str,
         task_name: str,
         update_fn: Callable[..., Any],
     ) -> int: ...
@@ -65,38 +80,62 @@ class StorageApi(ABC):
     @abstractmethod
     def sync_columns(
         self,
+        course_name: str,
         deadlines_config: ManytaskDeadlinesConfig,
     ) -> None: ...
+
+    @abstractmethod
+    def get_course(
+        self,
+        course_name: str,
+    ) -> Course | None: ...
 
     @abstractmethod
     def update_task_groups_from_config(
         self,
+        course_name: str,
         deadlines_config: ManytaskDeadlinesConfig,
     ) -> None: ...
 
     @abstractmethod
-    def find_task(self, task_name: str) -> tuple[ManytaskGroupConfig, ManytaskTaskConfig]: ...
+    def create_course(
+        self,
+        settings_config: ManytaskSettingsConfig,
+    ) -> bool: ...
+
+    @abstractmethod
+    def update_course(
+        self,
+        course_name: str,
+        ui_config: ManytaskUiConfig,
+    ) -> None: ...
+
+    @abstractmethod
+    def find_task(self, course_name: str, task_name: str) -> tuple[ManytaskGroupConfig, ManytaskTaskConfig]: ...
 
     @abstractmethod
     def get_groups(
         self,
+        course_name: str,
         enabled: bool | None = None,
         started: bool | None = None,
         now: datetime | None = None,
     ) -> list[ManytaskGroupConfig]: ...
 
     @abstractmethod
-    def get_now_with_timezone(self) -> datetime: ...
+    def get_now_with_timezone(
+        self,
+        course_name: str,
+    ) -> datetime: ...
 
     @abstractmethod
-    def max_score(self, started: bool | None = True) -> int: ...
-
-    @property
-    @abstractmethod
-    def max_score_started(self) -> int: ...
+    def max_score(self, course_name: str, started: bool | None = True) -> int: ...
 
     @abstractmethod
-    def sync_and_get_admin_status(self, course_name: str, student: Student) -> bool: ...
+    def max_score_started(self, course_name: str) -> int: ...
+
+    @abstractmethod
+    def sync_and_get_admin_status(self, course_name: str, student: Student, course_admin: bool) -> bool: ...
 
     @abstractmethod
     def check_user_on_course(self, course_name: str, student: Student) -> bool: ...

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -291,7 +291,7 @@ def get_score() -> ResponseReturnValue:
             )
         else:
             assert False, "unreachable"
-        student_scores = course.storage_api.get_scores(student.username)
+        student_scores = course.storage_api.get_scores(course.course_name, student.username)
     except Exception:
         return f"There is no student with user_id {user_id} or username {username}", HTTPStatus.NOT_FOUND
 


### PR DESCRIPTION
Student object is ambiguous and used all over with different purpose. This change removes this object from the storage API making it more clear on what is passed there as arguments.