### PR TITLE
refactor: clarify role management

### DIFF
--- a/manytask/manytask/auth.py
+++ b/manytask/manytask/auth.py
@@ -297,7 +297,7 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
     @requires_auth
     @wraps(f)
     def decorated(*args: Any, **kwargs: Any) -> Any:
-        from .utils.flask import is_namespace_admin
+        from .utils.flask import check_if_instance_admin, check_if_namespace_admin
 
         app: CustomFlask = current_app  # type: ignore
 
@@ -305,10 +305,10 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
             return f(*args, **kwargs)
 
         username = session["manytask"]["username"]
-        is_instance_admin = app.storage_api.check_if_instance_admin(username)
-        is_namespace_admin_user = is_namespace_admin(app, username)
+        is_instance_admin = check_if_instance_admin(username)
+        is_namespace_admin = check_if_namespace_admin(app, username)
 
-        if not is_instance_admin and not is_namespace_admin_user:
+        if not is_instance_admin and not is_namespace_admin:
             logger.warning(
                 "User %s attempted to access %s without instance admin or namespace admin privileges",
                 username,

--- a/manytask/manytask/auth.py
+++ b/manytask/manytask/auth.py
@@ -297,7 +297,7 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
     @requires_auth
     @wraps(f)
     def decorated(*args: Any, **kwargs: Any) -> Any:
-        from .utils.flask import check_if_instance_admin, check_if_namespace_admin
+        from .utils.flask import check_if_instance_admin, check_if_user_has_namespaces_to_admin
 
         app: CustomFlask = current_app  # type: ignore
 
@@ -306,9 +306,9 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
 
         username = session["manytask"]["username"]
         is_instance_admin = check_if_instance_admin(username)
-        is_namespace_admin = check_if_namespace_admin(app, username)
+        is_some_namespace_admin = check_if_user_has_namespaces_to_admin(app)
 
-        if not is_instance_admin and not is_namespace_admin:
+        if not is_instance_admin and not is_some_namespace_admin:
             logger.warning(
                 "User %s attempted to access %s without instance admin or namespace admin privileges",
                 username,

--- a/manytask/manytask/templates/courses.html
+++ b/manytask/manytask/templates/courses.html
@@ -55,11 +55,11 @@
             </div>
         </form>
 
-        {% if is_instance_admin or is_namespace_admin %}
+        {% if can_create_courses %}
             <a class="btn btn-success mt-3" href="{{ url_for('instance_admin.create_course') }}">Create course</a>
         {% endif %}
 
-        {% if is_instance_admin or is_namespace_admin %}
+        {% if can_create_courses %}
             <a class="btn btn-info mt-3" href="{{ url_for('instance_admin.namespaces_list') }}">
                 <i class="fas fa-folder me-1"></i>Namespaces
             </a>

--- a/manytask/manytask/utils/flask.py
+++ b/manytask/manytask/utils/flask.py
@@ -135,17 +135,17 @@ def get_user_roles(app: CustomFlask, username: str, course_name: str | None = No
     """
     roles = []
 
-    if app.storage_api.check_if_instance_admin(username):
-        roles.append("instance_admin")
+    if course_name:
+        if app.storage_api.check_if_instance_admin(username):
+            roles.append("instance_admin")
 
-    if check_if_namespace_admin(app, username):
-        roles.append("namespace_admin")
-
-    if course_name and app.storage_api.check_if_course_admin(course_name, username):
-        if "namespace_admin" not in roles:
+        if check_if_namespace_admin(app, course_name=course_name):
             roles.append("namespace_admin")
 
-    if course_name:
+        if app.storage_api.check_if_course_admin(course_name, username):
+            if "namespace_admin" not in roles:
+                roles.append("namespace_admin")
+
         roles.append("student")
 
     return roles
@@ -185,7 +185,7 @@ def can_access_course(app: CustomFlask, username: str, course_name: str) -> bool
     if app.storage_api.check_if_course_admin(course_name, username):
         return True
 
-    if check_if_namespace_admin(app, username):
+    if check_if_namespace_admin(app, course_name=course_name):
         course = app.storage_api.get_course(course_name)
         if course and course.namespace_id:
             namespace_admin_namespaces = app.storage_api.get_namespace_admin_namespaces(username)

--- a/manytask/manytask/utils/flask.py
+++ b/manytask/manytask/utils/flask.py
@@ -8,7 +8,12 @@ def get_courses(app: CustomFlask) -> list[dict[str, str]]:
     username = "guest" if app.debug else session["manytask"]["username"]
     if app.debug or app.storage_api.check_if_instance_admin(username):
         courses_names = app.storage_api.get_all_courses_names_with_statuses()
-    elif is_namespace_admin(app, username):
+        """
+        Keeping the logic below for now, but this should be changed since namespace admin should see:
+        - Courses from their namespaces
+        - Courses they are registered to (not necessarily from their owned namespaces)
+        """
+    elif check_if_user_has_namespaces_to_admin(app):
         namespace_admin_namespaces = app.storage_api.get_namespace_admin_namespaces(username)
         namespace_courses = app.storage_api.get_courses_by_namespace_ids(namespace_admin_namespaces)
         course_admin_courses = app.storage_api.get_courses_where_course_admin(username)
@@ -45,7 +50,12 @@ def get_courses(app: CustomFlask) -> list[dict[str, str]]:
     return courses_list
 
 
-def check_instance_admin(app: CustomFlask) -> bool:
+def check_if_instance_admin(app: CustomFlask) -> bool:
+    """Check if user is an instance admin
+
+    :param app: Flask application instance
+    :return: True if user is an instance admin
+    """
     if app.debug:
         return True
     else:
@@ -53,27 +63,60 @@ def check_instance_admin(app: CustomFlask) -> bool:
         return app.storage_api.check_if_instance_admin(username)
 
 
-def check_if_course_admin(app: CustomFlask, course_name: str) -> bool:
+def check_if_namespace_admin(app: CustomFlask, course_name: str) -> bool:
+    """Check if user is a namespace admin for the given course
+
+    :param app: Flask application instance
+    :param username: Manytask username
+    :param course_name: Course to check for
+    :return: True if user is an instance admin
+    """
     if app.debug:
         return True
     else:
         username = session["manytask"]["username"]
-        return (
-            app.storage_api.check_if_instance_admin(username)
-            or is_namespace_admin(app, username)
-            or app.storage_api.check_if_course_admin(course_name, username)
-        )
+        course = app.storage_api.get_course(course_name)
+        if course and course.namespace_id:
+            namespace_admin_namespaces = app.storage_api.get_namespace_admin_namespaces(username)
+            if course.namespace_id in namespace_admin_namespaces:
+                return True
+        return False
 
 
-def is_namespace_admin(app: CustomFlask, username: str) -> bool:
-    """Check if user is a Namespace Admin (Owner of any namespace or has Namespace Admin role).
+def check_if_course_admin(app: CustomFlask, course_name: str) -> bool:
+    """Check if user is a course admin.
+    User is course admin if they are either
+    - Course admin
+    - An admin of the namespace this course belong to
+    - Instance admin
+    This is reflected in the underlying call to the database API function
 
     :param app: Flask application instance
-    :param username: manytask username
+    :param username: Manytask username
+    :param course_name: Course to check for
+    :return: True if user is a course admin
+    """
+    if app.debug:
+        return True
+    else:
+        username = session["manytask"]["username"]
+        return app.storage_api.check_if_course_admin(course_name, username)
+
+
+def check_if_user_has_namespaces_to_admin(app: CustomFlask) -> bool:
+    """The user can create course only if:
+    - They are instance admin
+    - There is a nemespace they are admin of.
+
+    :param app: Flask application instance
     :return: True if user is a namespace admin
     """
-    namespace_admin_namespaces = app.storage_api.get_namespace_admin_namespaces(username)
-    return len(namespace_admin_namespaces) > 0
+    if app.debug:
+        return True
+    else:
+        username = session["manytask"]["username"]
+        namespace_admin_namespaces = app.storage_api.get_namespace_admin_namespaces(username)
+        return len(namespace_admin_namespaces) > 0 or app.storage_api.check_if_instance_admin(username)
 
 
 def get_user_roles(app: CustomFlask, username: str, course_name: str | None = None) -> list[str]:
@@ -95,7 +138,7 @@ def get_user_roles(app: CustomFlask, username: str, course_name: str | None = No
     if app.storage_api.check_if_instance_admin(username):
         roles.append("instance_admin")
 
-    if is_namespace_admin(app, username):
+    if check_if_namespace_admin(app, username):
         roles.append("namespace_admin")
 
     if course_name and app.storage_api.check_if_course_admin(course_name, username):
@@ -142,7 +185,7 @@ def can_access_course(app: CustomFlask, username: str, course_name: str) -> bool
     if app.storage_api.check_if_course_admin(course_name, username):
         return True
 
-    if is_namespace_admin(app, username):
+    if check_if_namespace_admin(app, username):
         course = app.storage_api.get_course(course_name)
         if course and course.namespace_id:
             namespace_admin_namespaces = app.storage_api.get_namespace_admin_namespaces(username)

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -30,7 +30,7 @@ from .auth import (
 )
 from .course import Course, CourseConfig, CourseStatus, get_current_time
 from .main import CustomFlask
-from .utils.flask import check_if_course_admin, check_instance_admin, get_courses, has_role
+from .utils.flask import check_if_course_admin, check_if_instance_admin, get_courses, has_role
 from .utils.generic import generate_token_hex, sanitize_log_data, validate_name
 from .utils.sourcecraft import normalize_string
 
@@ -51,26 +51,21 @@ def healthcheck() -> ResponseReturnValue:
 @root_bp.route("/", methods=["GET"])
 @requires_auth
 def index() -> ResponseReturnValue:
+
+    from .utils.flask import check_if_user_has_namespaces_to_admin
+
     app: CustomFlask = current_app  # type: ignore
 
     courses = get_courses(app)
-    is_instance_admin = check_instance_admin(app)
 
-    # Check if user is a namespace admin
-    if app.debug:
-        is_namespace_admin_flag = True
-    else:
-        from .utils.flask import is_namespace_admin
-
-        is_namespace_admin_flag = is_namespace_admin(app, session["manytask"]["username"])
+    can_create_courses = check_if_user_has_namespaces_to_admin(app)
 
     return render_template(
         "courses.html",
         course_favicon=app.favicon,
         manytask_version=app.manytask_version,
         courses=courses,
-        is_instance_admin=is_instance_admin,
-        is_namespace_admin=is_namespace_admin_flag,
+        can_create_courses=can_create_courses,
     )
 
 
@@ -384,7 +379,7 @@ def not_ready(course_name: str) -> ResponseReturnValue:
     app: CustomFlask = current_app  # type: ignore
 
     course = app.storage_api.get_course(course_name)
-    is_instance_admin = check_instance_admin(app)
+    is_instance_admin = check_if_instance_admin(app)
 
     if course is None:
         return redirect(url_for("root.index"))
@@ -733,23 +728,23 @@ def instance_admin_index() -> ResponseReturnValue:
     Instance Admin -> /instance_admin/panel
     Namespace Admin -> /instance_admin/namespaces
     """
+    from .utils.flask import check_if_instance_admin, check_if_user_has_namespaces_to_admin
+
     app: CustomFlask = current_app  # type: ignore
 
     if app.debug:
         return redirect(url_for("instance_admin.instance_admin_panel"))
 
     username = session["manytask"]["username"]
-    is_instance_admin = app.storage_api.check_if_instance_admin(username)
+    is_instance_admin = check_if_instance_admin(app)
 
     if is_instance_admin:
         logger.info("Instance Admin %s accessing instance admin root, redirecting to panel", username)
         return redirect(url_for("instance_admin.instance_admin_panel"))
 
-    from .utils.flask import is_namespace_admin
+    is_namespace_admin = check_if_user_has_namespaces_to_admin(app)
 
-    is_namespace_admin_flag = is_namespace_admin(app, username)
-
-    if is_namespace_admin_flag:
+    if is_namespace_admin:
         logger.info("Namespace Admin %s accessing instance admin root, redirecting to namespaces", username)
         return redirect(url_for("instance_admin.namespaces_list"))
 


### PR DESCRIPTION
The is_namespace_admin checks if user is an admin of ANY namespace, which can be confusing and potentially dangerous: user may grant an access to the namespace they are not admins of. This change clarify the naming and creates function that actually checks for namespace admin status.