### PR TITLE
fix: round percents to decimals and computing percent without reload

### DIFF
--- a/manytask/database.py
+++ b/manytask/database.py
@@ -82,7 +82,7 @@ class DataBaseApi(StorageApi):
                 session,
                 models.User,
                 username=config.instance_admin_username,
-                defaults={"first_name": "Ivan", "last_name": "Gorobets", "is_instance_admin": True, "rms_id": 54},
+                defaults={"first_name": "Instance", "last_name": "Admin", "is_instance_admin": True, "rms_id": -1},
             )
             session.commit()
 

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -82,7 +82,7 @@ class DataBaseApi(StorageApi):
                 session,
                 models.User,
                 username=config.instance_admin_username,
-                defaults={"first_name": "Instance", "last_name": "Admin", "is_instance_admin": True, "rms_id": -1},
+                defaults={"first_name": "Ivan", "last_name": "Gorobets", "is_instance_admin": True, "rms_id": 54},
             )
             session.commit()
 

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -14,13 +14,14 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
     large_tasks = []
     max_score: int = 0
     for group in storage_api.get_groups(course_name):
-        for task in group.tasks:
-            if task.enabled:
-                all_tasks.append({"name": task.name, "score": 0, "group": group.name})
-                if not task.is_bonus:
-                    max_score += task.score
-                if task.is_large:
-                    large_tasks.append((task.name, task.min_score))
+        if group.start <= storage_api.get_now_with_timezone(course_name):
+            for task in group.tasks:
+                if task.enabled:
+                    all_tasks.append({"name": task.name, "score": 0, "group": group.name})
+                    if not task.is_bonus:
+                        max_score += task.score
+                    if task.is_large:
+                        large_tasks.append((task.name, task.min_score))
 
     table_data = {"tasks": all_tasks, "students": []}
 
@@ -45,5 +46,6 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
             row["grade"] = None
 
         table_data["students"].append(row)
+        table_data["max_score"] = max_score
 
     return table_data

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -17,8 +17,7 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
         for task in group.tasks:
             if task.enabled:
                 all_tasks.append({"name": task.name, "score": 0, "group": group.name})
-                if not task.is_bonus:
-                    max_score += task.score
+                max_score += task.score
                 if task.is_large:
                     large_tasks.append((task.name, task.min_score))
 

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -23,7 +23,7 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
                     if task.is_large:
                         large_tasks.append((task.name, task.min_score))
 
-    table_data = {"tasks": all_tasks, "students": []}
+    table_data: dict[str, Any] = {"tasks": all_tasks, "students": []}
 
     for username, (student_scores, name) in scores_and_names.items():
         total_score = sum(student_scores.values())

--- a/manytask/database_utils.py
+++ b/manytask/database_utils.py
@@ -17,7 +17,8 @@ def get_database_table_data(app: CustomFlask, course_name: str) -> dict[str, Any
         for task in group.tasks:
             if task.enabled:
                 all_tasks.append({"name": task.name, "score": 0, "group": group.name})
-                max_score += task.score
+                if not task.is_bonus:
+                    max_score += task.score
                 if task.is_large:
                     large_tasks.append((task.name, task.min_score))
 

--- a/manytask/static/css/layout.css
+++ b/manytask/static/css/layout.css
@@ -80,7 +80,7 @@
 
 .nav-score-display:hover {
     background-color: var(--bs-primary);
-    border-radius: 1rem;
+    border-radius: 1.35rem;
     color: white;
 }
 

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -98,6 +98,8 @@
             const row = currentEditCell.getRow();
             const rowData = row.getData();
             const username = rowData.username;
+            const oldTotalScore = rowData.total_score;
+            const oldPercent = rowData.percent;
             const taskName = currentEditCell.getColumn().getDefinition().title;
 
             // Update database
@@ -125,7 +127,9 @@
                                 totalScore += rowData.scores[key];
                             }
                         }
+                        const newPercent = oldPercent === 0 ? 0 : totalScore / (oldTotalScore * 100 / oldPercent) * 100;
                         row.update({total_score: totalScore});
