### PR TITLE
refactor: Remove black from the package list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ flake8 = "7.3.0"
 ruff = "0.13.1"
 mypy = "1.18.2"
 isort = "6.0.1"
-black = "25.1.0"
 types-requests = "2.32.0.20240907"
 types-PyYAML = "6.0.12.12"
 pytest = "8.4.0"
@@ -83,10 +82,6 @@ testpaths = [
     "tests",
     ".tmp"
 ]
-
-[tool.black]
-line-length = 120
-target-version = ["py312"]
 
 
 [tool.ruff]


### PR DESCRIPTION
Black is not used any more. There should be more unused packages.