### PR TITLE
feat: make Yandex OAuth base URL configurable via YANDEX_ID_OAUTH_BASE

### DIFF
--- a/manytask/manytask/local_config.py
+++ b/manytask/manytask/local_config.py
@@ -28,6 +28,7 @@ class LocalConfig:
     # yandex_id
     yandex_id_client_id: str
     yandex_id_client_secret: str
+    yandex_id_oauth_base: str
 
     @classmethod
     def from_env(cls) -> LocalConfig:
@@ -51,6 +52,7 @@ class LocalConfig:
             # yandex_id
             yandex_id_client_id=os.environ.get("YANDEX_ID_CLIENT_ID", ""),
             yandex_id_client_secret=os.environ.get("YANDEX_ID_CLIENT_SECRET", ""),
+            yandex_id_oauth_base=os.environ.get("YANDEX_ID_OAUTH_BASE", "https://oauth.yandex.com"),
         )
 
 
@@ -77,6 +79,7 @@ class DebugLocalConfig(LocalConfig):
     # yandex_id
     yandex_id_client_id: str = ""
     yandex_id_client_secret: str = ""
+    yandex_id_oauth_base: str = "https://oauth.yandex.com"
 
     show_allscores: bool = True
 

--- a/manytask/manytask/main.py
+++ b/manytask/manytask/main.py
@@ -145,8 +145,11 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
             OAuth(app),
             app.app_config.yandex_id_client_id,
             app.app_config.yandex_id_client_secret,
+            app.app_config.yandex_id_oauth_base,
         )
-        app.auth_api = yandex_id.YandexIDApi(yandex_id.YandexIDConfig())
+        app.auth_api = yandex_id.YandexIDApi(
+            yandex_id.YandexIDConfig(oauth_base=app.app_config.yandex_id_oauth_base)
+        )
         app.rms_api = sourcecraft.SourceCraftApi(
             sourcecraft.SourceCraftConfig(
                 base_url=app.app_config.sourcecraft_url,
@@ -361,13 +364,15 @@ def _authenticate(oauth: OAuth, internal_url: str, external_url: str, client_id:
     return oauth
 
 
-def _create_yandex_id_oauth(oauth: OAuth, client_id: str, client_secret: str) -> OAuth:
+def _create_yandex_id_oauth(
+    oauth: OAuth, client_id: str, client_secret: str, oauth_base: str
+) -> OAuth:
     oauth.register(
         name="auth_provider",
         client_id=client_id,
         client_secret=client_secret,
-        access_token_url="https://oauth.yandex.com/token",
-        authorize_url="https://oauth.yandex.com/authorize",
+        access_token_url=f"{oauth_base}/token",
+        authorize_url=f"{oauth_base}/authorize",
         api_base_url="https://login.yandex.ru/info",
         client_kwargs={"scope": "login:info"},
     )

--- a/manytask/manytask/yandex_id.py
+++ b/manytask/manytask/yandex_id.py
@@ -23,6 +23,7 @@ class YandexIDApiException(Exception):
 @dataclass
 class YandexIDConfig:
     dry_run: bool = False
+    oauth_base: str = "https://oauth.yandex.com"
 
 
 class YandexIDApi(AuthApi):
@@ -31,7 +32,7 @@ class YandexIDApi(AuthApi):
 
         # Yandex OAuth API endpoints
         self.user_info_url = "https://login.yandex.ru/info"
-        self.token_info_url = "https://oauth.yandex.com/token"
+        self.token_info_url = f"{config.oauth_base}/token"
 
     def _make_auth_request(self, token: str) -> requests.Response:
         headers = {"Authorization": f"OAuth {token}"}


### PR DESCRIPTION
## Summary

Make the Yandex OAuth base URL configurable via a new
`YANDEX_ID_OAUTH_BASE` environment variable, defaulting to
`https://oauth.yandex.com` so existing deployments are unaffected.

## Motivation

Yandex Passport exposes the same OAuth endpoints under two hostnames:

- `https://oauth.yandex.com/...` — serves the login screen in English.
- `https://oauth.yandex.ru/...` — serves the login screen in Russian.

manytask currently hardcodes the `.com` variant in two places
(`manytask/main.py::_create_yandex_id_oauth` and
`manytask/yandex_id.py::YandexIDApi.__init__`), so Russian-language
courses using the `sourcecraft` RMS get an English Yandex login page,
which is confusing for students. There is no functional or API
difference between the two hosts — only the UI language of the consent
screen changes.

## Changes

- `manytask/local_config.py`: add `yandex_id_oauth_base: str` field to
  `LocalConfig`, read `YANDEX_ID_OAUTH_BASE` (default
  `https://oauth.yandex.com`) in `LocalConfig.from_env()`, and mirror
  the default in `DebugLocalConfig` for the dev/test path.
- `manytask/yandex_id.py`: add `oauth_base: str = "https://oauth.yandex.com"`
  to `YandexIDConfig` and use it to build `token_info_url`. The user-info
  endpoint (`https://login.yandex.ru/info`) is a separate API and is
  left as-is.
- `manytask/main.py`: pass `app.app_config.yandex_id_oauth_base` into
  both `YandexIDConfig(...)` and `_create_yandex_id_oauth(...)`, and use
  it in the `access_token_url` / `authorize_url` f-strings.

## Backward compatibility

Fully backward compatible. When `YANDEX_ID_OAUTH_BASE` is unset,
behavior is identical to before (`https://oauth.yandex.com`).

## Usage

To serve the Russian Yandex login UI, add to your `.env`:

```env
YANDEX_ID_OAUTH_BASE=https://oauth.yandex.ru
```

## Tests

No dedicated unit tests exist for `LocalConfig.from_env()` or
`YandexIDConfig` in the current suite, so no test cases were added —
happy to add a couple of parametrized tests if maintainers prefer.
Existing `tests/test_web.py::app` fixture calls `LocalConfig.from_env()`
and continues to work because the new field has a default via env.

## Lint

`make lint` was not run locally (no `uv`/`ruff` on the author's
machine); the change is trivial (one dataclass field, one env read, one
function parameter, two f-string substitutions) and formatted
consistently with surrounding code. Happy to fix any lint issues CI
surfaces.

## Docs

`docs/deploy_guide.md §4.2` currently enumerates only GitLab-related env
vars (no `YANDEX_ID_*`, no `SOURCECRAFT_*`), so I did not touch it to
avoid a partial/inconsistent list. Happy to add a fuller RMS
environment-variables section in a follow-up if that's the preferred
direction.
