### PR TITLE
fix: remove check_if_instance_admin(..) wrapper (fixes admin routes 500)

### DIFF
--- a/manytask/manytask/auth.py
+++ b/manytask/manytask/auth.py
@@ -297,7 +297,7 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
     @requires_auth
     @wraps(f)
     def decorated(*args: Any, **kwargs: Any) -> Any:
-        from .utils.flask import check_if_instance_admin, check_if_user_has_namespaces_to_admin
+        from .utils.flask import check_if_user_has_namespaces_to_admin
 
         app: CustomFlask = current_app  # type: ignore
 
@@ -305,7 +305,7 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
             return f(*args, **kwargs)
 
         username = session["manytask"]["username"]
-        is_instance_admin = check_if_instance_admin(username)
+        is_instance_admin = app.storage_api.check_if_instance_admin(username)
         is_some_namespace_admin = check_if_user_has_namespaces_to_admin(app)
 
         if not is_instance_admin and not is_some_namespace_admin:

--- a/manytask/manytask/utils/flask.py
+++ b/manytask/manytask/utils/flask.py
@@ -50,19 +50,6 @@ def get_courses(app: CustomFlask) -> list[dict[str, str]]:
     return courses_list
 
 
-def check_if_instance_admin(app: CustomFlask) -> bool:
-    """Check if user is an instance admin
-
-    :param app: Flask application instance
-    :return: True if user is an instance admin
-    """
-    if app.debug:
-        return True
-    else:
-        username = session["manytask"]["username"]
-        return app.storage_api.check_if_instance_admin(username)
-
-
 def check_if_namespace_admin(app: CustomFlask, course_name: str) -> bool:
     """Check if user is a namespace admin for the given course
 

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -29,7 +29,7 @@ from .auth import (
 )
 from .course import Course, CourseConfig, CourseStatus, get_current_time
 from .main import CustomFlask
-from .utils.flask import check_if_instance_admin, get_courses, has_role
+from .utils.flask import get_courses, has_role
 from .utils.generic import (
     check_course_creation_namespace_permission,
     generate_token_hex,
@@ -63,8 +63,8 @@ def index() -> ResponseReturnValue:
     courses = get_courses(app)
 
     can_create_courses = check_if_user_has_namespaces_to_admin(app)
-    is_instance_admin = check_if_instance_admin(app)
     username = "guest" if app.debug else session["manytask"]["username"]
+    is_instance_admin = True if app.debug else app.storage_api.check_if_instance_admin(username)
 
     return render_template(
         "courses.html",
@@ -388,7 +388,7 @@ def not_ready(course_name: str) -> ResponseReturnValue:
     app: CustomFlask = current_app  # type: ignore
 
     course = app.storage_api.get_course(course_name)
-    is_instance_admin = check_if_instance_admin(app)
+    is_instance_admin = True if app.debug else app.storage_api.check_if_instance_admin(session["manytask"]["username"])
 
     if course is None:
         return redirect(url_for("root.index"))
@@ -699,7 +699,7 @@ def instance_admin_index() -> ResponseReturnValue:
     Instance Admin -> /instance_admin/panel
     Namespace Admin -> /instance_admin/namespaces
     """
-    from .utils.flask import check_if_instance_admin, check_if_user_has_namespaces_to_admin
+    from .utils.flask import check_if_user_has_namespaces_to_admin
 
     app: CustomFlask = current_app  # type: ignore
 
@@ -707,7 +707,7 @@ def instance_admin_index() -> ResponseReturnValue:
         return redirect(url_for("instance_admin.instance_admin_panel"))
 
     username = session["manytask"]["username"]
-    is_instance_admin = check_if_instance_admin(app)
+    is_instance_admin = app.storage_api.check_if_instance_admin(username)
 
     if is_instance_admin:
         logger.info("Instance Admin %s accessing instance admin root, redirecting to panel", username)


### PR DESCRIPTION
## Motivation

Same class of bug as #1022 (just merged), same fix pattern.

`manytask/utils/flask.py` used to define a `check_if_instance_admin(app)` helper whose name shadowed the underlying `storage_api.check_if_instance_admin(username)` method. In `auth.py::requires_instance_or_namespace_admin` the caller intended the storage-API method but grabbed the imported wrapper instead and passed a `username: str`. The wrapper then did `app.debug` on that string:

```
AttributeError: 'str' object has no attribute 'debug'
```

which surfaces as **HTTP 500** on every `@requires_instance_or_namespace_admin` route (`/instance_admin/courses/new`, `/instance_admin/courses/<name>/edit`, etc.) whenever `app.debug is False` (i.e. all real deployments).

#1022 fixed the sibling `check_if_course_admin` collision by deleting the wrapper altogether. This PR does the same for `check_if_instance_admin`.

## Changes

- `utils/flask.py` — delete `check_if_instance_admin(app)` (13 lines)
- `auth.py::requires_instance_or_namespace_admin` — drop the wrapper import, call `app.storage_api.check_if_instance_admin(username)` directly
- `web.py` — remove wrapper from top-level and local imports; three call sites (`index`, `not_ready`, `instance_admin_index`) now call `storage_api` directly. Debug bypass preserved inline where relevant:
  ```python
  is_instance_admin = True if app.debug else app.storage_api.check_if_instance_admin(username)
  ```

Net: **+7 / -20**.

## Backward compatibility

Bug fix only — no public API changes, no config changes, no schema changes. Behaviour of the removed wrapper is preserved exactly at every call site (debug bypass included).

## Tests

No new tests. The existing `tests/test_auth.py` and `tests/test_web.py` still pass (verified locally). No test referenced the deleted wrapper — only `storage_api.check_if_instance_admin`, which is unchanged.

## Verification

- `uv run --extra dev ruff check manytask` — clean
- `uv run --extra dev mypy manytask` — clean (21 files, no issues)
- `grep -rn check_if_instance_admin manytask/manytask/` — every remaining reference is either a `def` in `abstract.py` / `database.py` (the storage-API method itself) or a `storage_api.check_if_instance_admin(...)` call site
