### PR TITLE
fix: application logs are't displayed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ VOLUME ["/cache"]
 
 EXPOSE 5050
 HEALTHCHECK --interval=1m --timeout=15s --retries=3 --start-period=30s CMD curl -f http://localhost:5050/healthcheck
-CMD ["gunicorn", "--bind", "0.0.0.0:5050", "--workers", "2", "--threads", "4", "manytask:create_app()"]
+CMD ["gunicorn", "--bind", "0.0.0.0:5050", "--access-logfile", "-", "--log-file", "-", "--capture-output", "--workers", "2", "--threads", "4", "manytask:create_app()"]
 
 # Set up Yandex.Cloud certificate
 RUN mkdir -p /root/.postgresql && \

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -144,7 +144,7 @@ def _logging_config(app: CustomFlask) -> dict[str, Any]:
                 "[process-%(process)d:%(thread)d] app in [%(module)s:%(lineno)s] : %(message)s",
             },
             "access": {
-                "format": "%(message)s",
+                "format": "[%(asctime)s] - %(message)s",
             },
         },
         "handlers": {

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -137,11 +137,11 @@ def _database_storage_setup(app: CustomFlask) -> abstract.StorageApi:
 def _logging_config(app: CustomFlask) -> dict[str, Any]:
     return {
         "version": 1,
-        "disable_existing_loggers": True,
+        "disable_existing_loggers": False,
         "formatters": {
             "default": {
-                "format": "%(asctime)s %(levelname)s - "
-                "process-%(process)d:%(thread)d app in %(filename)s : %(message)s",
+                "format": "[%(asctime)s] [%(levelname)s] - "
+                "[process-%(process)d:%(thread)d] app in [%(module)s:%(lineno)s] : %(message)s",
             },
             "access": {
                 "format": "%(message)s",


### PR DESCRIPTION
Now we can see ```access``` and ```error``` logs in docker console and in ```access.log```, ```general.log```, ```error.log``` files.
And very minor change format logs for readability improvements 
<img width="2526" height="543" alt="image" src="https://github.com/user-attachments/assets/5415e495-1474-41ff-a0d2-1847d4ba8325" />
