### PR TITLE
fix: resolve session profile mismatch security vulnerability

### DIFF
--- a/manytask/api.py
+++ b/manytask/api.py
@@ -351,7 +351,11 @@ def get_database(course_name: str, auth_method: AuthMethod) -> ResponseReturnVal
     if auth_method == AuthMethod.SESSION:
         rms_user = app.rms_api.get_rms_user_by_id(session["gitlab"]["user_id"])
         is_course_admin = storage_api.check_if_course_admin(course.course_name, rms_user.username)
-        logger.info("[DEBUG] API /database auth_method=SESSION, username=%s, is_course_admin=%s", rms_user.username, is_course_admin)
+        logger.info(
+            "[DEBUG] API /database auth_method=SESSION, username=%s, is_course_admin=%s",
+            rms_user.username,
+            is_course_admin,
+        )
     else:
         is_course_admin = True
         logger.info("[DEBUG] API /database auth_method=COURSE_TOKEN, is_course_admin=True (by default)")

--- a/manytask/api.py
+++ b/manytask/api.py
@@ -351,8 +351,10 @@ def get_database(course_name: str, auth_method: AuthMethod) -> ResponseReturnVal
     if auth_method == AuthMethod.SESSION:
         rms_user = app.rms_api.get_rms_user_by_id(session["gitlab"]["user_id"])
         is_course_admin = storage_api.check_if_course_admin(course.course_name, rms_user.username)
+        logger.info("[DEBUG] API /database auth_method=SESSION, username=%s, is_course_admin=%s", rms_user.username, is_course_admin)
     else:
         is_course_admin = True
+        logger.info("[DEBUG] API /database auth_method=COURSE_TOKEN, is_course_admin=True (by default)")
 
     logger.info("Fetching database snapshot for course=%s", course_name)
     table_data = get_database_table_data(app, course, include_admin_data=is_course_admin)
@@ -372,7 +374,7 @@ def update_database(course_name: str, auth_method: AuthMethod) -> ResponseReturn
     storage_api = app.storage_api
 
     if auth_method == AuthMethod.SESSION:
-        username = session["profile"]["username"]
+        username = session["gitlab"]["username"]
         logger.info("Request by admin=%s for course=%s", username, course_name)
         student_course_admin = storage_api.check_if_course_admin(course_name, username)
 
@@ -445,10 +447,10 @@ def update_comment(course_name: str) -> ResponseReturnValue:
 
     storage_api = app.storage_api
 
-    profile_username_ = session["profile"]["username"]
-    logger.info("Comment update request by user=%s for course=%s", profile_username_, course_name)
+    username = session["gitlab"]["username"]
+    logger.info("Comment update request by user=%s for course=%s", username, course_name)
 
-    student_course_admin = storage_api.check_if_course_admin(course.course_name, profile_username_)
+    student_course_admin = storage_api.check_if_course_admin(course.course_name, username)
 
     if not student_course_admin:
         return jsonify({"success": False, "message": "Only course admins can update comments"}), HTTPStatus.FORBIDDEN

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -103,7 +103,6 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
     app.register_blueprint(web.course_bp)
     app.register_blueprint(web.admin_bp)
 
-
     # debug updates
     if app.debug:
         _create_debug_course(app)

--- a/manytask/main.py
+++ b/manytask/main.py
@@ -47,6 +47,10 @@ class CustomFlask(Flask):
 def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
     app = CustomFlask(__name__)
 
+    logger = logging.getLogger(__name__)
+
+    logger.info(f"[DEBUG] debug parameter passed to create_app: {debug}")
+
     if debug:
         app.debug = debug
 
@@ -99,7 +103,6 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
     app.register_blueprint(web.course_bp)
     app.register_blueprint(web.admin_bp)
 
-    logger = logging.getLogger(__name__)
 
     # debug updates
     if app.debug:

--- a/manytask/utils/flask.py
+++ b/manytask/utils/flask.py
@@ -7,10 +7,11 @@ def get_courses(app: CustomFlask) -> list[dict[str, str]]:
     if app.debug:
         courses_names = app.storage_api.get_all_courses_names_with_statuses()
 
-    if app.storage_api.check_if_instance_admin(session["profile"]["username"]):
+    username = session["gitlab"]["username"]
+    if app.storage_api.check_if_instance_admin(username):
         courses_names = app.storage_api.get_all_courses_names_with_statuses()
     else:
