### PR TITLE
feat: hide gitlab_course_group in UI for non-GitLab RMS backends

### DIFF
--- a/manytask/manytask/templates/edit_course.html
+++ b/manytask/manytask/templates/edit_course.html
@@ -90,6 +90,7 @@
 
             <div class="col-md-6 mb-4">
                 <h4>GitLab Configuration</h4>
+                {% if rms == "gitlab" %}
                 <div class="mb-3">
                     <label for="gitlab_course_group" class="form-label">GitLab Course Group</label>
                     <input type="text" class="form-control" id="gitlab_course_group" name="gitlab_course_group" value="{{ course.gitlab_course_group }}" placeholder="test-course" required>
@@ -97,6 +98,11 @@
                         stored
                     </div>
                 </div>
+                {% else %}
+                {# gitlab_course_group is UNUSED for non-GitLab RMS backends (see sourcecraft.py: :param course_group: UNUSED). #}
+                {# Hidden input preserves the stored value so backend Pydantic validation stays happy (backward compatible). #}
+                <input type="hidden" name="gitlab_course_group" value="{{ course.gitlab_course_group or 'unused-non-gitlab' }}">
+                {% endif %}
                 <div class="mb-3">
                     <label for="gitlab_course_public_repo" class="form-label">GitLab Public Repo</label>
                     <input type="text" class="form-control" id="gitlab_course_public_repo" name="gitlab_course_public_repo" value="{{ course.gitlab_course_public_repo }}" placeholder="test-course/public-repo" required>

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -719,10 +719,15 @@ def edit_course(course_name: str) -> ResponseReturnValue:
             logger.info("Successfully updated course settings for: %s", sanitize_log_data(course_name))
             return redirect(url_for("course.course_page", course_name=course_name))
 
-        return render_template("edit_course.html", course=updated_settings, error_message="Error while updating course")
+        return render_template(
+            "edit_course.html",
+            course=updated_settings,
+            error_message="Error while updating course",
+            rms=app.app_config.rms,
+        )
 
     course_users = app.storage_api.get_course_users_with_admin_status(course_name)
-    return render_template("edit_course.html", course=course, course_users=course_users)
+    return render_template("edit_course.html", course=course, course_users=course_users, rms=app.app_config.rms)
 
 
 @instance_admin_bp.route("/", methods=["GET"])


### PR DESCRIPTION
## Summary

Hide the `gitlab_course_group` input in the **Edit Course** UI when the instance is not running the GitLab RMS backend. For other backends (currently `sourcecraft`, `mock`), the field is submitted as a hidden `<input>` carrying the existing stored value (or the placeholder `unused-non-gitlab` when empty), so nothing changes on the backend side.

## Motivation

`gitlab_course_group` is a legacy, GitLab-only concept. It is explicitly marked as **UNUSED** for the SourceCraft backend:

- `manytask/sourcecraft.py`:
  - `create_public_repo(..., course_group: str, ...)` — `:param course_group: UNUSED`
  - `create_course_group(...) -> int:` — `# TODO: implement when SourceCraft supports groups of repos` and returns `-1` as a stub
- `manytask/main.py` — the create-course form already localizes the field via `_CREATE_COURSE_LABELS[rms]` (e.g. "SourceCraft Course Prefix" instead of "GitLab Course Group") because the concept doesn't cleanly map to non-GitLab RMS backends.

But the **Edit Course** form still hard-codes "GitLab Course Group" as a required text input, which is confusing for teachers running SourceCraft courses (concretely: a HSE AMI course running on a SourceCraft instance ran into this — the field name, "GitLab", and the required-marker made it look like a broken/misconfigured install).

## Changes

- `manytask/templates/edit_course.html`:
  - Wrap the visible "GitLab Course Group" input in `{% if rms == "gitlab" %}` / `{% else %}`.
  - In the `else` branch, emit a hidden `<input name="gitlab_course_group" value="{{ course.gitlab_course_group or 'unused-non-gitlab' }}">` — this preserves whatever is currently stored (roundtrips a real value if present, falls back to a placeholder if empty) so the POST handler and dataclass validation remain happy.
- `manytask/web.py` (`edit_course` view): pass `rms=app.app_config.rms` into `render_template("edit_course.html", ...)` on both the GET and the POST-error render paths (the existing CSRF-error render already passed `rms`).

## Backward compatibility

- GitLab RMS: no visual or behavioral change — the input is rendered exactly as before.
- Non-GitLab RMS: field disappears from the UI, but a hidden input with the same `name` is still submitted, so the backend `edit_course` handler (`request.form["gitlab_course_group"]`) and the downstream `CourseConfig` dataclass see a non-empty string just like before.
- No DB / model / API changes.

## Tests

- Existing test suite: `make lint` passes (`ruff format`, `ruff check`, `mypy` all green).
- Full pytest suite: **417 passed** locally (via `DOCKER_HOST=... TESTCONTAINERS_RYUK_DISABLED=true uv run pytest`, i.e. the same setup used by the `test-colima` target).
- No new tests: there are currently no HTTP-level tests for the `edit_course` route (only DB-layer tests around `db_api.edit_course(...)`), and this change is a template + one context-var addition — behavior for GitLab RMS is unchanged, and for non-GitLab RMS the wire format submitted to the backend is intentionally identical.

## Docs

No user-facing docs need updating: the field is UI-cosmetic in this context.

## Lint

- `uv run ruff format manytask tests` — 41 files left unchanged.
- `uv run ruff check manytask tests` — all checks passed.
- `uv run mypy manytask` — success: no issues found in 21 source files.