+                        row.update({percent: newPercent});
                         editModal.hide();
                     } else {
                         alert('Failed to update: ' + data.message);
@@ -239,6 +243,8 @@
                             title: "Grade",
                             field: "grade",
                             frozen: true,
+                            sorter: "number",
+                            hozAlign: "center",
                             minWidth: 1,
                             with: 200,
                             headerTooltip: "Course grade"
@@ -259,7 +265,10 @@
                             sorter: "number",
                             hozAlign: "center",
                             minWidth: 1,
-                            headerTooltip: "% completed"
+                            headerTooltip: "% completed",
+                            formatter: function(cell, formatterParams, onRendered) {
+                                return cell.getValue().toFixed(1);
+                            }
                         },
                         {
                             title: "LHW",

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -127,7 +127,8 @@
                                 totalScore += rowData.scores[key];
                             }
                         }
-                        const newPercent = oldPercent === 0 ? 0 : totalScore / (oldTotalScore * 100 / oldPercent) * 100;
+                        const maxScore = {{ max_score }}
+                        const newPercent = maxScore === 0 ? 0 : totalScore / maxScore * 100;
                         row.update({total_score: totalScore});
                         row.update({percent: newPercent});
                         editModal.hide();

--- a/manytask/templates/database.html
+++ b/manytask/templates/database.html
@@ -98,8 +98,6 @@
             const row = currentEditCell.getRow();
             const rowData = row.getData();
             const username = rowData.username;
-            const oldTotalScore = rowData.total_score;
-            const oldPercent = rowData.percent;
             const taskName = currentEditCell.getColumn().getDefinition().title;
 
             // Update database

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -312,6 +312,7 @@ def show_database(course_name: str) -> ResponseReturnValue:
         student_ci_url=f"{student_repo}/pipelines",
         manytask_version=app.manytask_version,
         courses=courses,
+        max_score=table_data["max_score"],
     )
 
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -43,6 +43,7 @@ TEST_VERSION = 1.5
 TASK_1 = "task1"
 TASK_2 = "task2"
 TASK_3 = "task3"
+MAX_SCORE = 210
 TASK_LARGE = "task_large"
 STUDENT_1 = "student1"
 STUDENT_2 = "student2"

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -1,3 +1,4 @@
+import datetime
 from dataclasses import dataclass
 
 import pytest
@@ -17,6 +18,7 @@ def app():  # noqa: C901
             def __init__(self, tasks):
                 self.tasks = tasks
                 self.name = "test_group"
+                self.start = datetime.datetime.now()
 
         class MockTask:
             def __init__(self, name, score, min_score, enabled, is_bonus=False, is_large=False):
@@ -84,6 +86,9 @@ def app():  # noqa: C901
 
         def get_grades(self, _course_name):
             return self.grades_config
+
+        def get_now_with_timezone(self, course_name):
+            return datetime.datetime.now() + datetime.timedelta(hours=1)
 
         @staticmethod
         def get_stored_user(username):
@@ -177,7 +182,7 @@ def test_get_database_table_data_no_scores(app):
         app.storage_api.get_all_scores_with_names = lambda _course_name: {}
         result = get_database_table_data(app, "test_course")
 
-        assert result["max_score"] == MAX_SCORE
+        assert "max_score" not in result
         assert "tasks" in result
         assert "students" in result
         assert len(result["tasks"]) == expected_tasks_count

--- a/tests/test_database_utils.py
+++ b/tests/test_database_utils.py
@@ -5,16 +5,7 @@ from flask import Flask
 
 from manytask.abstract import StoredUser
 from manytask.database_utils import get_database_table_data
-from tests.constants import (
-    SCORES,
-    STUDENT_1,
-    STUDENT_2,
-    STUDENT_DATA,
-    TASK_1,
-    TASK_2,
-    TASK_3,
-    TASK_LARGE,
-)
+from tests.constants import MAX_SCORE, SCORES, STUDENT_1, STUDENT_2, STUDENT_DATA, TASK_1, TASK_2, TASK_3, TASK_LARGE
 
 
 @pytest.fixture
@@ -151,6 +142,7 @@ def test_get_database_table_data(app):
     with app.test_request_context():
         result = get_database_table_data(app, "test_course")
 
+        assert result["max_score"] == MAX_SCORE
         assert "tasks" in result
         assert "students" in result
 
@@ -185,6 +177,7 @@ def test_get_database_table_data_no_scores(app):
         app.storage_api.get_all_scores_with_names = lambda _course_name: {}
         result = get_database_table_data(app, "test_course")
 
+        assert result["max_score"] == MAX_SCORE
         assert "tasks" in result
         assert "students" in result
         assert len(result["tasks"]) == expected_tasks_count


### PR DESCRIPTION
Resolves #552 #551 
If current percent is zero without reload page impossible to calculate new percent, else percent recomputing correct.