-        courses_names = app.storage_api.get_user_courses_names_with_statuses(session["profile"]["username"])
+        courses_names = app.storage_api.get_user_courses_names_with_statuses(username)
 
     return [
         {

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -237,8 +237,11 @@ def signup_finish() -> ResponseReturnValue:  # noqa: PLR0911
             return redirect(url_for("root.index"))
         else:
             # Profile mismatch - user switched accounts, clear old profile
-            logger.warning("Profile mismatch: session profile=%s, gitlab=%s - clearing old profile",
-                         session["profile"]["username"], session["gitlab"]["username"])
+            logger.warning(
+                "Profile mismatch: session profile=%s, gitlab=%s - clearing old profile",
+                session["profile"]["username"],
+                session["gitlab"]["username"],
+            )
             session.pop("profile", None)
 
     stored_user_or_none = app.storage_api.get_stored_user_by_rms_id(session["gitlab"]["user_id"])

--- a/manytask/web.py
+++ b/manytask/web.py
@@ -113,7 +113,7 @@ def course_page(course_name: str) -> ResponseReturnValue:
         student_repo = app.rms_api.get_url_for_repo(
             username=student_username, course_students_group=course.gitlab_course_students_group
         )
-        student_course_admin = storage_api.check_if_course_admin(course.course_name, session["profile"]["username"])
+        student_course_admin = storage_api.check_if_course_admin(course.course_name, student_username)
 
     # update cache if more than 1h passed or in debug mode
     try:
@@ -230,9 +230,16 @@ def signup_finish() -> ResponseReturnValue:  # noqa: PLR0911
     if not valid_gitlab_session(session):
         return redirect_to_login_with_bad_session()
 
+    # Check if profile matches the current GitLab user
     if valid_client_profile_session(session):
-        logger.warning("User already has username=%s in session", session["profile"]["username"])
-        return redirect(url_for("root.index"))
+        if session["profile"]["username"] == session["gitlab"]["username"]:
+            logger.warning("User already has username=%s in session", session["profile"]["username"])
+            return redirect(url_for("root.index"))
+        else:
+            # Profile mismatch - user switched accounts, clear old profile
+            logger.warning("Profile mismatch: session profile=%s, gitlab=%s - clearing old profile",
+                         session["profile"]["username"], session["gitlab"]["username"])
+            session.pop("profile", None)
 
     stored_user_or_none = app.storage_api.get_stored_user_by_rms_id(session["gitlab"]["user_id"])
     if stored_user_or_none is not None:
@@ -308,7 +315,7 @@ def create_project(course_name: str) -> ResponseReturnValue:
             base_url=app.rms_api.base_url,
         )
 
-    app.storage_api.sync_user_on_course(course.course_name, session["profile"]["username"], is_course_admin)
+    app.storage_api.sync_user_on_course(course.course_name, rms_user.username, is_course_admin)
 
     # Create use if needed
     try:
@@ -366,10 +373,13 @@ def show_database(course_name: str) -> ResponseReturnValue:
             username=student_username, course_students_group=course.gitlab_course_students_group
         )
 
-        student_course_admin = storage_api.check_if_course_admin(course.course_name, session["profile"]["username"])
+        student_course_admin = storage_api.check_if_course_admin(course.course_name, student_username)
+        logger.info("[DEBUG] WEB /database username=%s, is_course_admin=%s", student_username, student_course_admin)
 
     scores = storage_api.get_scores(course.course_name, student_username)
     bonus_score = storage_api.get_bonus_score(course.course_name, student_username)
+
+    logger.info("[DEBUG] WEB /database rendering template with is_course_admin=%s", student_course_admin)
 
     return render_template(
         "database.html",


### PR DESCRIPTION
## Problem
The application used session["profile"]["username"] for authorization checks,
but this profile was not synchronized with the currently authenticated user
session["gitlab"]["username"]. This created a critical security vulnerability:

- If User A logged in, then User B logged in using the same browser, User B
  would receive User A's permissions
- This allowed unauthorized access to admin features and other users' data

## Root Cause
The profile was set once during signup and never updated when users switched
accounts. The code relied on this stale profile data for authorization decisions.

## Solution
1. Add profile validation in signup_finish() endpoint to detect and clear
   mismatched profiles
2. Replace all uses of session["profile"]["username"] with
   session["gitlab"]["username"] in authorization checks

## Changes
- manytask/web.py: 
  - Add profile mismatch detection in signup_finish (lines 233-242)
  - Fix authorization checks in course_page, show_database, create_project
- manytask/api.py:
  - Fix authorization in update_database and update_comment endpoints
- manytask/utils/flask.py:
  - Fix user identification in get_courses helper

## Security Impact
This vulnerability allowed privilege escalation and unauthorized data access.
The fix ensures that authorization checks always use the current user's identity.

## Testing
Manually verified that switching between admin and non-admin accounts now
correctly enforces permissions.