### PR TITLE
feat(mr-reviewer): prod-release config wiring

### DIFF
--- a/course-template/.manytask.yml
+++ b/course-template/.manytask.yml
@@ -56,3 +56,21 @@ deadlines:
       tasks:
         - task: add_rust
           score: 100
+
+# Optional: manual code review via merge requests, handled by the mr-reviewer bot.
+# Uncomment and adapt to enable. The bot reads this same file (delivered by the
+# `deploy-mr-review` CI job) and only scans the course when this section exists.
+# See docs/manytask_yml_reference.md#mr_review for the full field reference.
+#
+# mr_review:
+#   gitlab_group: sandbox/students          # GitLab group the bot scans for student MRs
+#   score_comment_pattern: "Score: {score}"  # how a teacher's grade comment is parsed
+#   tasks:
+#     - name: add                            # task name == the label put on the MR
+#       manual_review: true
+#       checklist:
+#         - type: pipeline_passed            # MR head pipeline must be green
+#         - type: forbidden_files            # MR must not touch these extensions
+#           extensions: [csv, json, txt]
+#         - type: folder_structure           # every change stays under this path
+#           required_path: "python/add"

--- a/course-template/.releaser-ci.yml
+++ b/course-template/.releaser-ci.yml
@@ -135,3 +135,39 @@ deploy-public:
       else
         echo "Skipping course-config update — MANYTASK_TOKEN not set (app.manytask2.org currently down)"
       fi
+
+# Deliver the mr-reviewer config to the review bot. The bot reads the SAME
+# .manytask.yml and picks up its `mr_review:` subsection; without that section
+# the course is not scanned, so this job self-skips when it is absent.
+#
+# The bot authenticates the push by replaying MANYTASK_TOKEN against manytask's
+# per-course /ping — it is the same course token used for update_config above,
+# so no extra secret is needed. Set BOT_URL (group/project CI/CD variable) to
+# the reviewer bot's base URL, e.g. https://bot.manytask.org. When BOT_URL is
+# unset the job is a no-op, keeping the template runnable on courses without a
+# bot.
+deploy-mr-review:
+  image: python:3.12-slim
+  stage: deploy
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      when: on_success
+    - when: never
+  before_script:
+    - apt-get update -qq && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+  script:
+    - |
+      if [ -z "$BOT_URL" ] || [ -z "$MANYTASK_TOKEN" ]; then
+        echo "Skipping mr-reviewer config push — BOT_URL or MANYTASK_TOKEN not set"
+        exit 0
+      fi
+      # No section -> nothing to scan. A top-level `mr_review:` key is required.
+      if ! grep -qE '^mr_review:' .manytask.yml; then
+        echo "Skipping mr-reviewer config push — no mr_review section in .manytask.yml"
+        exit 0
+      fi
+      curl -fsSL -X POST \
+        "${BOT_URL}/courses/${MANYTASK_COURSE:-sandbox}" \
+        -H "Authorization: Bearer $MANYTASK_TOKEN" \
+        -H "Content-Type: application/x-yaml" \
+        --data-binary @.manytask.yml

--- a/docs/manytask_yml_reference.md
+++ b/docs/manytask_yml_reference.md
@@ -16,6 +16,9 @@ deadlines:
 
 grades:               # optional
   ...
+
+mr_review:            # optional
+  ...
 ```
 
 | Field | Type | Required | Description |
@@ -25,6 +28,7 @@ grades:               # optional
 | `ui` | object | yes | UI display settings. See [`ui`](#ui). |
 | `deadlines` | object | yes | Deadline schedule and submission rules. See [`deadlines`](#deadlines). |
 | `grades` | object | no | Final grade computation rules. See [`grades`](#grades). |
+| `mr_review` | object | no | Merge-request review bot settings. See [`mr_review`](#mr_review). |
 
 
 ## `status`
@@ -233,6 +237,52 @@ Use an empty key `""` with value `0` to create a condition that always matches �
 2:
   - { "": 0 }
 ```
