### PR TITLE
docs: add favicon to docs tab

### DIFF
--- a/docs/.yfm
+++ b/docs/.yfm
@@ -5,6 +5,8 @@ resources:
   style:
     - _assets/style/custom.css
 
+interface:
+    favicon-src: ../manytask/static/favicon.ico
+
 docs-viewer:
   project-name: manytask
-  favicon-src: https://github.com/manytask/identity/blob/main/favicons/favicon.ico


### PR DESCRIPTION
Now we have logo of Manytask in tab, when we watch docs