### PR TITLE
feat: add local GitLab for development

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -55,7 +55,43 @@ services:
             timeout: 5s
             retries: 5
 
+    gitlab:
+        image: gitlab/gitlab-ce:latest
+        container_name: manytask_gitlab
+        restart: always
+        hostname: gitlab
+        environment:
+            GITLAB_ROOT_PASSWORD: "changeme123!"
+            GITLAB_OMNIBUS_CONFIG: |
+                external_url 'http://localhost:8929'
+                gitlab_rails['gitlab_shell_ssh_port'] = 8222
+        ports:
+            - "8929:8929"    # HTTP web UI
+            - "8222:22"      # SSH (optional)
+        volumes:
+            - gitlab_config:/etc/gitlab
+            - gitlab_logs:/var/log/gitlab
+            - gitlab_data:/var/opt/gitlab
+
+    gitlab-runner:
+        image: gitlab/gitlab-runner:alpine
+        container_name: manytask_gitlab_runner
+        restart: always
+        volumes:
+            - gitlab_runner_config:/etc/gitlab-runner
+            - /var/run/docker.sock:/var/run/docker.sock
+        depends_on:
+            - gitlab
+
 
 volumes:
     postgres_data:
         name: manytask_postgres_data
+    gitlab_config:
+        name: manytask_gitlab_config
+    gitlab_logs:
+        name: manytask_gitlab_logs
+    gitlab_data:
+        name: manytask_gitlab_data
+    gitlab_runner_config:
+        name: manytask_gitlab_runner_config

