### PR TITLE
feat: refresh oauth token

### DIFF
--- a/manytask/abstract.py
+++ b/manytask/abstract.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable
 
+from authlib.integrations.flask_client import OAuth
+
 from .config import ManytaskConfig, ManytaskGroupConfig, ManytaskTaskConfig
 from .course import Course, CourseConfig
 
@@ -251,11 +253,13 @@ class RmsApi(ABC):
     @abstractmethod
     def check_user_authenticated_in_rms(
         self,
-        oauth_token: str,
+        oauth: OAuth,
+        oauth_access_token: str,
+        oauth_refresh_token: str,
     ) -> bool: ...
 
     @abstractmethod
     def get_authenticated_rms_user(
         self,
-        oauth_token: str,
+        oauth_access_token: str,
     ) -> RmsUser: ...

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -108,7 +108,9 @@ def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
             return f(*args, **kwargs)
 
         if valid_session(session):
-            if not app.rms_api.check_user_authenticated_in_rms(session["gitlab"]["access_token"]):
+            if not app.rms_api.check_user_authenticated_in_rms(
+                app.oauth, session["gitlab"]["access_token"], session["gitlab"]["refresh_token"]
+            ):
                 return __redirect_to_login()
         else:
             logger.error("Failed to verify session.", exc_info=True)

--- a/manytask/auth.py
+++ b/manytask/auth.py
@@ -109,7 +109,9 @@ def requires_auth(f: Callable[..., Any]) -> Callable[..., Any]:
 
         if valid_session(session):
             if not app.rms_api.check_user_authenticated_in_rms(
-                app.oauth, session["gitlab"]["access_token"], session["gitlab"]["refresh_token"]
+                app.oauth,
+                session["gitlab"]["access_token"],
+                session["gitlab"]["refresh_token"],
             ):
                 return __redirect_to_login()
         else:

--- a/manytask/glab.py
+++ b/manytask/glab.py
@@ -9,6 +9,7 @@ import gitlab
 import gitlab.const
 import gitlab.v4.objects
 import requests
+from authlib.integrations.base_client import OAuthError
 from authlib.integrations.flask_client import OAuth
 from flask import session
 from requests.exceptions import HTTPError
@@ -282,7 +283,6 @@ class GitLabApi(RmsApi):
         try:
             response.raise_for_status()
             return True
-
         except HTTPError as e:
             if e.response.status_code == HTTPStatus.UNAUTHORIZED:
                 try:
@@ -300,9 +300,10 @@ class GitLabApi(RmsApi):
                     response.raise_for_status()
 
                     session["gitlab"].update({"access_token": new_access, "refresh_token": new_refresh})
+                    logger.info("Token refreshed successfully.")
 
                     return True
-                except HTTPError as refresh_error:
+                except (HTTPError, OAuthError) as refresh_error:
                     logger.error(f"Failed to refresh token: {refresh_error}", exc_info=True)
                     return False
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -202,7 +202,7 @@ def mock_gitlab_api(mock_rms_user):
                 return self._rms_user_class(TEST_USER_ID, TEST_USERNAME, TEST_NAME)
             raise GitLabApiException("User not found")
 
-        def check_user_authenticated_in_rms(self, access_token):
+        def check_user_authenticated_in_rms(self, oauth, oauth_access_token, oauth_refresh_token):
             return True
 
         def get_authenticated_rms_user(self, access_token):
@@ -492,6 +492,7 @@ def test_get_database_not_ready(app, mock_gitlab_oauth):
                 "username": TEST_USERNAME,
                 "user_id": TEST_USER_ID,
                 "access_token": 123,
+                "refresh_token": 123,
             }
         response = client.get(f"/api/{TEST_COURSE_NAME}/database")
         assert response.status_code == HTTPStatus.FOUND  # Redirects to not ready page

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -65,7 +65,7 @@ def mock_gitlab_api():
         def get_rms_user_by_id(user_id: int):
             return RmsUser(id=TEST_USER_ID, username=TEST_USERNAME, name=TEST_NAME)
 
-        def check_user_authenticated_in_rms(self, gitlab_access_token: str):
+        def check_user_authenticated_in_rms(self, oauth, oauth_access_token, oauth_refresh_token):
             return True
 
         def get_authenticated_rms_user(self, gitlab_access_token: str):
@@ -230,6 +230,7 @@ def test_requires_auth_with_valid_session(app, mock_gitlab_oauth):
             "username": "test_user",
             "user_id": 123,
             "access_token": TEST_TOKEN,
+            "refresh_token": TEST_TOKEN,
         }
         response = test_route(course_name=TEST_COURSE_NAME)
         assert response == "success"
@@ -343,6 +344,7 @@ def test_requires_admin_with_admin_rules(app, mock_gitlab_oauth):
             "username": "test_user",
             "user_id": 123,
             "access_token": TEST_TOKEN,
+            "refresh_token": TEST_TOKEN,
         }
 
         response = test_route(course_name=TEST_COURSE_NAME)
@@ -365,6 +367,7 @@ def test_requires_admin_with_no_admin_rules(app, mock_gitlab_oauth):
             "username": "test_user",
             "user_id": 123,
             "access_token": TEST_TOKEN,
+            "refresh_token": TEST_TOKEN,
         }
 
         with pytest.raises(HTTPException) as e:

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -78,7 +78,7 @@ def mock_gitlab_api():
         def get_rms_user_by_id(user_id: int):
             return RmsUser(id=TEST_USER_ID, username=TEST_USERNAME, name=TEST_STUDENT_NAME)
 
-        def check_user_authenticated_in_rms(self, access_token):
+        def check_user_authenticated_in_rms(self, oauth, oauth_access_token, oauth_refresh_token):
             return True
 
         def get_rms_user_by_username(self, username: str) -> RmsUser:
@@ -273,6 +273,7 @@ def test_course_page_only_with_valid_session(app, mock_gitlab_oauth):
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "access_token": TEST_TOKEN,
+                    "refresh_token": TEST_TOKEN,
                 }
             app.oauth = mock_gitlab_oauth
             mock_check_user_on_course.return_value = False
@@ -359,6 +360,7 @@ def test_course_page_user_sync(app, mock_gitlab_oauth, mock_course, path_and_fun
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "access_token": TEST_TOKEN,
+                    "refresh_token": TEST_TOKEN,
                 }
 
             app.oauth = mock_gitlab_oauth
@@ -379,6 +381,7 @@ def test_course_page_user_sync(app, mock_gitlab_oauth, mock_course, path_and_fun
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "access_token": TEST_TOKEN,
+                    "refresh_token": TEST_TOKEN,
                 }
 
             app.storage_api.stored_user.course_admin = True
@@ -398,6 +401,7 @@ def test_course_page_user_sync(app, mock_gitlab_oauth, mock_course, path_and_fun
                     "username": TEST_USERNAME,
                     "user_id": TEST_USER_ID,
                     "access_token": TEST_TOKEN,
+                    "refresh_token": TEST_TOKEN,
                 }
             app.storage_api.stored_user.course_admin = False
             app.storage_api.instance_admin = True


### PR DESCRIPTION
If we get a 401 error when trying to verify if the user is logged in, we try to update the token.