### PR TITLE
fix: remove invalid uv install command from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ install-deps:
 	uv sync --active --all-extras
 
 install-hooks:
-	uv install
 	uv run pre-commit install --install-hooks
 
 run-hooks:


### PR DESCRIPTION
make setup` fails at the `install-hooks` target because `uv install` is not a valid uv subcommand. 
Dependencies are already installed by `uv sync` in the `install-deps` target, so the line is redundant.

Closes #835 

**Test plan**

- [ ] Run `make setup` — should complete without errors