### PR TITLE
refactor: Use username instead of Student when checking if the project exists

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -178,7 +178,7 @@ class RmsApi(ABC):
     @abstractmethod
     def check_project_exists(
         self,
-        student: Student,
+        username: str,
         course_students_group: str,
     ) -> bool: ...
 

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -45,17 +45,17 @@ def set_oauth_session(
     return result
 
 
-def handle_course_membership(app: CustomFlask, course: Course, student: Student) -> bool | str | Response:
+def handle_course_membership(app: CustomFlask, course: Course, username: str) -> bool | str | Response:
     """Checking user on course"""
 
     try:
-        if app.storage_api.check_user_on_course(course.course_name, student.username):
+        if app.storage_api.check_user_on_course(course.course_name, username):
             return True
         else:
-            logger.info(f"No user {student.username} on course {course.course_name} asking secret")
+            logger.info(f"No user {username} on course {course.course_name} asking secret")
             return False
     except NoResultFound:
-        logger.info(f"User: {student.username} not in the database")
+        logger.info(f"User: {username} not in the database")
         return False
     except Exception:
         logger.error("Failed login while working with db", exc_info=True)
@@ -162,10 +162,9 @@ def requires_course_access(f: Callable[..., Any]) -> Callable[..., Any]:
 
         course: Course = app.storage_api.get_course(kwargs["course_name"])  # type: ignore
         student: Student = get_authenticate_student(oauth, app)  # type: ignore
-        first_name, last_name = student.name.split()
 
-        if not handle_course_membership(app, course, student) or not app.rms_api.check_project_exists(
-            student=student, course_students_group=course.gitlab_course_students_group
+        if not handle_course_membership(app, course, student.username) or not app.rms_api.check_project_exists(
+            username=student.username, course_students_group=course.gitlab_course_students_group
         ):
             abort(redirect(url_for("course.create_project", course_name=course.course_name)))
 

--- a/manytask/glab.py
+++ b/manytask/glab.py
@@ -133,22 +133,22 @@ class GitLabApi(RmsApi):
 
     def check_project_exists(
         self,
-        student: Student,
+        username: str,
         course_students_group: str,
     ) -> bool:
-        gitlab_project_path = f"{course_students_group}/{student.username}"
+        gitlab_project_path = f"{course_students_group}/{username}"
         logger.info(f"Gitlab project path: {gitlab_project_path}")
 
-        for project in self._gitlab.projects.list(get_all=True, search=student.username):
+        for project in self._gitlab.projects.list(get_all=True, search=username):
             logger.info(f"Check project path: {project.path_with_namespace}")
 
             # Because of implicit conversion
             # TODO: make global problem solve
             if project.path_with_namespace == gitlab_project_path:
-                logger.info(f"Project {student.username} for group {course_students_group} exists")
+                logger.info(f"Project {username} for group {course_students_group} exists")
                 return True
 
-        logger.info(f"Project {student.username} for group {course_students_group} does not exist")
+        logger.info(f"Project {username} for group {course_students_group} does not exist")
         return False
 
     def create_project(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -204,7 +204,7 @@ def mock_gitlab_api(mock_student):
             return f"https://gitlab.com/{username}/test-repo"
 
         @staticmethod
-        def check_project_exists(_student, course_students_group):
+        def check_project_exists(_username, course_students_group):
             return True
 
     return MockGitlabApi()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -72,7 +72,7 @@ def mock_gitlab_api():
             return False
 
         @staticmethod
-        def check_project_exists(student: Student, course_students_group: str):
+        def check_project_exists(username: str, course_students_group: str):
             return True
 
         @staticmethod

--- a/tests/test_glab.py
+++ b/tests/test_glab.py
@@ -293,24 +293,24 @@ def test_get_group_by_name_not_found(gitlab):
         gitlab_api._get_group_by_name(TEST_GROUP_NAME)
 
 
-def test_check_project_exists(gitlab, mock_gitlab_student_project, mock_student):
+def test_check_project_exists(gitlab, mock_gitlab_student_project):
     gitlab_api, mock_gitlab_instance = gitlab
     mock_gitlab_instance.projects.list.return_value = [mock_gitlab_student_project]
 
-    exists = gitlab_api.check_project_exists(mock_student, TEST_GROUP_STUDENT_NAME)
+    exists = gitlab_api.check_project_exists(TEST_USERNAME, TEST_GROUP_STUDENT_NAME)
 
     assert exists is True
-    mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=mock_student.username)
+    mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=TEST_USERNAME)
 
 
-def test_check_project_not_exists(gitlab, mock_student):
+def test_check_project_not_exists(gitlab):
     gitlab_api, mock_gitlab_instance = gitlab
     mock_gitlab_instance.projects.list.return_value = []
 
-    exists = gitlab_api.check_project_exists(mock_student, TEST_GROUP_NAME)
+    exists = gitlab_api.check_project_exists(TEST_USERNAME, TEST_GROUP_NAME)
 
     assert exists is False
-    mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=mock_student.username)
+    mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=TEST_USERNAME)
 
 
 def test_create_project_existing_project(gitlab, mock_student, mock_gitlab_student_project, mock_gitlab_group_member):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -88,7 +88,7 @@ def mock_gitlab_api():
             return Student(id=TEST_USER_ID, username=TEST_USERNAME, name=TEST_STUDENT_NAME)
 
         @staticmethod
-        def check_project_exists(student: Student, course_students_group: str):
+        def check_project_exists(username: str, course_students_group: str):
             return True
 
         @staticmethod


### PR DESCRIPTION
The username is used to construct path to a project, hence it should be provided directly, not inside a container.