### PR TITLE
refactor: Return bool instead of throwing when checking authenticated RMS user

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -249,10 +249,10 @@ class RmsApi(ABC):
     ) -> RmsUser: ...
 
     @abstractmethod
-    def check_authenticated_rms_user(
+    def check_user_authenticated_in_rms(
         self,
         oauth_token: str,
-    ) -> None: ...
+    ) -> bool: ...
 
     @abstractmethod
     def get_authenticated_rms_user(

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -109,10 +109,7 @@ def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
             return f(*args, **kwargs)
 
         if valid_session(session):
-            try:
-                app.rms_api.check_authenticated_rms_user(session["gitlab"]["access_token"])
-            except (HTTPError, KeyError) as e:
-                logger.error(f"Failed login in gitlab, redirect to login: {e}", exc_info=True)
+            if not app.rms_api.check_user_authenticated_in_rms(session["gitlab"]["access_token"]):
                 return __redirect_to_login()
         else:
             logger.error("Failed to verify session.", exc_info=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -202,8 +202,8 @@ def mock_gitlab_api(mock_rms_user):
                 return self._rms_user_class(TEST_USER_ID, TEST_USERNAME, TEST_NAME)
             raise GitLabApiException("User not found")
 
-        def check_authenticated_rms_user(self, access_token):
-            pass
+        def check_user_authenticated_in_rms(self, access_token):
+            return True
 
         def get_authenticated_rms_user(self, access_token):
             return RmsUser(id=TEST_USER_ID, username=TEST_USERNAME, name="")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -65,8 +65,8 @@ def mock_gitlab_api():
         def get_rms_user_by_id(user_id: int):
             return RmsUser(id=TEST_USER_ID, username=TEST_USERNAME, name=TEST_NAME)
 
-        def check_authenticated_rms_user(self, gitlab_access_token: str):
-            pass
+        def check_user_authenticated_in_rms(self, gitlab_access_token: str):
+            return True
 
         def get_authenticated_rms_user(self, gitlab_access_token: str):
             return RmsUser(id=TEST_USER_ID, username=TEST_USERNAME, name=TEST_NAME)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -78,8 +78,8 @@ def mock_gitlab_api():
         def get_rms_user_by_id(user_id: int):
             return RmsUser(id=TEST_USER_ID, username=TEST_USERNAME, name=TEST_STUDENT_NAME)
 
-        def check_authenticated_rms_user(self, access_token):
-            pass
+        def check_user_authenticated_in_rms(self, access_token):
+            return True
 
         def get_rms_user_by_username(self, username: str) -> RmsUser:
             return RmsUser(


### PR DESCRIPTION
Checking if user logged into RMS should not throw and exception: this is a routine check and nothing is wrong when user is not authenticated. Hence this function should return boolean instead of throwing an exception.

Changed the name of the function accordingly.