### PR TITLE
feat: make export push options configurable via .checker.yml

### DIFF
--- a/checker/checker/configs/checker.py
+++ b/checker/checker/configs/checker.py
@@ -75,6 +75,12 @@ class CheckerExportConfig(CustomBaseModel):
     default_branch: str = "main"
     commit_message: str = "chore(auto): export new tasks"
     templates: TemplateType = TemplateType.SEARCH
+    # Push options passed to `git push` as `-o <option>` flags when exporting.
+    # Backward-compatible default matches the previous hardcoded behavior:
+    # `["ci.skip"]` tells GitLab to skip pipelines for the auto-export commit.
+    # Set to `[]` for git servers that do not support push options (e.g. SourceCraft),
+    # or override with any other list of options understood by the destination server.
+    push_options: list[str] = Field(default_factory=lambda: ["ci.skip"])
 
 
 class PipelineStageConfig(CustomBaseModel):

--- a/checker/checker/exporter.py
+++ b/checker/checker/exporter.py
@@ -765,12 +765,14 @@ class Exporter:
             raise Exception(f"Git commit failed with code {r.returncode}: {r.stdout}")
 
         print_info("* git pushing...")
+        push_option_args: list[str] = []
+        for option in self.export_config.push_options:
+            push_option_args.extend(["-o", option])
         r = subprocess.run(
-            "git push -o ci.skip origin",
+            ["git", "push", *push_option_args, "origin"],
             encoding="utf-8",
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            shell=True,
             cwd=repo_dir,
         )
         print_info(r.stdout, color="grey")

--- a/checker/tests/configs/test_checker_configs.py
+++ b/checker/tests/configs/test_checker_configs.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from checker.configs import CheckerExportConfig
+
+
+class TestCheckerExportConfig:
+    def test_push_options_default(self) -> None:
+        """By default `push_options` is `["ci.skip"]` to preserve backward-compatible
+        GitLab behavior (skip pipelines on the auto-export commit)."""
+        config = CheckerExportConfig(destination="https://example.com")
+        assert config.push_options == ["ci.skip"]
+
+    def test_push_options_default_is_not_shared(self) -> None:
+        """Distinct instances must not share the same default list object."""
+        a = CheckerExportConfig(destination="https://example.com")
+        b = CheckerExportConfig(destination="https://example.com")
+        a.push_options.append("mutated")
+        assert b.push_options == ["ci.skip"]
+
+    @pytest.mark.parametrize(
+        "push_options",
+        [
+            [],
+            ["ci.skip"],
+            ["ci.skip", "merge_request.create"],
+            ["custom-option"],
+        ],
+    )
+    def test_push_options_override(self, push_options: list[str]) -> None:
+        """`push_options` can be set to any list of strings, including an empty list
+        (used for git servers that reject push options, e.g. SourceCraft)."""
+        config = CheckerExportConfig(
+            destination="https://example.com", push_options=push_options
+        )
+        assert config.push_options == push_options

--- a/docs/checker_yml_reference.md
+++ b/docs/checker_yml_reference.md
@@ -108,6 +108,7 @@ export:
   default_branch: main
   commit_message: "chore(auto): export new tasks"
   templates: search
