### PR TITLE
perf: optimize calls to db when table is rendering

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable, Tuple
+from typing import Any, Callable
 
 from .config import ManytaskConfig, ManytaskGroupConfig, ManytaskTaskConfig
 from .course import Course, CourseConfig
@@ -61,9 +61,7 @@ class StorageApi(ABC):
     ) -> StoredUser: ...
 
     @abstractmethod
-    def get_all_scores_with_names(
-        self, course_name: str
-    ) -> Tuple[dict[str, dict[str, int]], dict[str, tuple[str, str]]]: ...
+    def get_all_scores_with_names(self, course_name: str) -> dict[str, tuple[dict[str, int], tuple[str, str]]]: ...
 
     @abstractmethod
     def get_stats(self, course_name: str) -> dict[str, float]: ...

--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any, Callable, Tuple
 
 from .config import ManytaskConfig, ManytaskGroupConfig, ManytaskTaskConfig
 from .course import Course, CourseConfig
@@ -61,7 +61,9 @@ class StorageApi(ABC):
     ) -> StoredUser: ...
 
     @abstractmethod
-    def get_all_scores(self, course_name: str) -> dict[str, dict[str, int]]: ...
+    def get_all_scores_with_names(
+        self, course_name: str
+    ) -> Tuple[dict[str, dict[str, int]], dict[str, tuple[str, str]]]: ...
 
     @abstractmethod
     def get_stats(self, course_name: str) -> dict[str, float]: ...

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -177,7 +177,7 @@ class DataBaseApi(StorageApi):
         """
 
         with Session(self.engine) as session:
-            all_users = self._get_all_users(session, course_name)
+            all_users = self._get_all_users_on_course(session, course_name)
 
         scores_and_names: dict[str, tuple[dict[str, int], tuple[str, str]]] = {}
         for user in all_users:
@@ -1011,7 +1011,7 @@ class DataBaseApi(StorageApi):
         return query.all()
 
     @staticmethod
-    def _get_all_users(
+    def _get_all_users_on_course(
         session: Session,
         course_name: str,
     ) -> Iterable["models.User"]:

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -2,7 +2,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Callable, Iterable, Optional, Tuple, Type, TypeVar, cast
+from typing import Any, Callable, Iterable, Optional, Type, TypeVar, cast
 from zoneinfo import ZoneInfo
 
 from alembic import command
@@ -170,26 +170,23 @@ class DataBaseApi(StorageApi):
                 course_admin=user_on_course.is_course_admin,
             )
 
-    def get_all_scores_with_names(
-        self, course_name: str
-    ) -> Tuple[dict[str, dict[str, int]], dict[str, tuple[str, str]]]:
-        """Method for getting all scores for all users
-
+    def get_all_scores_with_names(self, course_name: str) -> dict[str, tuple[dict[str, int], tuple[str, str]]]:
+        """Method for getting all users scores with names
         :param course_name: course name
-
-        :return: dict with usernames and all their scores
+        :return: dict with the usernames as keys and a tuple of (first_name, last_name) and scores dict as values
         """
 
         with Session(self.engine) as session:
             all_users = self._get_all_users(session, course_name)
 
-        all_scores: dict[str, dict[str, int]] = {}
-        names: dict[str, tuple[str, str]] = {}
+        scores_and_names: dict[str, tuple[dict[str, int], tuple[str, str]]] = {}
         for user in all_users:
-            all_scores[user.username] = self.get_scores(course_name, user.username)
-            names[user.username] = (user.first_name, user.last_name)
+            scores_and_names[user.username] = (
+                self.get_scores(course_name, user.username),
+                (user.first_name, user.last_name),
+            )
 
