### PR TITLE
fix: User creation on login

### DIFF
--- a/manytask/database.py
+++ b/manytask/database.py
@@ -79,7 +79,7 @@ class DataBaseApi(StorageApi):
 
         # Create the zero-instance admin user if it does not exist
         with self._session_create() as session:
-            self._update_or_create(
+            self._get_or_create(
                 session,
                 models.User,
                 username=config.instance_admin_username,
@@ -1173,7 +1173,14 @@ class DataBaseApi(StorageApi):
     ) -> ModelType:
         try:
             instance = DataBaseApi._query_with_for_update(session, model, **kwargs)
-            return DataBaseApi._create_or_update_instance(session, model, instance, defaults, **kwargs)
+            return DataBaseApi._create_or_update_instance(
+                session,
+                model,
+                instance,
+                defaults=None,
+                **kwargs,
+                **(defaults or {}),
+            )
         except Exception:
             session.rollback()
             raise

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -1178,8 +1178,8 @@ class DataBaseApi(StorageApi):
                 session,
                 model,
                 instance,
-                defaults = None,
-                create_defaults = defaults,
+                defaults=None,
+                create_defaults=defaults,
                 **kwargs,
             )
         except Exception:

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -79,11 +79,12 @@ class DataBaseApi(StorageApi):
 
         # Create the zero-instance admin user if it does not exist
         with self._session_create() as session:
-            self._get_or_create(
+            self._update_or_create(
                 session,
                 models.User,
                 username=config.instance_admin_username,
-                defaults={"first_name": "Instance", "last_name": "Admin", "is_instance_admin": True, "rms_id": -1},
+                defaults={"is_instance_admin": True},
+                create_defaults={"first_name": "Instance", "last_name": "Admin", "rms_id": -1},
             )
             session.commit()
 
@@ -1177,9 +1178,9 @@ class DataBaseApi(StorageApi):
                 session,
                 model,
                 instance,
-                defaults=None,
+                defaults = None,
+                create_defaults = defaults,
                 **kwargs,
-                **(defaults or {}),
             )
         except Exception:
             session.rollback()

--- a/manytask/database.py
+++ b/manytask/database.py
@@ -646,10 +646,12 @@ class DataBaseApi(StorageApi):
             self._get_or_create(
                 session,
                 models.User,
+                defaults=dict(
+                    first_name=first_name,
+                    rms_id=rms_id,
+                    last_name=last_name,
+                ),
                 username=username,
-                first_name=first_name,
-                rms_id=rms_id,
-                last_name=last_name,
             )
             session.commit()
 

--- a/manytask/utils.py
+++ b/manytask/utils.py
@@ -2,6 +2,7 @@ import secrets
 
 from flask import session, url_for
 
+from manytask.abstract import RmsUser
 from manytask.main import CustomFlask
 
 
@@ -37,3 +38,12 @@ def check_admin(app: CustomFlask) -> bool:
     else:
         student_username = session["gitlab"]["username"]
         return app.storage_api.check_if_instance_admin(student_username)
+
+
+def guess_first_last_name(user: RmsUser) -> tuple[str, str]:
+    # TODO: implement better method for separating names
+    name = user.name
+    parts = name.split()
+    if len(parts) == 2:
+        return tuple(parts) # type: ignore
+    return name, ""

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -16,7 +16,7 @@ from .auth import handle_oauth_callback, requires_admin, requires_auth, requires
 from .course import Course, CourseConfig, CourseStatus, get_current_time
 from .database_utils import get_database_table_data
 from .main import CustomFlask
-from .utils import check_admin, generate_token_hex, get_courses
+from .utils import check_admin, generate_token_hex, get_courses, guess_first_last_name
 
 SESSION_VERSION = 1.5
 CACHE_TIMEOUT_SECONDS = 3600
@@ -221,7 +221,7 @@ def create_project(course_name: str) -> ResponseReturnValue:
             base_url=app.rms_api.base_url,
         )
 
-    first_name, last_name = rms_user.name.split()  # TODO: come up with how to separate names
+    first_name, last_name = guess_first_last_name(rms_user)
     app.storage_api.create_user_if_not_exist(rms_user.username, first_name, last_name, rms_user.id)
 
     app.storage_api.sync_user_on_course(course.course_name, rms_user.username, is_course_admin)


### PR DESCRIPTION
If the user was originally registered on gitlab, corresponding entity is not created in manytask upon login. This also means, I can't transfer admin rights to other user before creating a new course