+
+## `mr_review`
+
+Optional section consumed by the **mr-reviewer bot**, not by the Manytask web app. When a course opts into manual code review through merge requests, the bot reads this subsection from the same `.manytask.yml` (delivered by the `deploy-mr-review` CI job). If the section is absent, the bot does not scan the course.
+
+```yaml
+mr_review:
+  gitlab_group: my-course/students-2026
+  score_comment_pattern: "Score: {score}"
+  tasks:
+    - name: compgraph
+      manual_review: true
+      checklist:
+        - type: pipeline_passed
+        - type: forbidden_files
+          extensions: [csv, json, txt]
+        - type: folder_structure
+          required_path: "week_1/compgraph"
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `gitlab_group` | string | yes | — | GitLab group path the bot scans for open student merge requests. |
+| `score_comment_pattern` | string | no | `Score: {score}` | Template a teacher's grade comment must match. Must contain exactly one `{score}` placeholder. |
+| `tasks` | list | yes | — | Tasks the bot handles. See [`mr_review` task](#mr_review-task). |
+
+### `mr_review` task
+
+Each entry ties a task (by name) to the checklist run on its merge requests. The task `name` must match the label put on the MR.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | yes | — | Task identifier; also the GitLab label that routes an MR to this task's checklist. |
+| `manual_review` | boolean | no | `true` | Whether the polling worker processes this task. Set `false` to skip it. |
+| `checklist` | list | yes | — | Ordered checklist steps. See [checklist steps](#checklist-steps). |
+
+### Checklist steps
+
+Each step is a mapping discriminated by `type`. Steps run in order and the summary is posted back to the MR as a single bot comment.
+
+| `type` | Extra fields | Description |
+|---|---|---|
+| `pipeline_passed` | — | The MR head pipeline must be `success`. |
+| `forbidden_files` | `extensions: [str]` (≥1) | The MR must not add files with any of these extensions. |
+| `folder_structure` | `required_path: str` | Every change in the MR must live under this path. |
+| `run` | `command: str` | Runs `<command>` in a sandboxed shallow checkout of the MR. **Trusted code** — only enable for staff you trust. |
 
 ## Validation rules
 

--- a/mr-reviewer/docker-compose.production.yml
+++ b/mr-reviewer/docker-compose.production.yml
@@ -15,6 +15,11 @@ services:
     image: redis:7-alpine
     container_name: mrr-redis
     restart: always
+    # Persist to the mrr-redis-data volume with append-only file (AOF) so a
+    # restart keeps the registered course configs and the processed-comment
+    # dedupe set — otherwise the bot re-scans every reviewed MR after a bounce
+    # and can re-report scores.
+    command: ["redis-server", "--appendonly", "yes", "--appendfsync", "everysec"]
     networks: [manytask-net]
     volumes:
       - mrr-redis-data:/data
@@ -25,11 +30,11 @@ services:
       retries: 5
 
   mrr-bot:
-    build:
-      context: ..
-      dockerfile: mr-reviewer/Dockerfile
-      target: app
-    image: manytask-mr-reviewer:prod
+    # Pull the pre-built image published by .github/workflows/publish.yml
+    # (manytask/mr-reviewer:<release-tag>) instead of building on the host.
+    # The registry carries no `latest`, so pin the released tag on the host:
+    #   MR_REVIEWER_TAG=<release-tag>  (e.g. in manytask/.env)
+    image: manytask/mr-reviewer:${MR_REVIEWER_TAG:-latest}
     container_name: mrr-bot
     restart: always
     env_file: .env


### PR DESCRIPTION
## Changes

- **prod compose** (`mr-reviewer/docker-compose.production.yml`)
  - Pull the published `manytask/mr-reviewer:<tag>` image from the registry (built by `publish.yml`) instead of building on the host. Registry has no `latest`, so pin `MR_REVIEWER_TAG` on the host.
  - Enable Redis AOF persistence (`--appendonly yes --appendfsync everysec`) so registered course configs and the processed-comment dedupe set survive a restart.
- **course CI** (`course-template/.releaser-ci.yml`)
  - New `deploy-mr-review` job: on push to `main`, delivers `.manytask.yml` to the bot (`POST /courses/<name>`) **only when an `mr_review:` section is present**. Reuses the course's `MANYTASK_TOKEN` (bot validates it via manytask `/ping`); no extra secret. No-op when `BOT_URL` unset.
- **course template** (`course-template/.manytask.yml`)
  - Commented, copy-pasteable `mr_review` example.
- **docs** (`docs/manytask_yml_reference.md`)
  - `mr_review` section reference (fields, tasks, checklist step types) + top-level link.