+  push_options: ["ci.skip"]
 ```
 
 | Field | Type | Required | Default | Description |
@@ -116,6 +117,7 @@ export:
 | `default_branch` | `str` | no  | `"main"` | Branch name to push to in the destination repository. |
 | `commit_message` | `str` | no  | `"chore(auto): export new tasks"` | Commit message used when pushing exported tasks. |
 | `templates` | `str` | no  | `"search"` | Template strategy for generating student-facing task files. One of `search`, `create`, `search_or_create`. |
+| `push_options` | `list[str]` | no | `["ci.skip"]` | Push options passed to `git push` as `-o <option>` flags on export. The default `"ci.skip"` tells GitLab to skip pipelines for the auto-export commit. Set to `[]` for git servers that do not support push options (e.g. SourceCraft), or override with any other list of options understood by the destination server. |
 
 ### `templates` strategies
 


### PR DESCRIPTION
## Summary

Make the push options used by `checker export --commit` configurable
via a new `export.push_options: list[str]` field in `.checker.yml`,
defaulting to `["ci.skip"]` so existing GitLab-hosted courses are
unaffected.

## Motivation

`Exporter._commit_and_push_repo` currently hardcodes:

```python
subprocess.run("git push -o ci.skip origin", ..., shell=True)
```

`-o ci.skip` is a **GitLab-specific** push option that tells GitLab
to skip pipeline creation for the pushed commit — useful for
`checker export --commit`, which typically runs from CI and would
otherwise trigger a pipeline in the students' public repo on every
export.

Other Git servers do not universally support push options. In
particular, **SourceCraft** (Yandex's Git hosting, increasingly used
by Russian courses now that the `sourcecraft` RMS is supported in
manytask) rejects **any** push options with:

```
fatal: the receiving end does not support push options
```

which makes `checker export --commit` unusable for SourceCraft-hosted
courses. This is a real blocker for the "Продвинутый Python" course
at HSE AMI 2026, which uses manytask + SourceCraft.

## Changes

- `checker/checker/configs/checker.py`: add `push_options: list[str]`
  field to `CheckerExportConfig` with `default_factory=lambda: ["ci.skip"]`
  (fresh list per instance so the default cannot be mutated across
  configs). Documented inline with rationale + SourceCraft note.
- `checker/checker/exporter.py::_commit_and_push_repo`: build the
  `git push` argv from `self.export_config.push_options`, then invoke
  `subprocess.run` with a list (no `shell=True`). An empty
  `push_options` results in a plain `git push origin` with no `-o`
  flags. Behavior for the default `["ci.skip"]` value is
  byte-identical to the previous hardcoded call.
- `checker/tests/configs/test_checker_configs.py`: **new** test file
  covering the default value, non-shared-default-instance guarantee,
  and parametrized overrides (empty list, single option, multiple
  options, custom option).
- `docs/checker_yml_reference.md`: add `push_options` row to the
  `export` field table and include it in the example YAML.

## Backward compatibility

Fully backward compatible. When `export.push_options` is unset in
`.checker.yml`, the value is `["ci.skip"]` and `git push` is invoked
with exactly `-o ci.skip origin` — the same option list as before.
Existing GitLab-hosted courses need no config changes.

## Usage

For a SourceCraft-hosted course, opt out of push options:

```yaml
# .checker.yml
export:
  destination: https://sourcecraft.dev/<org>/<public-repo>
  push_options: []
```

For a GitLab course that also wants to skip merge-request pipelines:

```yaml
export:
  push_options: ["ci.skip", "merge_request.create"]
```

## Tests

Added `checker/tests/configs/test_checker_configs.py` with 6 test
cases (1 default + 1 no-shared-default + 4 parametrized overrides).

Local run of the affected suites:

```
$ pytest tests/configs tests/test_exporter.py
================= 117 passed, 1 xfailed, 15 warnings in 0.37s =================
```

`_commit_and_push_repo` itself is marked `# pragma: no cover` (it
shells out to `git push`), so I did not add a subprocess-mock test
for the push invocation — happy to add one with `pytest-mock` if
maintainers prefer.

## Lint

`ruff check` and `mypy` both pass cleanly on the changed files
(pinned `ruff==0.15.12` from `checker/uv.lock`, `mypy` per
`checker/pyproject.toml`):

```
$ ruff check checker tests
All checks passed!
$ mypy checker
Success: no issues found in 33 source files
```

`ruff format` would reformat several unrelated files that already had
pending formatter drift on `main`; I intentionally did not touch those
to keep this diff minimal. The lines I added match the surrounding
style.

## Docs

Added a `push_options` row to the `export` section table in
`docs/checker_yml_reference.md` and included it in the section's
example YAML.
