### PR TITLE
fix: change how the fields are validates by javascript

### DIFF
--- a/manytask/templates/create_course.html
+++ b/manytask/templates/create_course.html
@@ -122,11 +122,10 @@ document.addEventListener('DOMContentLoaded', function () {
     function validatePrefix(field, feedbackId) {
 
         const groupName = gitlabGroupField.value;
-        const isNoNamespace = namespaceSelect.value === '0';
+        const namespacePath = getSelectedNamespacePath();
         
         let validPrefix = "";
-        if (!isNoNamespace) {
-            const namespacePath = getSelectedNamespacePath();
+        if (namespacePath) {
             validPrefix = validPrefix + namespacePath + '/';
         }
         if (groupName) {


### PR DESCRIPTION
After namespaces were introduced, the name of the course students group and public repo may start by the namespace slug, not only by the course group. The checks in JavaScript did not reflect this. This change allows the student group and public repo to start by the namespace if the later is defined.