### PR TITLE
fix: use correct signature when calling check-if-admin function

### DIFF
--- a/manytask/manytask/auth.py
+++ b/manytask/manytask/auth.py
@@ -277,13 +277,14 @@ def requires_instance_admin(f: Callable[..., Any]) -> Callable[..., Any]:
     @requires_auth
     @wraps(f)
     def decorated(*args: Any, **kwargs: Any) -> Any:
+        from .utils.flask import check_if_current_user_is_instance_admin
+
         app: CustomFlask = current_app  # type: ignore
 
         if app.debug:
             return f(*args, **kwargs)
 
-        username = session["manytask"]["username"]
-        if not app.storage_api.check_if_instance_admin(username):
+        if not check_if_current_user_is_instance_admin(app):
             abort(HTTPStatus.FORBIDDEN)
 
         return f(*args, **kwargs)
@@ -297,7 +298,7 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
     @requires_auth
     @wraps(f)
     def decorated(*args: Any, **kwargs: Any) -> Any:
-        from .utils.flask import check_if_instance_admin, check_if_user_has_namespaces_to_admin
+        from .utils.flask import check_if_current_user_is_instance_admin, check_if_user_has_namespaces_to_admin
 
         app: CustomFlask = current_app  # type: ignore
 
@@ -305,7 +306,7 @@ def requires_instance_or_namespace_admin(f: Callable[..., Any]) -> Callable[...,
             return f(*args, **kwargs)
 
         username = session["manytask"]["username"]
-        is_instance_admin = check_if_instance_admin(username)
+        is_instance_admin = check_if_current_user_is_instance_admin(app)
         is_some_namespace_admin = check_if_user_has_namespaces_to_admin(app)
 
         if not is_instance_admin and not is_some_namespace_admin:

--- a/manytask/manytask/utils/flask.py
+++ b/manytask/manytask/utils/flask.py
@@ -50,11 +50,16 @@ def get_courses(app: CustomFlask) -> list[dict[str, str]]:
     return courses_list
 
 
-def check_if_instance_admin(app: CustomFlask) -> bool:
-    """Check if user is an instance admin
+def check_if_current_user_is_instance_admin(app: CustomFlask) -> bool:
+    """Check whether the current session user is an instance admin.
+
+    Session-aware Flask helper: resolves the username from the session (and
+    returns ``True`` in debug mode), then delegates to the storage primitive
+    :meth:`StorageApi.check_if_instance_admin`. Do not confuse it with that
+    storage method, which takes an explicit ``username`` argument.
 
     :param app: Flask application instance
-    :return: True if user is an instance admin
+    :return: True if the current user is an instance admin
     """
     if app.debug:
         return True
@@ -63,7 +68,7 @@ def check_if_instance_admin(app: CustomFlask) -> bool:
         return app.storage_api.check_if_instance_admin(username)
 
 
-def check_if_namespace_admin(app: CustomFlask, course_name: str) -> bool:
+def check_if_current_user_is_namespace_admin(app: CustomFlask, course_name: str) -> bool:
     """Check if user is a namespace admin for the given course
 
     :param app: Flask application instance
@@ -119,7 +124,7 @@ def get_user_roles(app: CustomFlask, username: str, course_name: str | None = No
         roles.append("instance_admin")
 
     if course_name:
-        if check_if_namespace_admin(app, course_name=course_name):
+        if check_if_current_user_is_namespace_admin(app, course_name=course_name):
             roles.append("namespace_admin")
 
         if app.storage_api.check_if_course_admin(course_name, username):
@@ -165,7 +170,7 @@ def can_access_course(app: CustomFlask, username: str, course_name: str) -> bool
     if app.storage_api.check_if_course_admin(course_name, username):
         return True
 
-    if check_if_namespace_admin(app, course_name=course_name):
+    if check_if_current_user_is_namespace_admin(app, course_name=course_name):
         course = app.storage_api.get_course(course_name)
         if course and course.namespace_id:
             namespace_admin_namespaces = app.storage_api.get_namespace_admin_namespaces(username)

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -29,7 +29,7 @@ from .auth import (
 )
 from .course import Course, CourseConfig, CourseStatus, get_current_time
 from .main import CustomFlask
-from .utils.flask import check_if_instance_admin, get_courses, has_role
+from .utils.flask import check_if_current_user_is_instance_admin, get_courses, has_role
 from .utils.generic import (
     check_course_creation_namespace_permission,
     generate_token_hex,
@@ -63,7 +63,7 @@ def index() -> ResponseReturnValue:
     courses = get_courses(app)
 
     can_create_courses = check_if_user_has_namespaces_to_admin(app)
-    is_instance_admin = check_if_instance_admin(app)
+    is_instance_admin = check_if_current_user_is_instance_admin(app)
     username = "guest" if app.debug else session["manytask"]["username"]
 
     return render_template(
@@ -388,7 +388,7 @@ def not_ready(course_name: str) -> ResponseReturnValue:
     app: CustomFlask = current_app  # type: ignore
 
     course = app.storage_api.get_course(course_name)
-    is_instance_admin = check_if_instance_admin(app)
+    is_instance_admin = check_if_current_user_is_instance_admin(app)
 
     if course is None:
         return redirect(url_for("root.index"))
@@ -496,7 +496,7 @@ def create_course() -> ResponseReturnValue:  # noqa: PLR0911
             )
 
         username = session["manytask"]["username"]
-        is_instance_admin = app.storage_api.check_if_instance_admin(username)
+        is_instance_admin = check_if_current_user_is_instance_admin(app)
 
         namespace, role, error, _ = check_course_creation_namespace_permission(
             app.storage_api, namespace_id, username, is_instance_admin
@@ -621,7 +621,7 @@ def edit_course(course_name: str) -> ResponseReturnValue:
 
     if not app.debug:
         username = session["manytask"]["username"]
-        is_instance_admin = app.storage_api.check_if_instance_admin(username)
+        is_instance_admin = check_if_current_user_is_instance_admin(app)
 
         if not is_instance_admin:
             if course.namespace_id:
@@ -699,7 +699,7 @@ def instance_admin_index() -> ResponseReturnValue:
     Instance Admin -> /instance_admin/panel
     Namespace Admin -> /instance_admin/namespaces
     """
-    from .utils.flask import check_if_instance_admin, check_if_user_has_namespaces_to_admin
+    from .utils.flask import check_if_current_user_is_instance_admin, check_if_user_has_namespaces_to_admin
 
     app: CustomFlask = current_app  # type: ignore
 
@@ -707,7 +707,7 @@ def instance_admin_index() -> ResponseReturnValue:
         return redirect(url_for("instance_admin.instance_admin_panel"))
 
     username = session["manytask"]["username"]
-    is_instance_admin = check_if_instance_admin(app)
+    is_instance_admin = check_if_current_user_is_instance_admin(app)
 
     if is_instance_admin:
         logger.info("Instance Admin %s accessing instance admin root, redirecting to panel", username)
@@ -801,7 +801,7 @@ def update_profile() -> ResponseReturnValue:
         app.logger.error("CSRF validation failed: %s", e)
         return render_template("courses.html", error_message="CSRF Error")
 
-    if request_username != current_username and not app.storage_api.check_if_instance_admin(current_username):
+    if request_username != current_username and not check_if_current_user_is_instance_admin(app):
         abort(HTTPStatus.FORBIDDEN)
 
     target_user = app.storage_api.get_stored_user_by_username(request_username)
@@ -832,7 +832,7 @@ def namespaces_list() -> ResponseReturnValue:
     app: CustomFlask = current_app  # type: ignore
 
     username = session["manytask"]["username"]
-    is_instance_admin = app.storage_api.check_if_instance_admin(username)
+    is_instance_admin = check_if_current_user_is_instance_admin(app)
 
     if is_instance_admin:
         logger.info("Instance Admin %s accessing all namespaces", username)
@@ -897,7 +897,7 @@ def namespace_panel(namespace_id: int) -> ResponseReturnValue:
     app: CustomFlask = current_app  # type: ignore
 
     username = session["manytask"]["username"]
-    is_instance_admin = app.storage_api.check_if_instance_admin(username)
+    is_instance_admin = check_if_current_user_is_instance_admin(app)
 
     try:
         namespace, user_role = app.storage_api.get_namespace_by_id(namespace_id, username)

--- a/manytask/tests/test_flask_utils.py
+++ b/manytask/tests/test_flask_utils.py
@@ -18,7 +18,7 @@ def app():
     storage_api.check_if_instance_admin.return_value = False
     storage_api.check_if_course_admin.return_value = False
     storage_api.get_namespace_admin_namespaces.return_value = []
-    # Course with no namespace so check_if_namespace_admin short-circuits to False.
+    # Course with no namespace so check_if_current_user_is_namespace_admin short-circuits to False.
     course = MagicMock()
     course.namespace_id = None
     storage_api.get_course.return_value = course
@@ -44,7 +44,7 @@ def test_get_user_roles_instance_admin_visibility(app, is_instance_admin, course
     app.storage_api.check_if_instance_admin.return_value = is_instance_admin
 
     with app.test_request_context():
-        # get_user_roles may reach into session via check_if_namespace_admin;
+        # get_user_roles may reach into session via check_if_current_user_is_namespace_admin;
         # only need to seed session when a course_name is supplied.
         if course_name is not None:
             from flask import session


### PR DESCRIPTION
1. Rename the flask util function so that it is called differently from the Storage API method
2. Use the flask utils function where it is appropriate
3. Fix the function call where the wrong signature was used
4. Rename the function that checks namespace adminity accordingly