### PR TITLE
refactor: Create get_user_on_course(..) method and use it

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -48,7 +48,7 @@ class StorageApi(ABC):
     def get_stored_user(
         self,
         course_name: str,
-        student: Student,
+        username: str,
     ) -> StoredUser: ...
 
     @abstractmethod
@@ -76,7 +76,7 @@ class StorageApi(ABC):
     def store_score(
         self,
         course_name: str,
-        student: Student,
+        username: str,
         repo_name: str,
         task_name: str,
         update_fn: Callable[..., Any],

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -213,7 +213,7 @@ def report_score(course_name: str) -> ResponseReturnValue:
     )
     final_score = app.storage_api.store_score(
         course.course_name,
-        student,
+        student.username,
         app.rms_api.get_url_for_repo(student.username, course.gitlab_course_students_group),
         task.name,
         update_function,
@@ -349,8 +349,7 @@ def update_database(course_name: str) -> ResponseReturnValue:
 
     storage_api = app.storage_api
 
-    student = app.gitlab_api.get_student(session["gitlab"]["user_id"])
-    stored_user = storage_api.get_stored_user(course.course_name, student)
+    stored_user = storage_api.get_stored_user(course.course_name, session["gitlab"]["username"])
     student_course_admin = stored_user.course_admin
 
     if not student_course_admin:
@@ -379,7 +378,7 @@ def update_database(course_name: str) -> ResponseReturnValue:
             if isinstance(new_score, (int, float)):
                 storage_api.store_score(
                     course.course_name,
-                    student=student,
+                    username == student.username,
                     repo_name=repo_name,
                     task_name=task_name,
                     update_fn=lambda _flags, _old_score: int(new_score),

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -78,9 +78,9 @@ def course_page(course_name: str) -> ResponseReturnValue:
     storage_api = app.storage_api
 
     if app.debug:
-        student_username = "guest"
+        username = "guest"
         student_repo = app.rms_api.get_url_for_repo(
-            username=student_username, course_students_group=course.gitlab_course_students_group
+            username=username, course_students_group=course.gitlab_course_students_group
         )
 
         if request.args.get("admin", None) in ("true", "1", "yes", None):
@@ -88,15 +88,13 @@ def course_page(course_name: str) -> ResponseReturnValue:
         else:
             student_course_admin = False
     else:
-        student_username = session["gitlab"]["username"]
-        student_id = session["gitlab"]["user_id"]
+        username = session["gitlab"]["username"]
 
         student_repo = app.rms_api.get_url_for_repo(
-            username=student_username, course_students_group=course.gitlab_course_students_group
+            username=username, course_students_group=course.gitlab_course_students_group
         )
 
-        student = app.gitlab_api.get_student(user_id=student_id)
-        stored_user = storage_api.get_stored_user(course.course_name, student)
+        stored_user = storage_api.get_stored_user(course.course_name, username)
 
         student_course_admin = stored_user.course_admin
 
@@ -114,7 +112,7 @@ def course_page(course_name: str) -> ResponseReturnValue:
         cache_delta = datetime.now(tz=cache_time.tzinfo) - cache_time
 
     # get scores
-    tasks_scores = storage_api.get_scores(course.course_name, student_username)
+    tasks_scores = storage_api.get_scores(course.course_name, username)
     tasks_stats = storage_api.get_stats(course.course_name)
 
     allscores_url = url_for("course.show_database", course_name=course_name)
@@ -122,7 +120,7 @@ def course_page(course_name: str) -> ResponseReturnValue:
     return render_template(
         "tasks.html",
         task_base_url=app.rms_api.get_url_for_task_base(course.gitlab_course_public_repo, course.gitlab_default_branch),
-        username=student_username,
+        username=username,
         course_name=course.course_name,
         app=app,
         gitlab_url=app.rms_api.base_url,
@@ -134,7 +132,7 @@ def course_page(course_name: str) -> ResponseReturnValue:
         task_url_template=course.task_url_template,
         links=course.links,
         scores=tasks_scores,
-        bonus_score=storage_api.get_bonus_score(course.course_name, student_username),
+        bonus_score=storage_api.get_bonus_score(course.course_name, username),
         now=get_current_time(),
         task_stats=tasks_stats,
         course_favicon=app.favicon,
@@ -262,9 +260,9 @@ def show_database(course_name: str) -> ResponseReturnValue:
     storage_api = app.storage_api
 
     if app.debug:
-        student_username = "guest"
+        username = "guest"
         student_repo = app.rms_api.get_url_for_repo(
-            username=student_username, course_students_group=course.gitlab_course_students_group
+            username=username, course_students_group=course.gitlab_course_students_group
         )
 
         if request.args.get("admin", None) in ("true", "1", "yes", None):
@@ -272,20 +270,18 @@ def show_database(course_name: str) -> ResponseReturnValue:
         else:
             student_course_admin = False
     else:
-        student_username = session["gitlab"]["username"]
-        student_id = session["gitlab"]["user_id"]
+        username = session["gitlab"]["username"]
 
         student_repo = app.rms_api.get_url_for_repo(
-            username=student_username, course_students_group=course.gitlab_course_students_group
+            username=username, course_students_group=course.gitlab_course_students_group
         )
 
-        student = app.gitlab_api.get_student(user_id=student_id)
-        stored_user = storage_api.get_stored_user(course.course_name, student)
+        stored_user = storage_api.get_stored_user(course.course_name, username)
 
         student_course_admin = stored_user.course_admin
 
-    scores = storage_api.get_scores(course.course_name, student_username)
-    bonus_score = storage_api.get_bonus_score(course.course_name, student_username)
+    scores = storage_api.get_scores(course.course_name, username)
+    bonus_score = storage_api.get_bonus_score(course.course_name, username)
     table_data = get_database_table_data(app, course.course_name)
 
     return render_template(
@@ -294,7 +290,7 @@ def show_database(course_name: str) -> ResponseReturnValue:
         course_name=course.course_name,
         scores=scores,
         bonus_score=bonus_score,
-        username=student_username,
+        username=username,
         is_course_admin=student_course_admin,
         app=app,
         course_favicon=app.favicon,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -110,10 +110,10 @@ def mock_storage_api(mock_course, mock_student, mock_task, mock_group):  # noqa:
             )
             self.course_name = TEST_COURSE_NAME
 
-        def store_score(self, _course_name, student, repo_name, task_name, update_fn):
-            old_score = self.scores.get(f"{student.username}_{task_name}", 0)
+        def store_score(self, _course_name, username, repo_name, task_name, update_fn):
+            old_score = self.scores.get(f"{username}_{task_name}", 0)
             new_score = update_fn("", old_score)
-            self.scores[f"{student.username}_{task_name}"] = new_score
+            self.scores[f"{username}_{task_name}"] = new_score
             return new_score
 
         @staticmethod
@@ -128,11 +128,12 @@ def mock_storage_api(mock_course, mock_student, mock_task, mock_group):  # noqa:
             return {"test_user": self.get_scores(course_name, "test_user")}
 
         @staticmethod
-        def get_stored_user(_course_name, student):
+        def get_stored_user(_course_name, username):
             from manytask.abstract import StoredUser
 
-            first_name, last_name = student.name.split()
-            return StoredUser(username=student.username, first_name=first_name, last_name=last_name, course_admin=True)
+            return StoredUser(
+                username=username, first_name=TEST_FIRST_NAME, last_name=TEST_LAST_NAME, course_admin=True
+            )
 
         def update_cached_scores(self, _course_name):
             pass

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -119,7 +119,7 @@ def mock_storage_api(mock_course):  # noqa: C901
         def get_course(_name):
             return mock_course
 
-        def get_stored_user(self, _student):
+        def get_stored_user(self, _username):
             return self.stored_user
 
         def sync_and_get_admin_status(self, course_name: str, student: Student, course_admin: bool) -> bool:

--- a/tests/test_db_api.py
+++ b/tests/test_db_api.py
@@ -25,7 +25,11 @@ TEST_LAST_NAME = "Last"
 TEST_REPO_NAME = "repo1"
 
 TEST_USERNAME_1 = "user1"
+TEST_FIRST_NAME_1 = "First"
+TEST_LAST_NAME_1 = "Last"
 TEST_USERNAME_2 = "user2"
+TEST_FIRST_NAME_2 = "Second"
+TEST_LAST_NAME_2 = "SecondToLast"
 
 DEADLINES_CONFIG_FILES = [  # part of manytask config file
     "tests/.deadlines.test.yml",
@@ -459,6 +463,9 @@ def test_store_score(db_api_with_initialized_first_course, session):
     assert session.query(User).count() == 0
     assert session.query(UserOnCourse).count() == 0
 
+    student = Student(id=2, username=TEST_USERNAME, name=f"{TEST_FIRST_NAME} {TEST_LAST_NAME}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student, FIRST_COURSE_NAME)
+
     assert (
         db_api_with_initialized_first_course.store_score(
             FIRST_COURSE_NAME, TEST_USERNAME, TEST_REPO_NAME, "not_exist_task", update_func(1)
@@ -512,6 +519,9 @@ def test_store_score(db_api_with_initialized_first_course, session):
 def test_store_score_bonus_task(db_api_with_initialized_first_course, session):
     expected_score = 22
 
+    student = Student(id=2, username=TEST_USERNAME, name=f"{TEST_FIRST_NAME} {TEST_LAST_NAME}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student, FIRST_COURSE_NAME)
+
     assert (
         db_api_with_initialized_first_course.store_score(
             FIRST_COURSE_NAME, TEST_USERNAME, "repo1", "task_1_3", update_func(expected_score)
@@ -549,6 +559,9 @@ def test_store_score_with_changed_task_name(
     first_course_updated_ui_config,
 ):
     create_course(db_api, first_course_config, first_course_deadlines_config)
+
+    student = Student(id=2, username=TEST_USERNAME, name=f"{TEST_FIRST_NAME} {TEST_LAST_NAME}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student, FIRST_COURSE_NAME)
 
     db_api.store_score(FIRST_COURSE_NAME, TEST_USERNAME, "repo1", "task_0_0", update_func(10))
 
@@ -614,9 +627,15 @@ def test_many_users(db_api_with_initialized_first_course, session):
     expected_grades = 3
     expected_stats_ratio = 0.5
 
+    student1 = Student(id=2, username=TEST_USERNAME_1, name=f"{TEST_FIRST_NAME_1} {TEST_LAST_NAME_1}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student1, FIRST_COURSE_NAME)
+
     db_api_with_initialized_first_course.store_score(
         FIRST_COURSE_NAME, TEST_USERNAME_1, "repo1", "task_0_0", update_func(1)
     )
+
+    student2 = Student(id=3, username=TEST_USERNAME_2, name=f"{TEST_FIRST_NAME_2} {TEST_LAST_NAME_2}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student2, FIRST_COURSE_NAME)
     db_api_with_initialized_first_course.store_score(
         FIRST_COURSE_NAME, TEST_USERNAME_1, "repo1", "task_1_3", update_func(expected_score_1)
     )
@@ -655,6 +674,10 @@ def test_many_users(db_api_with_initialized_first_course, session):
 
 
 def test_many_courses(db_api_with_two_initialized_courses, session):
+    student = Student(id=2, username=TEST_USERNAME, name=f"{TEST_FIRST_NAME} {TEST_LAST_NAME}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student, FIRST_COURSE_NAME)
+    db_api_with_initialized_first_course.create_user_if_not_exist(student, SECOND_COURSE_NAME)
+
     db_api_with_two_initialized_courses.store_score(
         FIRST_COURSE_NAME, TEST_USERNAME, "repo1", "task_0_0", update_func(30)
     )
@@ -704,6 +727,14 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     expected_user_on_course = 4
     expected_grades = 5
     expected_stats_ratio = 0.5
+
+    student1 = Student(id=1, username=TEST_USERNAME_1, name=f"{TEST_FIRST_NAME_1} {TEST_LAST_NAME_1}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student1, FIRST_COURSE_NAME)
+    db_api_with_initialized_first_course.create_user_if_not_exist(student1, SECOND_COURSE_NAME)
+
+    student2 = Student(id=2, username=TEST_USERNAME_2, name=f"{TEST_FIRST_NAME_2} {TEST_LAST_NAME_2}")
+    db_api_with_initialized_first_course.create_user_if_not_exist(student2, FIRST_COURSE_NAME)
+    db_api_with_initialized_first_course.create_user_if_not_exist(student2, SECOND_COURSE_NAME)
 
     db_api_with_two_initialized_courses.store_score(
         FIRST_COURSE_NAME, TEST_USERNAME_1, "repo1", "task_0_0", update_func(1)

--- a/tests/test_db_api.py
+++ b/tests/test_db_api.py
@@ -561,7 +561,7 @@ def test_store_score_with_changed_task_name(
     create_course(db_api, first_course_config, first_course_deadlines_config)
 
     student = Student(id=2, username=TEST_USERNAME, name=f"{TEST_FIRST_NAME} {TEST_LAST_NAME}")
-    db_api_with_initialized_first_course.create_user_if_not_exist(student, FIRST_COURSE_NAME)
+    db_api.create_user_if_not_exist(student, FIRST_COURSE_NAME)
 
     db_api.store_score(FIRST_COURSE_NAME, TEST_USERNAME, "repo1", "task_0_0", update_func(10))
 
@@ -675,8 +675,8 @@ def test_many_users(db_api_with_initialized_first_course, session):
 
 def test_many_courses(db_api_with_two_initialized_courses, session):
     student = Student(id=2, username=TEST_USERNAME, name=f"{TEST_FIRST_NAME} {TEST_LAST_NAME}")
-    db_api_with_initialized_first_course.create_user_if_not_exist(student, FIRST_COURSE_NAME)
-    db_api_with_initialized_first_course.create_user_if_not_exist(student, SECOND_COURSE_NAME)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student, FIRST_COURSE_NAME)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student, SECOND_COURSE_NAME)
 
     db_api_with_two_initialized_courses.store_score(
         FIRST_COURSE_NAME, TEST_USERNAME, "repo1", "task_0_0", update_func(30)
@@ -729,12 +729,12 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     expected_stats_ratio = 0.5
 
     student1 = Student(id=1, username=TEST_USERNAME_1, name=f"{TEST_FIRST_NAME_1} {TEST_LAST_NAME_1}")
-    db_api_with_initialized_first_course.create_user_if_not_exist(student1, FIRST_COURSE_NAME)
-    db_api_with_initialized_first_course.create_user_if_not_exist(student1, SECOND_COURSE_NAME)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student1, FIRST_COURSE_NAME)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student1, SECOND_COURSE_NAME)
 
     student2 = Student(id=2, username=TEST_USERNAME_2, name=f"{TEST_FIRST_NAME_2} {TEST_LAST_NAME_2}")
-    db_api_with_initialized_first_course.create_user_if_not_exist(student2, FIRST_COURSE_NAME)
-    db_api_with_initialized_first_course.create_user_if_not_exist(student2, SECOND_COURSE_NAME)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student2, FIRST_COURSE_NAME)
+    db_api_with_two_initialized_courses.create_user_if_not_exist(student2, SECOND_COURSE_NAME)
 
     db_api_with_two_initialized_courses.store_score(
         FIRST_COURSE_NAME, TEST_USERNAME_1, "repo1", "task_0_0", update_func(1)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -149,7 +149,7 @@ def mock_storage_api(mock_course):  # noqa: C901
         def get_now_with_timezone(_course_name):
             return datetime.now(tz=ZoneInfo("UTC"))
 
-        def get_stored_user(self, _course_name, _student):
+        def get_stored_user(self, _course_name, _username):
             return self.stored_user
 
         @staticmethod


### PR DESCRIPTION
When calling store_score and get_stored_user, we do not need to call get-or-create type of method on stored user: we only need to read the data if any. This allow to simplify the signature of some functions and tests.