### PR TITLE
fix: remove link to GitLab account from the drop-down menu

### DIFF
--- a/manytask/manytask/templates/_user_menu.html
+++ b/manytask/manytask/templates/_user_menu.html
@@ -9,13 +9,6 @@
     </a>
     <ul class="dropdown-menu dropdown-menu-end shadow-sm border-0 mt-2">
         <li>
-            <a class="dropdown-item d-flex align-items-center py-2" target="_blank"
-               href="{{ gitlab_url }}/-/user_settings/profile">
-                <i class="fas fa-user-cog me-2 opacity-75"></i>
-                Account Settings
-            </a>
-        </li>
-        <li>
             <button type="button" class="btn dropdown-item d-flex align-items-center py-2" data-bs-toggle="modal"
                     data-bs-target="#changeUserInfoModal">
                 <i class="fas fa-user-edit me-2 opacity-75"></i>

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -74,7 +74,6 @@ def index() -> ResponseReturnValue:
         can_create_courses=can_create_courses,
         is_instance_admin=is_instance_admin,
         username=username,
-        gitlab_url=app.rms_api.base_url,
     )
 
 
@@ -152,7 +151,6 @@ def course_page(course_name: str) -> ResponseReturnValue:
         course_name=course.course_name,
         course_status=course.status,
         app=app,
-        gitlab_url=app.rms_api.base_url,
         allscores_url=allscores_url,
         show_allscores=course.show_allscores,
         student_repo_url=student_repo,
@@ -446,7 +444,6 @@ def show_database(course_name: str) -> ResponseReturnValue:
         course_favicon=app.favicon,
         readonly_fields=["username", "total_score"],  # Cannot be edited in database web viewer
         links=course.links,
-        gitlab_url=app.rms_api.base_url,
         show_allscores=course.show_allscores,
         student_repo_url=student_repo,
         student_ci_url=student_ci_url,

--- a/manytask/tests/test_web.py
+++ b/manytask/tests/test_web.py
@@ -289,8 +289,6 @@ def test_index_shows_profile_menu(app, mock_gitlab_oauth):
             assert response.status_code == HTTPStatus.OK
             body = response.data.decode()
             assert "nav-user-menu" in body
-            assert "Account Settings" in body
-            assert f"{GITLAB_BASE_URL}/-/user_settings/profile" in body
             assert "changeUserInfoModal" in body
             assert TEST_USERNAME in body
 


### PR DESCRIPTION
This link is not universal and works only for gitlab. It has nothing to do with manytask itself and user can find their profile in gitlab interface.

Closes #1021