### PR TITLE
feat: Improve error reporting for /report API (fixes #702)

### DIFF
--- a/checker/checker/pipeline.py
+++ b/checker/checker/pipeline.py
@@ -7,7 +7,7 @@ from typing import Any
 import jinja2.nativetypes
 
 from .configs import PipelineStageConfig
-from .exceptions import BadConfig, PluginExecutionFailed
+from .exceptions import BadConfig, PluginExecutionFailed, TestingError
 from .plugins import PluginABC
 from .utils import print_info
 
@@ -222,11 +222,15 @@ class PipelineRunner:
         if allow_partial:
             print_info("error! (ignored due to partially_scored)", color="yellow")
 
+        # Include both output and message in stage result so failures can be reported later (e.g. in tester)
+        failure_output = error.output or ""
+        if error.message and error.message != str(TestingError):
+            failure_output = f"{failure_output}\nError: {error.message}".lstrip()
         stage_result = PipelineStageResult(
             name=pipeline_stage.name,
             failed=not allow_partial,  # flip the flag based on partial scoring
             skipped=False,
-            output=error.output or "",
+            output=failure_output,
             percentage=error.percentage,
             elapsed_time=elapsed_time,
         )

--- a/checker/checker/plugins/manytask.py
+++ b/checker/checker/plugins/manytask.py
@@ -11,10 +11,12 @@ import urllib3
 from pydantic import AnyUrl
 
 from checker.exceptions import PluginExecutionFailed
+from checker.utils import print_info
 
 from .base import PluginABC, PluginOutput
 
 HTTP_ERROR_STATUS_CODE = 400
+MIN_LOG_TOKEN_LEN = 16
 
 
 class ManytaskPlugin(PluginABC):
@@ -63,6 +65,17 @@ class ManytaskPlugin(PluginABC):
         if verbose:
             output.append(str(files))
 
+        # Log request details for debugging (token is never logged in full)
+        token_len = len(args.report_token)
+        token_hint = f"length={token_len}"
+        if token_len > MIN_LOG_TOKEN_LEN:
+            token_hint += f", prefix={args.report_token[:4]!r}"
+        print_info(
+            f"Report API: POST {args.report_url} | task={args.task_name!r}, username={args.username!r}, "
+            f"score={args.score}, token: {token_hint}",
+            color="grey",
+        )
+
         response = self._post_with_retries(args.report_url, data, files)
 
         try:
@@ -89,7 +102,7 @@ class ManytaskPlugin(PluginABC):
         response = session.post(url=f"{report_url}", data=data, files=files)
 
         if response.status_code >= HTTP_ERROR_STATUS_CODE:
-            raise PluginExecutionFailed(f"{response.status_code}: {response.text}")
+            raise PluginExecutionFailed(f"Request to {report_url} failed: {response.status_code}: {response.text}")
 
         return response
 

--- a/checker/checker/tester.py
+++ b/checker/checker/tester.py
@@ -157,6 +157,15 @@ class Tester:
             pipeline_conf = self.testing_config.report_pipeline
         return PipelineRunner(pipeline_conf, self.plugins, verbose=self.verbose)
 
+    def _print_report_failure_details(self, result: PipelineResult) -> None:
+        """Print per-stage status and output when report pipeline fails."""
+        for stage in result.stage_results:
+            status = "FAILED" if stage.failed else ("skipped" if stage.skipped else "ok")
+            print_info(f"  stage '{stage.name}': {status}", color="red" if stage.failed else "grey")
+            if stage.output:
+                for line in stage.output.splitlines():
+                    print_info(f"    {line}", color="grey")
+
     def validate(self) -> None:
         # get all tasks
         tasks = self.course.get_tasks(enabled=True)
@@ -250,13 +259,17 @@ class Tester:
             # Report score if task pipeline succeeded
             if task_pipeline_result:
                 report_pipeline = self._get_task_report_pipeline_runner(task)
-                print_info(f"Reporting <{task.name}> task tests:", color="pink")
+                print_info(
+                    f"Reporting <{task.name}> task tests ({len(report_pipeline)} stage(s) in report pipeline):",
+                    color="pink",
+                )
                 if report:
                     task_report_result: PipelineResult = report_pipeline.run(context, dry_run=self.dry_run)
                     if task_report_result:
                         print_info("->Reporting succeeded")
                     else:
                         print_info("->Reporting failed")
+                        self._print_report_failure_details(task_report_result)
                 else:
                     _: PipelineResult = report_pipeline.run(context, dry_run=True)
                     print_info("->Reporting disabled (dry-run)")


### PR DESCRIPTION
manytask plugin (checker/plugins/manytask.py): Before sending the report request, log request URL, task name, username, score, and a token hint (length only; if length > 16, also first 4 characters). Never log the full token. On HTTP errors (4xx/5xx), include the request URL in the exception message.

tester (checker/tester.py): When starting the report pipeline, log how many stages it has. When reporting fails, print a short summary for each stage (name, status: failed/skipped/ok) and, for failed stages, the stage output/error text line by line.

pipeline (checker/pipeline.py): When a plugin raises PluginExecutionFailed, store both error.output and error.message in the stage result’s output so that the tester can show full error details when reporting fails.