-        return all_scores, names
+        return scores_and_names
 
     def get_stats(self, course_name: str) -> dict[str, float]:
         """Method for getting stats of all tasks

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -7,7 +7,7 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
     """Get the database table data structure used by both web and API endpoints."""
 
     storage_api = app.storage_api
-    all_scores, all_names = storage_api.get_all_scores_with_names(course_name)
+    scores_and_names = storage_api.get_all_scores_with_names(course_name)
 
     all_tasks = []
     large_tasks = []
@@ -23,14 +23,15 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
 
     table_data = {"tasks": all_tasks, "students": []}
 
-    for username, student_scores in all_scores.items():
+    for username, (student_scores, name) in scores_and_names.items():
         total_score = sum(student_scores.values())
         large_count = sum(1 for task in large_tasks if student_scores.get(task, 0) > 0)
+        first_name, last_name = name
         table_data["students"].append(
             {
                 "username": username,
-                "first_name": all_names[username][0],
-                "last_name": all_names[username][1],
+                "first_name": first_name,
+                "last_name": last_name,
                 "scores": student_scores,
                 "total_score": total_score,
                 "percent": 0 if max_score == 0 else total_score * 100.0 / max_score,

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -7,7 +7,7 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
     """Get the database table data structure used by both web and API endpoints."""
 
     storage_api = app.storage_api
-    all_scores = storage_api.get_all_scores(course_name)
+    all_scores, all_names = storage_api.get_all_scores_with_names(course_name)
 
     all_tasks = []
     large_tasks = []
@@ -26,13 +26,11 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
     for username, student_scores in all_scores.items():
         total_score = sum(student_scores.values())
         large_count = sum(1 for task in large_tasks if student_scores.get(task, 0) > 0)
-        stored_user = storage_api.get_stored_user(course_name, username)
-        first_name, last_name = stored_user.first_name, stored_user.last_name
         table_data["students"].append(
             {
                 "username": username,
-                "first_name": first_name,
-                "last_name": last_name,
+                "first_name": all_names[username][0],
+                "last_name": all_names[username][1],
                 "scores": student_scores,
                 "total_score": total_score,
                 "percent": 0 if max_score == 0 else total_score * 100.0 / max_score,

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -2,7 +2,10 @@
 {% set active_page = "database" -%}
 
 {% block content %}
-    <div class="container-fluid">
+    <div id="loader" class="position-absolute top-50 start-50" >
+        <div class="spinner-border text-secondary" style="width: 3rem; height: 3rem;"></div>
+    </div>
+    <div class="container-fluid  position-relative">
         <h2>Course Database</h2>
 
             <div class="search-controls mb-3 mt-4">
@@ -550,6 +553,10 @@
                         },
                         persistenceMode: "local",
                         persistentLayout: true
+                    });
+
+                    window.tabulatorTable.on("tableBuilt", function () {
+                        document.getElementById("loader").style.display = "none"
                     });
 
                     // Wait for a short delay to ensure table is rendered

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -72,17 +72,23 @@ def app():
         @staticmethod
         def get_all_scores_with_names(_course_name):
             return {
-                STUDENT_1: {
-                    TASK_1: SCORES[STUDENT_1][TASK_1],
-                    TASK_2: SCORES[STUDENT_1][TASK_2],
-                    TASK_LARGE: SCORES[STUDENT_1][TASK_LARGE],
-                },
-                STUDENT_2: {
-                    TASK_1: SCORES[STUDENT_2][TASK_1],
-                    TASK_2: SCORES[STUDENT_2][TASK_2],
-                    TASK_LARGE: SCORES[STUDENT_2][TASK_LARGE],
-                },
-            }, STUDENT_NAMES
+                STUDENT_1: (
+                    {
+                        TASK_1: SCORES[STUDENT_1][TASK_1],
+                        TASK_2: SCORES[STUDENT_1][TASK_2],
+                        TASK_LARGE: SCORES[STUDENT_1][TASK_LARGE],
+                    },
+                    STUDENT_NAMES[STUDENT_1],
+                ),
+                STUDENT_2: (
+                    {
+                        TASK_1: SCORES[STUDENT_2][TASK_1],
+                        TASK_2: SCORES[STUDENT_2][TASK_2],
+                        TASK_LARGE: SCORES[STUDENT_2][TASK_LARGE],
+                    },
+                    STUDENT_NAMES[STUDENT_2],
+                ),
+            }
 
         @staticmethod
         def get_course(_name):
@@ -141,7 +147,7 @@ def test_get_database_table_data_no_scores(app):
     expected_tasks_count = 3
 
     with app.test_request_context():
-        app.storage_api.get_all_scores_with_names = lambda _course_name: ({}, {})
+        app.storage_api.get_all_scores_with_names = lambda _course_name: {}
         result = get_database_table_data(app, "test_course")
 
         assert "tasks" in result

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -70,7 +70,7 @@ def app():
             )
 
         @staticmethod
-        def get_all_scores(_course_name):
+        def get_all_scores_with_names(_course_name):
             return {
                 STUDENT_1: {
                     TASK_1: SCORES[STUDENT_1][TASK_1],
@@ -82,7 +82,7 @@ def app():
                     TASK_2: SCORES[STUDENT_2][TASK_2],
                     TASK_LARGE: SCORES[STUDENT_2][TASK_LARGE],
                 },
-            }
+            }, STUDENT_NAMES
 
         @staticmethod
         def get_course(_name):
@@ -141,7 +141,7 @@ def test_get_database_table_data_no_scores(app):
     expected_tasks_count = 3
 
     with app.test_request_context():
-        app.storage_api.get_all_scores = lambda _course_name: {}
+        app.storage_api.get_all_scores_with_names = lambda _course_name: ({}, {})
         result = get_database_table_data(app, "test_course")
 
         assert "tasks" in result

--- a/tests/test_db_api.py
+++ b/tests/test_db_api.py
@@ -278,7 +278,7 @@ def test_not_initialized_course(session, db_api, first_course_config):
     assert course.submission_penalty == 0
 
     stats = db_api.get_stats(course_name)
-    all_scores = db_api.get_all_scores(course_name)
+    all_scores, _ = db_api.get_all_scores_with_names(course_name)
     bonus_score = db_api.get_bonus_score(course_name, "some_user")
     scores = db_api.get_scores(course_name, "some_user")
     max_score_started = db_api.max_score_started(course_name)
@@ -507,7 +507,7 @@ def test_store_score(db_api_with_initialized_first_course, session):
     assert grade.score == 1
 
     stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
-    all_scores = db_api_with_initialized_first_course.get_all_scores(FIRST_COURSE_NAME)
+    all_scores, _ = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -547,7 +547,7 @@ def test_store_score_bonus_task(db_api_with_initialized_first_course, session):
     assert grade.score == expected_score
 
     stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
-    all_scores = db_api_with_initialized_first_course.get_all_scores(FIRST_COURSE_NAME)
+    all_scores, _ = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -586,7 +586,7 @@ def test_store_score_with_changed_task_name(
     )
 
     stats = db_api.get_stats(FIRST_COURSE_NAME)
-    all_scores = db_api.get_all_scores(FIRST_COURSE_NAME)
+    all_scores, _ = db_api.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score = db_api.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores = db_api.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -702,7 +702,7 @@ def test_many_users(db_api_with_initialized_first_course, session):
     assert session.query(Grade).count() == expected_grades
 
     stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
-    all_scores = db_api_with_initialized_first_course.get_all_scores(FIRST_COURSE_NAME)
+    all_scores, _ = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score_user1 = db_api_with_initialized_first_course.get_bonus_score(
         FIRST_COURSE_NAME, constants.TEST_USERNAME_1
     )
@@ -755,7 +755,7 @@ def test_many_courses(db_api_with_two_initialized_courses, session):
     assert session.query(Grade).count() == expected_grades
 
     stats1 = db_api_with_two_initialized_courses.get_stats(FIRST_COURSE_NAME)
-    all_scores1 = db_api_with_two_initialized_courses.get_all_scores(FIRST_COURSE_NAME)
+    all_scores1, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score_user1 = db_api_with_two_initialized_courses.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores_user1 = db_api_with_two_initialized_courses.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -768,7 +768,7 @@ def test_many_courses(db_api_with_two_initialized_courses, session):
     assert scores_user1 == {"task_0_0": 30}
 
     stats2 = db_api_with_two_initialized_courses.get_stats(SECOND_COURSE_NAME)
-    all_scores2 = db_api_with_two_initialized_courses.get_all_scores(SECOND_COURSE_NAME)
+    all_scores2, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(SECOND_COURSE_NAME)
     bonus_score_user2 = db_api_with_two_initialized_courses.get_bonus_score(SECOND_COURSE_NAME, constants.TEST_USERNAME)
     scores_user2 = db_api_with_two_initialized_courses.get_scores(SECOND_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -839,7 +839,7 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     assert session.query(Grade).count() == expected_grades
 
     stats1 = db_api_with_two_initialized_courses.get_stats(FIRST_COURSE_NAME)
-    all_scores1 = db_api_with_two_initialized_courses.get_all_scores(FIRST_COURSE_NAME)
+    all_scores1, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score1_user1 = db_api_with_two_initialized_courses.get_bonus_score(
         FIRST_COURSE_NAME, constants.TEST_USERNAME_1
     )
@@ -864,7 +864,7 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     assert scores1_user2 == {"task_0_0": expected_score_2}
 
     stats2 = db_api_with_two_initialized_courses.get_stats(SECOND_COURSE_NAME)
-    all_scores2 = db_api_with_two_initialized_courses.get_all_scores(SECOND_COURSE_NAME)
+    all_scores2, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(SECOND_COURSE_NAME)
     bonus_score2_user1 = db_api_with_two_initialized_courses.get_bonus_score(
         SECOND_COURSE_NAME, constants.TEST_USERNAME_1
     )

--- a/tests/test_db_api.py
+++ b/tests/test_db_api.py
@@ -278,7 +278,7 @@ def test_not_initialized_course(session, db_api, first_course_config):
     assert course.submission_penalty == 0
 
     stats = db_api.get_stats(course_name)
-    all_scores, _ = db_api.get_all_scores_with_names(course_name)
+    all_scores = db_api.get_all_scores_with_names(course_name)
     bonus_score = db_api.get_bonus_score(course_name, "some_user")
     scores = db_api.get_scores(course_name, "some_user")
     max_score_started = db_api.max_score_started(course_name)
@@ -507,7 +507,7 @@ def test_store_score(db_api_with_initialized_first_course, session):
     assert grade.score == 1
 
     stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
-    all_scores, _ = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
+    all_scores = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -515,7 +515,9 @@ def test_store_score(db_api_with_initialized_first_course, session):
     assert stats["task_0_0"] == 1.0
     assert all(v == 0.0 for k, v in stats.items() if k != "task_0_0")
 
-    assert all_scores == {constants.TEST_USERNAME: {"task_0_0": 1}}
+    assert all_scores == {
+        constants.TEST_USERNAME: ({"task_0_0": 1}, (constants.TEST_FIRST_NAME, constants.TEST_LAST_NAME))
+    }
     assert bonus_score == 0
     assert scores == {"task_0_0": 1}
 
@@ -547,7 +549,7 @@ def test_store_score_bonus_task(db_api_with_initialized_first_course, session):
     assert grade.score == expected_score
 
     stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
-    all_scores, _ = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
+    all_scores = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score = db_api_with_initialized_first_course.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores = db_api_with_initialized_first_course.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -555,7 +557,9 @@ def test_store_score_bonus_task(db_api_with_initialized_first_course, session):
     assert stats["task_1_3"] == 1.0
     assert all(v == 0.0 for k, v in stats.items() if k != "task_1_3")
 
-    assert all_scores == {constants.TEST_USERNAME: {"task_1_3": expected_score}}
+    assert all_scores == {
+        constants.TEST_USERNAME: ({"task_1_3": expected_score}, (constants.TEST_FIRST_NAME, constants.TEST_LAST_NAME))
+    }
     assert bonus_score == expected_score
     assert scores == {"task_1_3": expected_score}
 
@@ -586,14 +590,14 @@ def test_store_score_with_changed_task_name(
     )
 
     stats = db_api.get_stats(FIRST_COURSE_NAME)
-    all_scores, _ = db_api.get_all_scores_with_names(FIRST_COURSE_NAME)
+    all_scores = db_api.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score = db_api.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores = db_api.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
     assert set(stats.keys()) == FIRST_COURSE_EXPECTED_STATS_KEYS - {"task_0_0"} | {"task_0_0_changed"}
     assert all(v == 0.0 for k, v in stats.items())
 
-    assert all_scores == {constants.TEST_USERNAME: {}}
+    assert all_scores == {constants.TEST_USERNAME: ({}, (constants.TEST_FIRST_NAME, constants.TEST_LAST_NAME))}
     assert bonus_score == 0
     assert scores == {}
 
@@ -702,7 +706,7 @@ def test_many_users(db_api_with_initialized_first_course, session):
     assert session.query(Grade).count() == expected_grades
 
     stats = db_api_with_initialized_first_course.get_stats(FIRST_COURSE_NAME)
-    all_scores, _ = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
+    all_scores = db_api_with_initialized_first_course.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score_user1 = db_api_with_initialized_first_course.get_bonus_score(
         FIRST_COURSE_NAME, constants.TEST_USERNAME_1
     )
@@ -718,8 +722,14 @@ def test_many_users(db_api_with_initialized_first_course, session):
     assert all(v == 0.0 for k, v in stats.items() if k not in ["task_0_0", "task_1_3"])
 
     assert all_scores == {
-        constants.TEST_USERNAME_1: {"task_0_0": 1, "task_1_3": expected_score_1},
-        constants.TEST_USERNAME_2: {"task_0_0": expected_score_2},
+        constants.TEST_USERNAME_1: (
+            {"task_0_0": 1, "task_1_3": expected_score_1},
+            (constants.TEST_FIRST_NAME_1, constants.TEST_LAST_NAME_1),
+        ),
+        constants.TEST_USERNAME_2: (
+            {"task_0_0": expected_score_2},
+            (constants.TEST_FIRST_NAME_2, constants.TEST_LAST_NAME_2),
+        ),
     }
     assert bonus_score_user1 == expected_score_1
     assert scores_user1 == {"task_0_0": 1, "task_1_3": expected_score_1}
@@ -755,7 +765,7 @@ def test_many_courses(db_api_with_two_initialized_courses, session):
     assert session.query(Grade).count() == expected_grades
 
     stats1 = db_api_with_two_initialized_courses.get_stats(FIRST_COURSE_NAME)
-    all_scores1, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(FIRST_COURSE_NAME)
+    all_scores1 = db_api_with_two_initialized_courses.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score_user1 = db_api_with_two_initialized_courses.get_bonus_score(FIRST_COURSE_NAME, constants.TEST_USERNAME)
     scores_user1 = db_api_with_two_initialized_courses.get_scores(FIRST_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -763,12 +773,14 @@ def test_many_courses(db_api_with_two_initialized_courses, session):
     assert stats1["task_0_0"] == 1.0
     assert all(v == 0.0 for k, v in stats1.items() if k != "task_0_0")
 
-    assert all_scores1 == {constants.TEST_USERNAME: {"task_0_0": 30}}
+    assert all_scores1 == {
+        constants.TEST_USERNAME: ({"task_0_0": 30}, (constants.TEST_FIRST_NAME, constants.TEST_LAST_NAME))
+    }
     assert bonus_score_user1 == 0
     assert scores_user1 == {"task_0_0": 30}
 
     stats2 = db_api_with_two_initialized_courses.get_stats(SECOND_COURSE_NAME)
-    all_scores2, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(SECOND_COURSE_NAME)
+    all_scores2 = db_api_with_two_initialized_courses.get_all_scores_with_names(SECOND_COURSE_NAME)
     bonus_score_user2 = db_api_with_two_initialized_courses.get_bonus_score(SECOND_COURSE_NAME, constants.TEST_USERNAME)
     scores_user2 = db_api_with_two_initialized_courses.get_scores(SECOND_COURSE_NAME, constants.TEST_USERNAME)
 
@@ -777,7 +789,9 @@ def test_many_courses(db_api_with_two_initialized_courses, session):
     assert all(v == 0.0 for k, v in stats2.items() if k != "task_1_3")
 
     user2_score = 40
-    assert all_scores2 == {constants.TEST_USERNAME: {"task_1_3": user2_score}}
+    assert all_scores2 == {
+        constants.TEST_USERNAME: ({"task_1_3": user2_score}, (constants.TEST_FIRST_NAME, constants.TEST_LAST_NAME))
+    }
     assert bonus_score_user2 == user2_score
     assert scores_user2 == {"task_1_3": user2_score}
 
@@ -839,7 +853,7 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     assert session.query(Grade).count() == expected_grades
 
     stats1 = db_api_with_two_initialized_courses.get_stats(FIRST_COURSE_NAME)
-    all_scores1, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(FIRST_COURSE_NAME)
+    all_scores1 = db_api_with_two_initialized_courses.get_all_scores_with_names(FIRST_COURSE_NAME)
     bonus_score1_user1 = db_api_with_two_initialized_courses.get_bonus_score(
         FIRST_COURSE_NAME, constants.TEST_USERNAME_1
     )
@@ -855,8 +869,14 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     assert all(v == 0.0 for k, v in stats1.items() if k not in ["task_0_0", "task_1_3"])
 
     assert all_scores1 == {
-        constants.TEST_USERNAME_1: {"task_0_0": 1, "task_1_3": expected_score_1},
-        constants.TEST_USERNAME_2: {"task_0_0": expected_score_2},
+        constants.TEST_USERNAME_1: (
+            {"task_0_0": 1, "task_1_3": expected_score_1},
+            (constants.TEST_FIRST_NAME_1, constants.TEST_LAST_NAME_1),
+        ),
+        constants.TEST_USERNAME_2: (
+            {"task_0_0": expected_score_2},
+            (constants.TEST_FIRST_NAME_2, constants.TEST_LAST_NAME_2),
+        ),
     }
     assert bonus_score1_user1 == expected_score_1
     assert scores1_user1 == {"task_0_0": 1, "task_1_3": expected_score_1}
@@ -864,7 +884,7 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     assert scores1_user2 == {"task_0_0": expected_score_2}
 
     stats2 = db_api_with_two_initialized_courses.get_stats(SECOND_COURSE_NAME)
-    all_scores2, _ = db_api_with_two_initialized_courses.get_all_scores_with_names(SECOND_COURSE_NAME)
+    all_scores2 = db_api_with_two_initialized_courses.get_all_scores_with_names(SECOND_COURSE_NAME)
     bonus_score2_user1 = db_api_with_two_initialized_courses.get_bonus_score(
         SECOND_COURSE_NAME, constants.TEST_USERNAME_1
     )
@@ -879,7 +899,10 @@ def test_many_users_and_courses(db_api_with_two_initialized_courses, session):
     assert stats2["task_1_1"] == expected_stats_ratio
     assert all(v == 0.0 for k, v in stats2.items() if k not in ["task_1_0", "task_1_1"])
 
-    assert all_scores2 == {constants.TEST_USERNAME_1: {"task_1_0": 99}, "user2": {"task_1_1": 7}}
+    assert all_scores2 == {
+        constants.TEST_USERNAME_1: ({"task_1_0": 99}, (constants.TEST_FIRST_NAME_1, constants.TEST_LAST_NAME_1)),
+        constants.TEST_USERNAME_2: ({"task_1_1": 7}, (constants.TEST_FIRST_NAME_2, constants.TEST_LAST_NAME_2)),
+    }
     assert bonus_score2_user1 == 0
     assert scores2_user1 == {"task_1_0": 99}
     assert bonus_score2_user2 == 0

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -119,8 +119,8 @@ def mock_storage_api(mock_course):  # noqa: C901
             return {"task1": 100, "task2": 90}
 
         @staticmethod
-        def get_all_scores(_course_name):
-            return {TEST_USERNAME: {"task1": 100, "task2": 90}}
+        def get_all_scores_with_names(_course_name):
+            return {TEST_USERNAME: {"task1": 100, "task2": 90}}, {TEST_USERNAME: (TEST_FIRST_NAME, TEST_LAST_NAME)}
 
         @staticmethod
         def get_stats(_course_name):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -120,7 +120,7 @@ def mock_storage_api(mock_course):  # noqa: C901
 
         @staticmethod
         def get_all_scores_with_names(_course_name):
-            return {TEST_USERNAME: {"task1": 100, "task2": 90}}, {TEST_USERNAME: (TEST_FIRST_NAME, TEST_LAST_NAME)}
+            return {TEST_USERNAME: ({"task1": 100, "task2": 90}, (TEST_FIRST_NAME, TEST_LAST_NAME))}
 
         @staticmethod
         def get_stats(_course_name):


### PR DESCRIPTION
This PR improve speed of rendering table at twice. Even visually I can see strong difference.
Some benchmark tests (if I wrote their correctly :) ):
```test_db (NOW)``` - **old** realisation
```test_db (0004_...)``` - **new** realisation
When we have ```1000``` users on course:
![image](https://github.com/user-attachments/assets/b75eb3d2-9757-49c7-8963-08711036903f)
When we have ```500``` users:
![image](https://github.com/user-attachments/assets/47a9c2b5-6c17-471d-83b3-ae98aaba647f)
When we have ```100``` users:
![image](https://github.com/user-attachments/assets/60ad5c1a-81d1-41fa-b412-943423ac7d6b)

But I had to change a signature of method ```get_all_scores```, now it is ```get_all_scores_with_names```. In this method I make new ```dict``` for names, where key is ```username```, but we already have ```dict``` with key ```username```(```all_scores```). And maybe will be good if we combine them, but in my case tests is refactoring very quickly and code is readable