### PR TITLE
refactor: Create user when signing up, not when creating the first project

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -210,7 +210,7 @@ class RmsApi(ABC):
     @abstractmethod
     def create_project(
         self,
-        student: Student,
+        username: str,
         course_students_group: str,
         course_public_repo: str,
     ) -> None: ...

--- a/manytask/glab.py
+++ b/manytask/glab.py
@@ -153,10 +153,12 @@ class GitLabApi(RmsApi):
 
     def create_project(
         self,
-        student: Student,
+        username: str,
         course_students_group: str,
         course_public_repo: str,
     ) -> None:
+        student = self.get_student_by_username(username)
+
         course_group = self._get_group_by_name(course_students_group)
 
         gitlab_project_path = f"{course_students_group}/{student.username}"

--- a/tests/test_glab.py
+++ b/tests/test_glab.py
@@ -318,8 +318,9 @@ def test_create_project_existing_project(gitlab, mock_student, mock_gitlab_stude
     mock_gitlab_instance.projects.list.return_value = [mock_gitlab_student_project]
     mock_gitlab_instance.projects.get.return_value = mock_gitlab_student_project
     mock_gitlab_student_project.members.create.return_value = mock_gitlab_group_member
+    gitlab_api.get_student_by_username = MagicMock(return_value=mock_student)
 
-    gitlab_api.create_project(mock_student, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME)
+    gitlab_api.create_project(mock_student.username, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME)
 
     mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=mock_student.username)
     mock_gitlab_instance.projects.get.assert_called_with(mock_gitlab_student_project.id)
@@ -335,11 +336,12 @@ def test_create_project_no_existing_project_creates_fork(
     mock_gitlab_instance.projects.list.return_value = []
     gitlab_api._get_group_by_name = MagicMock(return_value=mock_gitlab_group)
     gitlab_api._get_project_by_name = MagicMock(return_value=mock_gitlab_student_project)
+    gitlab_api.get_student_by_username = MagicMock(return_value=mock_student)
     mock_gitlab_student_project.forks.create.return_value = mock_gitlab_fork
 
-    gitlab_api.create_project(mock_student, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME)
+    gitlab_api.create_project(TEST_USERNAME, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME)
 
-    mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=mock_student.username)
+    mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=TEST_USERNAME)
     gitlab_api._get_project_by_name.assert_called_with(TEST_GROUP_PUBLIC_NAME)
     gitlab_api._get_group_by_name.assert_called_with(TEST_GROUP_STUDENT_NAME)
 

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -185,6 +185,10 @@ def mock_storage_api(mock_course):  # noqa: C901
         def check_user_on_course(*a, **k):
             return True
 
+        @staticmethod
+        def create_user_if_not_exist(username: str, first_name: str, last_name: str) -> None:
+            pass
+
         def sync_and_get_admin_status(self, course_name: str, student: Student, course_admin: bool) -> bool:
             self.stored_user.course_admin = self.stored_user.course_admin or course_admin
             return self.stored_user.course_admin


### PR DESCRIPTION
User on GitLab and in the database were created in two separate places. Because of that we were parsing gitlab username into first and last names. This moves the creation of the user in the database, so it is created when the signup form is filled.

This is a follow-up for 75e4914ac35b6e427cb53e02a0ff52dd89e9f64b