--- a/docs/local_oauth_flow.md
+++ b/docs/local_oauth_flow.md
@@ -1,0 +1,299 @@
+# OAuth Authentication Flow in Local Development
+
+This document explains how OAuth authentication works in local development when Manytask and GitLab run in Docker containers.
+
+## Purpose
+
+Use this guide when you:
+
+- run Manytask locally with Docker,
+- use a local GitLab instance,
+- want to understand why OAuth needs different internal and external URLs,
+- need a stable startup sequence and troubleshooting steps.
+
+## Prerequisites
+
+- Docker and Docker Compose installed.
+- Colima installed (macOS).
+- Local project configured with `docker-compose.development.yml`.
+
+### Minimum Colima configuration for local GitLab
+
+GitLab needs enough RAM to become healthy. Start Colima with at least:
+
+```bash
+colima start --memory 4 --cpu 2 --disk 100
+```
+
+You can verify current resources with:
+
+```bash
+colima list
+```
+
+## URL model used by OAuth
+
+Manytask uses two GitLab URLs in local development:
+
+- `GITLAB_OAUTH_URL`: browser-facing URL (for redirects), usually `http://localhost:8929`
+- `GITLAB_URL`: internal API URL used by Manytask container for token and userinfo calls
+
+Typical values:
+
+```bash
+GITLAB_OAUTH_URL=http://localhost:8929
+GITLAB_URL=http://gitlab:8929
+```
+
+If your container network setup does not resolve `gitlab`, use:
+
+```bash
+GITLAB_URL=http://host.docker.internal:8929
+```
+
+## Quick start
+
+Start the environment:
+
+```bash
+./scripts/start_local_dev.sh
+```
+
+This script does the following:
+
+1. Starts Docker containers.
+2. Waits for GitLab readiness.
+3. Runs `scripts/setup_local_gitlab.sh`.
+4. Creates or reuses:
+   - admin PAT,
+   - OAuth app,
+   - runner registration.
+5. Appends missing GitLab keys to `.env`.
+6. Restarts Manytask to pick up updated env vars.
+
+## OAuth flow: step by step
+
+### 1. User starts sign-in
+
+The browser opens Manytask and user clicks "Sign in with GitLab":
+
+- Browser requests `http://localhost:8081/login`.
+- Manytask returns redirect to GitLab authorization endpoint.
+
+### 2. Authorization redirect (browser)
+
+Manytask builds URL using `GITLAB_OAUTH_URL`:
+
+```http
+GET http://localhost:8929/oauth/authorize?...&redirect_uri=http://localhost:8081/login_finish
+```
+
+This must be browser-accessible.
+
+### 3. GitLab authenticates user
+
+GitLab shows sign-in / approval page.
+After approval, GitLab redirects back to Manytask with `code` and `state`:
+
+```http
+GET http://localhost:8081/login_finish?code=...&state=...
+```
+
+### 4. Token exchange (container-to-container)
+
+Manytask backend exchanges `code` for `access_token` using `GITLAB_URL`:
+
+```http
+POST <GITLAB_URL>/oauth/token
+```
+
+This request is sent from the Manytask container, not from the browser.
+
+### 5. Userinfo fetch (container-to-container)
+
+Manytask fetches user profile:
+
+```http
+GET <GITLAB_URL>/oauth/userinfo
+Authorization: Bearer <access_token>
+```
+
+### 6. Session is created
+
+Manytask stores OAuth data in Flask session and redirects user to signup/login finish routes.
+
+## Why two URLs are required
+
+OAuth in Docker has two traffic paths:
+
+1. Browser to GitLab (`GITLAB_OAUTH_URL`):
+   - user-facing redirects,
+   - must be reachable from host machine browser.
+2. Manytask container to GitLab (`GITLAB_URL`):
+   - token exchange,
+   - userinfo and API calls,
+   - must be reachable from inside the Manytask container.
+
+Using one URL for both paths often fails in local Docker setups.
+
+## Code reference
+
+OAuth registration is configured in `manytask/main.py`:
+
+```python
+def _authenticate(oauth: OAuth, internal_url: str, external_url: str, client_id: str, client_secret: str) -> OAuth:
+    oauth.register(
+        name="gitlab",
+        client_id=client_id,
+        client_secret=client_secret,
+        authorize_url=f"{external_url}/oauth/authorize",
+        access_token_url=f"{internal_url}/oauth/token",
+        userinfo_endpoint=f"{internal_url}/oauth/userinfo",
+        jwks_uri=f"{internal_url}/oauth/discovery/keys",
+        client_kwargs={
+            "scope": "openid email profile read_user",
+            "code_challenge_method": "S256",
+        },
+    )
+    return oauth
+```
+
+Config fields are defined in `manytask/local_config.py`:
+
+- `gitlab_url`
+- `gitlab_oauth_url`
+- `gitlab_client_id`
+- `gitlab_client_secret`
+
+## What setup script configures
+
+`scripts/setup_local_gitlab.sh` does:
+
+- waits for GitLab web endpoint,
+- creates or reuses root PAT (`manytask-admin`),
+- creates or reuses OAuth app (`manytask-local`),
+- reads runner registration token,
+- tries to register local runner,
+- appends missing values to `.env` without overwriting existing keys.
+
+Keys appended when missing:
+
+- `GITLAB_URL`
+- `GITLAB_OAUTH_URL`
+- `GITLAB_ADMIN_TOKEN`
+- `GITLAB_CLIENT_ID`
+- `GITLAB_CLIENT_SECRET`
+
+## Troubleshooting
+
+### GitLab does not become ready
+
+Symptoms:
+
+- startup script times out waiting for `/users/sign_in`.
+
+Actions:
+
+1. Check Colima resources (`colima list`).
+2. Start Colima with minimum config:
+
+```bash
+colima start --memory 4 --cpu 2 --disk 100
+```
+
+3. Check logs:
+
+```bash
+docker logs -f manytask_gitlab
+```
+
+### Token exchange fails with connection errors
+
+Symptoms:
+
+- errors on `/oauth/token`,
+- browser returns to login loop,
+- `Connection refused` in Manytask logs.
+
+Actions:
+
+1. Check that container can reach `GITLAB_URL`:
+
+```bash
+docker exec test-manytask sh -lc 'curl -fsS $GITLAB_URL/users/sign_in >/dev/null && echo OK'
+```
+
+2. If `gitlab` hostname is not resolvable in your setup, set:
+
+```bash
+GITLAB_URL=http://host.docker.internal:8929
+```
+
+3. Restart Manytask container.
+
+### OAuth scope errors
+
+Symptoms:
+
+- GitLab returns invalid scope / malformed scope.
+
+Cause:
+
+- OAuth app created with incomplete scopes.
+
+Fix:
+
+- rerun setup script:
+
+```bash
+./scripts/setup_local_gitlab.sh
+```
+
+The script updates app scopes to:
+
+- `openid email profile read_user api`
+
+### Runner registration returns 502
+
+This does not block Manytask OAuth login flow.
+You can continue local app testing and debug runner separately.
+
+## Useful commands
+
+Start full local stack:
+
+```bash
+./scripts/start_local_dev.sh
+```
+
+Check containers:
+
+```bash
+docker-compose -f docker-compose.development.yml ps
+```
+
+Manytask logs:
+
+```bash
+docker logs -f test-manytask
+```
+
+GitLab logs:
+
+```bash
+docker logs -f manytask_gitlab
+```
+
+Stop stack:
+
+```bash
+docker-compose -f docker-compose.development.yml down
+```
+
+## References
+
+- OAuth 2.0: https://datatracker.ietf.org/doc/html/rfc6749
+- PKCE: https://datatracker.ietf.org/doc/html/rfc7636
+- OpenID Connect: https://openid.net/specs/openid-connect-core-1_0.html
+- GitLab OAuth docs: https://docs.gitlab.com/ee/api/oauth2.html
+- Authlib Flask client: https://docs.authlib.org/en/latest/client/flask.html

