### PR TITLE
feat: add first and last name in score table

### DIFF
--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -26,11 +26,13 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
     for username, student_scores in all_scores.items():
         total_score = sum(student_scores.values())
         large_count = sum(1 for task in large_tasks if student_scores.get(task, 0) > 0)
-        student_name = app.gitlab_api.get_student_by_username(username).name
+        stored_user = storage_api.get_stored_user(course_name, username)
+        first_name, last_name = stored_user.first_name, stored_user.last_name
         table_data["students"].append(
             {
                 "username": username,
-                "student_name": student_name,
+                "first_name": first_name,
+                "last_name": last_name,
                 "scores": student_scores,
                 "total_score": total_score,
                 "percent": 0 if max_score == 0 else total_score * 100.0 / max_score,

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -275,12 +275,12 @@
             const valueEl = document.getElementById("filter-value");
 
             function customFilter(data) {
-                if (data.username.toLowerCase().includes(valueEl.value.toLowerCase())) {
+                const searchTerm = valueEl.value.toLowerCase();
+                if (data.username.toLowerCase().includes(searchTerm)) {
                     return true;
                 }
                 const full_name = `${data.first_name} ${data.last_name}`.toLowerCase();
-                return full_name.includes(valueEl.value.toLowerCase());
-
+                return full_name.includes(searchTerm);
             }
 
             document.getElementById("filter-value")

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -275,8 +275,12 @@
             const valueEl = document.getElementById("filter-value");
 
             function customFilter(data) {
-                return data.username.toLowerCase().includes(valueEl.value.toLowerCase()) ||
-                    data.student_name.toLowerCase().includes(valueEl.value.toLowerCase());
+                if (data.username.toLowerCase().includes(valueEl.value.toLowerCase())) {
+                    return true;
+                }
+                const full_name = `${data.first_name} ${data.last_name}`.toLowerCase();
+                return full_name.includes(valueEl.value.toLowerCase());
+
             }
 
             document.getElementById("filter-value")
@@ -310,26 +314,34 @@
                             headerTooltip: "Username"
                         },
                         {
-                            title: "Name",
-                            field: "student_name",
+                            title: "First<br>Name",
+                            field: "first_name",
                             frozen: true,
                             minWidth: 1,
-                            width: 200,
-                            headerTooltip: "Full name"
+                            headerTooltip: "First Name"
                         },
                         {
-                            title: "Total Score",
+                            title: "Last<br>Name",
+                            field: "last_name",
+                            frozen: true,
+                            minWidth: 1,
+                            headerTooltip: "Last Name"
+                        },
+                        {
+                            title: "Total<br>Score",
                             field: "total_score",
                             frozen: true,
                             sorter: "number",
+                            hozAlign: "center",
                             minWidth: 1,
                             headerTooltip: "Total Score"
                         },
                         {
-                            title: "Percent",
+                            title: "Per<br>cent",
                             field: "percent",
                             frozen: true,
                             sorter: "number",
+                            hozAlign: "center",
                             minWidth: 1,
                             headerTooltip: "% completed"
                         },
@@ -338,6 +350,7 @@
                             field: "large_count",
                             frozen: true,
                             sorter: "number",
+                            hozAlign: "center",
                             minWidth: 1,
                             headerTooltip: "Number of Large Homeworks"
                         }
@@ -363,6 +376,7 @@
                             title: task.name,
                             field: `scores.${task.name}`,
                             sorter: "number",
+                            hozAlign: "center",
                             headerTooltip: task.name,
                             {% if is_course_admin %}
                             cellClick: function(e, cell) {

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -3,8 +3,9 @@ from dataclasses import dataclass
 import pytest
 from flask import Flask
 
+from manytask.abstract import StoredUser
 from manytask.database_utils import get_database_table_data
-from manytask.glab import Student
+from tests import constants
 
 TASK_1 = "task1"
 TASK_2 = "task2"
@@ -14,7 +15,10 @@ TASK_LARGE = "task_large"
 STUDENT_1 = "student1"
 STUDENT_2 = "student2"
 
-STUDENT_NAMES = {STUDENT_1: "Student Oneich", STUDENT_2: "Student Twoich"}
+STUDENT_NAMES = {
+    STUDENT_1: [constants.TEST_FIRST_NAME_1, constants.TEST_LAST_NAME_1],
+    STUDENT_2: [constants.TEST_FIRST_NAME_2, constants.TEST_LAST_NAME_2],
+}
 
 SCORES = {
     STUDENT_1: {TASK_1: 100, TASK_2: 90, TASK_LARGE: 200, "total": 390, "large_count": 1},
@@ -57,6 +61,15 @@ def app():
             return self.groups
 
         @staticmethod
+        def get_stored_user(_course_name, username):
+            return StoredUser(
+                username=username,
+                first_name=STUDENT_NAMES[username][0],
+                last_name=STUDENT_NAMES[username][1],
+                course_admin=False,
+            )
+
+        @staticmethod
         def get_all_scores(_course_name):
             return {
                 STUDENT_1: {
@@ -83,13 +96,6 @@ def app():
     class MockGitLabApi:
         def __init__(self):
             pass
-
-        def get_student_by_username(self, username: str) -> Student:
-            return Student(
-                id=1,
-                username=username,
-                name=STUDENT_NAMES[username],
-            )
 
     app.storage_api = MockStorageApi()
     app.gitlab_api = MockGitLabApi()
@@ -120,7 +126,8 @@ def test_get_database_table_data(app):
 
         for student_id in [STUDENT_1, STUDENT_2]:
             student = next(s for s in students if s["username"] == student_id)
-            assert student["student_name"] == STUDENT_NAMES[student_id]
+            assert student["first_name"] == STUDENT_NAMES[student_id][0]
+            assert student["last_name"] == STUDENT_NAMES[student_id][1]
             assert student["total_score"] == SCORES[student_id]["total"]
             assert student["large_count"] == SCORES[student_id]["large_count"]
             assert student["scores"] == {


### PR DESCRIPTION
Now, the DB looks like this:
![image](https://github.com/user-attachments/assets/631007ec-6dd8-4a39-9130-4c22d7e0c8f6)

```Name``` is replaced by two columns: ```First Name``` and ```Last Name```. Search is working on any column.

And some UI updates (you can see this on screenshot), to my mind now it looks better, but I'm ready to listen criticism