### PR TITLE
feat: Add line number column to students table

### DIFF
--- a/manytask/templates/namespace_panel.html
+++ b/manytask/templates/namespace_panel.html
@@ -50,6 +50,7 @@
                     <table class="table table-striped table-hover">
                         <thead>
                             <tr>
+                                <th>#</th>
                                 <th>User ID</th>
                                 <th>Username</th>
                                 <th>RMS ID (GitLab)</th>
@@ -60,6 +61,7 @@
                         <tbody id="usersTableBody">
                             {% for user in users %}
                                 <tr data-user-id="{{ user.id }}" data-username="{{ user.username }}" data-current-role="{{ user.role }}">
+                                    <td>{{ loop.counter }}</td>
                                     <td>{{ user.id }}</td>
                                     <td><strong>{{ user.username }}</strong></td>
                                     <td>{{ user.rms_id }}</td>


### PR DESCRIPTION
## Summary

Adds a new '#' column at the beginning of the students/users table in the namespace panel to display line numbers. This improves readability and makes it easier to reference specific students.

## Changes

- Added '#' header column in the users table
- Uses Jinja2 `loop.counter` to automatically number rows starting from 1
- Line numbers are displayed in the first column before User ID

## Benefits

- Easier to reference students in discussions/communications
- Better readability in tables with many students
- Common UX pattern in data tables

## Affected File

- `manytask/templates/namespace_panel.html`

Closes #915