--- a/manytask/local_config.py
+++ b/manytask/local_config.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 class LocalConfig:
     # gitlab
     gitlab_url: str
+    gitlab_oauth_url: str  # URL for OAuth redirects (accessible from browser)
     gitlab_admin_token: str
     gitlab_verify_ssl: bool
 
@@ -17,9 +18,11 @@ class LocalConfig:
 
     @classmethod
     def from_env(cls) -> LocalConfig:
+        gitlab_url = os.environ.get("GITLAB_URL", "https://gitlab.manytask2.org")
         return cls(
             # gitlab
-            gitlab_url=os.environ.get("GITLAB_URL", "https://gitlab.manytask2.org"),
+            gitlab_url=gitlab_url,
+            gitlab_oauth_url=os.environ.get("GITLAB_OAUTH_URL", gitlab_url),  # fallback to GITLAB_URL if not set
             gitlab_admin_token=os.environ["GITLAB_ADMIN_TOKEN"],
             gitlab_verify_ssl=os.environ.get("GITLAB_VERIFY_SSL", "true").lower() in ("true", "1", "yes"),
             # gitlab oauth2
@@ -32,6 +35,7 @@ class LocalConfig:
 class DebugLocalConfig(LocalConfig):
     # gitlab
     gitlab_url: str = "https://gitlab.manytask2.org"
+    gitlab_oauth_url: str = "https://gitlab.manytask2.org"
     gitlab_admin_token: str = ""
     gitlab_verify_ssl: bool = True
 

--- a/scripts/setup_local_gitlab.sh
+++ b/scripts/setup_local_gitlab.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script bootstraps a local GitLab for manytask:
+# 1) Waits for GitLab HTTP to be ready
+# 2) Creates/reads an admin PAT
+# 3) Creates/reads an OAuth app for manytask and grabs client_id/secret
+# 4) Reads the runners registration token
+# 5) Registers the gitlab-runner container
+# 6) Appends all secrets into .env (non-destructive)
+
+GITLAB_CONTAINER="${GITLAB_CONTAINER:-manytask_gitlab}"
+RUNNER_CONTAINER="${RUNNER_CONTAINER:-manytask_gitlab_runner}"
+MANYTASK_ENV="${MANYTASK_ENV:-.env}"
+
+# Host URL for readiness check (external); internal URL for env variables
+HOST_GITLAB_URL="${HOST_GITLAB_URL:-http://localhost:8929}"
+# Internal URL for API calls between containers
+GITLAB_URL="${GITLAB_URL:-http://gitlab:8929}"
+# OAuth URL accessible from browser (external)
+GITLAB_OAUTH_URL="${GITLAB_OAUTH_URL:-http://localhost:8929}"
+REDIRECT_URI="${REDIRECT_URI:-http://localhost:8081/login_finish}"
+
+RUNNER_EXECUTOR="${RUNNER_EXECUTOR:-docker}"
+RUNNER_IMAGE="${RUNNER_IMAGE:-alpine:latest}"
+
+log() { echo "[setup] $*"; }
+err() { echo "[setup][error] $*" >&2; }
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || { err "Command '$1' not found"; exit 1; }
+}
+
+wait_for_gitlab() {
+    log "Waiting for GitLab at ${HOST_GITLAB_URL}..."
+    for i in {1..60}; do
+        if curl -fsS "${HOST_GITLAB_URL}/users/sign_in" >/dev/null 2>&1; then
+            log "GitLab is responding."
+            return
+        fi
+        sleep 5
+    done
+    err "GitLab did not become ready in time."
+    exit 1
+}
+
+rails_runner() {
+    docker exec -i "${GITLAB_CONTAINER}" sh -lc "gitlab-rails runner \"$1\""
+}
+
+ensure_env_line() {
+    local key="$1" value="$2"
+    if ! grep -q "^${key}=" "${MANYTASK_ENV}" 2>/dev/null; then
+        printf "%s=%s\n" "${key}" "${value}" >> "${MANYTASK_ENV}"
+    else
+        log "Key ${key} already present in ${MANYTASK_ENV}, leaving as is."
+    fi
+}
+
+main() {
+    require_cmd docker
+    require_cmd curl
+
+    wait_for_gitlab
+
+    log "Creating/retrieving admin PAT..."
+    ADMIN_PAT=$(rails_runner "
+        user = User.find_by_username('root')
+        pat  = user.personal_access_tokens.find_by(name: 'manytask-admin')
+        unless pat
+          pat = user.personal_access_tokens.create!(
+            name: 'manytask-admin',
+            scopes: [:api, :read_user, :read_api, :write_repository, :sudo],
+            expires_at: 1.year.from_now.to_date
+          )
+          pat.set_token(SecureRandom.hex(32))
+          pat.save!
+        end
+        puts pat.token
+    ")
+    log "Admin PAT acquired."
+
+    log "Creating/retrieving OAuth app..."
+    OAUTH_DATA=$(rails_runner "
+        app = Doorkeeper::Application.find_by(name: 'manytask-local')
+        if app
+          # Update existing app with correct scopes
+          app.update!(
+            redirect_uri: '${REDIRECT_URI}',
+            scopes: 'openid email profile read_user api'
+          )
+        else
+          # Create new app with all required scopes
+          app = Doorkeeper::Application.create!(
+            name: 'manytask-local',
+            redirect_uri: '${REDIRECT_URI}',
+            scopes: 'openid email profile read_user api',
+            confidential: true
+          )
+        end
+        puts [app.uid, app.secret].join(':')
+    ")
+    GITLAB_CLIENT_ID="${OAUTH_DATA%%:*}"
+    GITLAB_CLIENT_SECRET="${OAUTH_DATA#*:}"
+    log "OAuth app ready. Client ID: ${GITLAB_CLIENT_ID}"
+
+    log "Fetching runners registration token..."
+    RUNNERS_TOKEN=$(rails_runner "puts Gitlab::CurrentSettings.current_application_settings.runners_registration_token")
+
+    log "Registering runner container..."
+    docker exec -i "${RUNNER_CONTAINER}" gitlab-runner register \
+        --non-interactive \
+        --url "${GITLAB_URL}" \
+        --registration-token "${RUNNERS_TOKEN}" \
+        --executor "${RUNNER_EXECUTOR}" \
+        --docker-image "${RUNNER_IMAGE}" \
+        --description "manytask-local-runner" \
+        --locked="false" \
+        --run-untagged="true" || log "Runner registration may have failed; check runner logs."
+
+    log "Appending secrets to ${MANYTASK_ENV} (no overwrite)..."
+    touch "${MANYTASK_ENV}"
+    ensure_env_line "GITLAB_URL" "${GITLAB_URL}"
+    ensure_env_line "GITLAB_OAUTH_URL" "${GITLAB_OAUTH_URL}"
+    ensure_env_line "GITLAB_ADMIN_TOKEN" "${ADMIN_PAT}"
+    ensure_env_line "GITLAB_CLIENT_ID" "${GITLAB_CLIENT_ID}"
+    ensure_env_line "GITLAB_CLIENT_SECRET" "${GITLAB_CLIENT_SECRET}"
+
+    log "Done. Verify runner status in GitLab UI and values in ${MANYTASK_ENV}."
+}
+
+main "$@"

--- a/scripts/start_local_dev.sh
+++ b/scripts/start_local_dev.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script starts the full local development environment:
+# 1. Starts all Docker containers
+# 2. Waits for GitLab to be ready
+# 3. Sets up GitLab OAuth and tokens
+# 4. Restarts Manytask with new environment variables
+
+COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.development.yml}"
+GITLAB_URL="${GITLAB_URL:-http://localhost:8929}"
+SETUP_SCRIPT="${SETUP_SCRIPT:-./scripts/setup_local_gitlab.sh}"
+
+log() { echo "🚀 [start] $*"; }
+err() { echo "❌ [start][error] $*" >&2; }
+
+check_requirements() {
+    log "Checking requirements..."
+
+    if ! command -v docker &> /dev/null; then
+        err "Docker is not installed or not in PATH"
+        exit 1
+    fi
+
+    if ! command -v docker-compose &> /dev/null; then
+        err "docker-compose is not installed or not in PATH"
+        exit 1
+    fi
+
+    if [ ! -f "${COMPOSE_FILE}" ]; then
+        err "Docker Compose file not found: ${COMPOSE_FILE}"
+        exit 1
+    fi
+
+    if [ ! -f "${SETUP_SCRIPT}" ]; then
+        err "Setup script not found: ${SETUP_SCRIPT}"
+        exit 1
+    fi
+
+    log "All requirements satisfied ✓"
+}
+
+start_containers() {
+    log "Starting Docker containers..."
+    docker-compose -f "${COMPOSE_FILE}" up -d
+    log "Containers started ✓"
+}
+
+wait_for_gitlab() {
+    log "Waiting for GitLab to be ready (this may take 2-3 minutes)..."
+
+    local max_attempts=60
+    local attempt=0
+
+    while [ $attempt -lt $max_attempts ]; do
+        if curl -fsS "${GITLAB_URL}/users/sign_in" >/dev/null 2>&1; then
+            log "GitLab is ready ✓"
+            return 0
+        fi
+
+        attempt=$((attempt + 1))
+
+        # Show progress every 5 attempts
+        if [ $((attempt % 5)) -eq 0 ]; then
+            log "Still waiting for GitLab... (attempt ${attempt}/${max_attempts})"
+        fi
+
+        sleep 5
+    done
+
+    err "GitLab did not become ready in time (waited $((max_attempts * 5)) seconds)"
+    err "Check GitLab logs: docker logs manytask_gitlab"
+    exit 1
+}
+
+setup_gitlab() {
+    log "Running GitLab setup script..."
+
+    if ! bash "${SETUP_SCRIPT}"; then
+        err "GitLab setup failed"
+        exit 1
+    fi
+
+    log "GitLab setup completed ✓"
+}
+
+restart_manytask() {
+    log "Restarting Manytask with new environment variables..."
+    docker-compose -f "${COMPOSE_FILE}" up -d manytask
+    log "Manytask restarted ✓"
+}
+
+show_success_message() {
+    echo ""
+    echo "✅ =========================================="
+    echo "✅  Local development environment is ready!"
+    echo "✅ =========================================="
+    echo ""
+    echo "📝 Services:"
+    echo "   • Manytask:    http://localhost:8081"
+    echo "   • GitLab:      http://localhost:8929"
+    echo "   • Docs:        http://docs.localhost"
+    echo ""
+    echo "🔑 GitLab credentials:"
+    echo "   • Username:    root"
+    echo "   • Password:    changeme123!"
+    echo ""
+    echo "📊 Check status:"
+    echo "   docker-compose -f ${COMPOSE_FILE} ps"
+    echo ""
+    echo "📋 View logs:"
+    echo "   docker logs -f test-manytask"
+    echo "   docker logs -f manytask_gitlab"
+    echo ""
+    echo "🛑 Stop all services:"
+    echo "   docker-compose -f ${COMPOSE_FILE} down"
+    echo ""
+}
+
+main() {
+    log "Starting local development environment..."
+    echo ""
+
+    check_requirements
+    start_containers
+    wait_for_gitlab
+    setup_gitlab
+    restart_manytask
+
+    show_success_message
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add local GitLab bootstrap flow for development and make OAuth URL handling explicit.

### What changed

- Add separate OAuth/browser URL support via `GITLAB_OAUTH_URL`.
- Update OAuth registration to use:
  - external URL for `authorize_url`
  - internal URL for token/userinfo/JWKS endpoints
- Extend dev compose with local GitLab and GitLab Runner services.
- Add scripts:
  - `scripts/start_local_dev.sh`
  - `scripts/setup_local_gitlab.sh`
- Rewrite `docs/local_oauth_flow.md` in English.
- Add minimum Colima requirements for local GitLab startup:
  - `colima start --memory 4 --cpu 2 --disk 100`

## How to test

1. `colima start --memory 4 --cpu 2 --disk 100`
2. `./scripts/start_local_dev.sh`
3. Open Manytask and run OAuth login flow against local GitLab.