### PR TITLE
fix: Do not try to demote group owners to mainteiners

### DIFF
--- a/manytask/glab.py
+++ b/manytask/glab.py
@@ -259,7 +259,7 @@ class GitLabApi(RmsApi, AuthApi):
                     gitlab_group_id,
                     existing_member.access_level,
                 )
-                if existing_member.access_level != gitlab.const.AccessLevel.MAINTAINER:
+                if existing_member.access_level < gitlab.const.AccessLevel.MAINTAINER:
                     existing_member.access_level = gitlab.const.AccessLevel.MAINTAINER
                     existing_member.save()
                     logger.info("Updated user id=%s access level to Maintainer", user_id)


### PR DESCRIPTION
When group is greated by the owner of gitlab token, this user is set to this group as an owner. As a result, trying to change their ownership to mainterner throws an exception before the namespace is actually created. This change leave owners in their role, so that the rest of the code works normally.