### PR TITLE
feat: Better error reporting by /report API handle

### DIFF
--- a/checker/checker/plugins/manytask.py
+++ b/checker/checker/plugins/manytask.py
@@ -188,72 +188,37 @@ class ManytaskPlugin(PluginABC):
         except ValueError:
             reason = response.reason or "Unknown"
 
-        parts = [
-            f"Manytask rejected the report: HTTP {status} {reason} (from '{report_url}').",
-            f"Server said: {ManytaskPlugin._describe_response_body(response)}",
-        ]
-
-        hint = ManytaskPlugin._hint_for_status(status)
-        if hint:
-            parts.append(f"Hint: {hint}")
-
-        return "\n".join(parts)
-
-    @staticmethod
-    def _hint_for_status(status: int) -> str:
-        """Map a status code onto the most likely misconfiguration."""
-        if status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
-            return (
-                "the course token was not accepted. Check that `report_token` "
-                "holds the token of this exact course (usually the "
-                "MANYTASK_TOKEN secret of the CI job)."
-            )
-        if status == HTTPStatus.NOT_FOUND:
-            return (
-                "Manytask has no such endpoint, course, task or user. Check "
-                "that `report_url` is "
-                "'https://<manytask-host>/api/<course_name>/report', that the "
-                "task exists and is enabled in .manytask.yml, and that the "
-                "student is signed up for the course."
-            )
-        if status == HTTPStatus.CONFLICT:
-            return "the course is already finished, so scores cannot be changed."
-        if status == HTTPStatus.BAD_REQUEST:
-            return (
-                "Manytask could not parse the submission. Check `score` "
-                "(must be a number in [0.0, 2.0]) and `task_name`."
-            )
-        if status == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
-            return "the attached files are too big; narrow down `patterns`."
-        if status >= HTTPStatus.INTERNAL_SERVER_ERROR:
-            return "this is a server-side failure; check the Manytask instance logs."
-        return ""
+        return (
+            f"Manytask rejected the report: HTTP {status} {reason} (from '{report_url}').\n"
+            f"Server said: {ManytaskPlugin._describe_response_body(response)}"
+        )
 
     @staticmethod
     def _describe_response_body(response: requests.Response) -> str:
-        """Extract the message from a JSON or HTML error body."""
-        content_type = response.headers.get("Content-Type", "")
+        """Clean up an error body for display.
+
+        Manytask answers API errors with plain text (the message, plus a 'Hint:'
+        line), so it is shown as-is. Only a genuine HTML document - a proxy or
+        gateway page - gets its markup stripped.
+
+        The HTML check is deliberately narrow: Manytask quotes offending values
+        in angle brackets ("Cannot parse `score` <abc>"), and a looser test would
+        strip those as if they were tags, deleting the very detail being reported.
+        """
         text = response.text or ""
 
-        if "json" in content_type.lower():
-            try:
-                payload = response.json()
-            except (json.JSONDecodeError, ValueError):
-                payload = None
-            if isinstance(payload, dict):
-                for key in ("error", "message", "description"):
-                    value = payload.get(key)
-                    if isinstance(value, str) and value.strip():
-                        return value.strip()
+        content_type = response.headers.get("Content-Type", "").lower()
+        looks_like_html = "html" in content_type or re.match(
+            r"\s*(<!doctype\s+html|<html\b)", text, re.IGNORECASE
+        )
 
-        if "html" in content_type.lower() or "<html" in text.lower():
-            # Flask renders abort(code, "msg") as an HTML page; drop the markup
-            # so the actual message stays visible.
+        if looks_like_html:
             text = re.sub(r"(?is)<(script|style)\b.*?</\1>", " ", text)
             text = re.sub(r"(?s)<[^>]+>", " ", text)
             text = unescape(text)
+            text = " ".join(text.split())
 
-        text = " ".join(text.split())
+        text = text.strip()
         if len(text) > MAX_ERROR_BODY_LEN:
             text = f"{text[:MAX_ERROR_BODY_LEN]}... (truncated)"
         return text or "<empty response body>"

--- a/checker/checker/plugins/manytask.py
+++ b/checker/checker/plugins/manytask.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime
+from html import unescape
+from http import HTTPStatus
 from pathlib import Path
 from typing import IO, Any, Optional
 
@@ -16,6 +19,12 @@ from .base import PluginABC, PluginOutput
 
 HTTP_ERROR_STATUS_CODE = 400
 
+# Error bodies can be whole HTML pages; keep the reported extract readable.
+MAX_ERROR_BODY_LEN = 1000
+
+# (connect, read) timeouts, so a hanging server cannot block CI forever.
+DEFAULT_TIMEOUT = (10.0, 60.0)
+
 
 class ManytaskPlugin(PluginABC):
     """Given score report it to the manytask.
@@ -26,11 +35,15 @@ class ManytaskPlugin(PluginABC):
     name = "report_score_manytask"
 
     class Args(PluginABC.Args):
-        origin: Optional[str] = None  # as pydantic does not support | in older python versions
+        origin: Optional[str] = (
+            None  # as pydantic does not support | in older python versions
+        )
         patterns: list[str] = ["*"]
         username: str
         task_name: str
-        score: float | None  # TODO: validate score is in [0, 1] (bonus score is higher than 1)
+        score: (
+            float | None
+        )  # TODO: validate score is in [0, 1] (bonus score is higher than 1)
         report_url: AnyUrl
         report_token: str
         check_deadline: bool
@@ -40,7 +53,9 @@ class ManytaskPlugin(PluginABC):
         output: list[str] = []
 
         if not args.send_time.tzinfo:
-            output.append("Warning: No timezone provided for send_time, possible time miscalculations")
+            output.append(
+                "Warning: No timezone provided for send_time, possible time miscalculations"
+            )
         try:
             send_time_formatted = args.send_time.strftime(self.DEFAULT_TIME_FORMAT)
         except ValueError as e:
@@ -67,13 +82,30 @@ class ManytaskPlugin(PluginABC):
 
         try:
             result = response.json()
-            output.append(
-                f"Report for task '{args.task_name}' for user '{args.username}', "
-                f"requested score: {args.score}, result score: {result['score']}"
+            score = result["score"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            # A 2xx that is not the expected JSON usually means `report_url`
+            # points at something that is not the Manytask report endpoint
+            # (a proxy, a login page, a redirect...).
+            details = self._describe_response_body(response)
+            message = (
+                f"Unable to decode response from '{args.report_url}' "
+                f"(HTTP {response.status_code}). Expected JSON with a "
+                f"'score' field, got:\n{details}\n"
+                f"{self._REPORT_URL_HINT}"
             )
-            return PluginOutput(output="\n".join(output))
-        except (json.JSONDecodeError, KeyError):
-            raise PluginExecutionFailed("Unable to decode response")
+            raise PluginExecutionFailed(message, output=message)
+
+        output.append(
+            f"Report for task '{args.task_name}' for user '{args.username}', "
+            f"requested score: {args.score}, result score: {score}"
+        )
+        return PluginOutput(output="\n".join(output))
+
+    _REPORT_URL_HINT = (
+        "Hint: `report_url` must be the full report endpoint, i.e. "
+        "'https://<manytask-host>/api/<course_name>/report'."
+    )
 
     @staticmethod
     def _post_with_retries(
@@ -81,26 +113,155 @@ class ManytaskPlugin(PluginABC):
         data: dict[str, Any],
         files: dict[str, tuple[str, IO[bytes]]] | None,
     ) -> requests.Response:
-        retry_strategy = urllib3.Retry(total=3, backoff_factor=1, status_forcelist=[408, 500, 502, 503, 504])
+        retry_strategy = urllib3.Retry(
+            total=3, backoff_factor=1, status_forcelist=[408, 500, 502, 503, 504]
+        )
         adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
         session = requests.Session()
         session.mount("https://", adapter)
         session.mount("http://", adapter)
-        response = session.post(url=f"{report_url}", data=data, files=files)
+
+        try:
+            response = session.post(
+                url=f"{report_url}",
+                data=data,
+                files=files,
+                timeout=DEFAULT_TIMEOUT,
+            )
+        except requests.exceptions.RequestException as e:
+            # Without this the plugin dies with a bare traceback that says
+            # nothing about which URL failed or why.
+            message = ManytaskPlugin._describe_request_exception(e, report_url)
+            raise PluginExecutionFailed(message, output=message) from e
 
         if response.status_code >= HTTP_ERROR_STATUS_CODE:
-            # Put the full response body into `output` so the pipeline prints it
-            # unconditionally (pipeline.py prints `error.output` always, but `message`
-            # only in verbose mode).
+            # Put the full explanation into `output` so the pipeline prints it
+            # unconditionally (pipeline.py prints `error.output` always, but
+            # `message` only in verbose mode).
+            message = ManytaskPlugin._describe_http_error(response, report_url)
             raise PluginExecutionFailed(
                 f"{response.status_code}: {response.text}",
-                output=f"Manytask returned HTTP {response.status_code}:\n{response.text}",
+                output=message,
             )
 
         return response
 
     @staticmethod
-    def _collect_files_to_send(origin: str, patterns: list[str]) -> dict[str, tuple[str, IO[bytes]]]:
+    def _describe_request_exception(
+        exc: requests.exceptions.RequestException,
+        report_url: AnyUrl,
+    ) -> str:
+        """Turn a transport-level failure into an actionable message."""
+        if isinstance(exc, requests.exceptions.RetryError):
+            reason = (
+                "Manytask kept returning a retryable error (408/5xx) after "
+                "3 retries. The server is likely down or overloaded."
+            )
+        elif isinstance(exc, requests.exceptions.ConnectTimeout):
+            reason = "Timed out while connecting. The host may be firewalled or down."
+        elif isinstance(exc, requests.exceptions.ReadTimeout):
+            reason = "Manytask accepted the connection but did not answer in time."
+        elif isinstance(exc, requests.exceptions.SSLError):
+            reason = "TLS handshake failed. Check the certificate and the scheme (http vs https)."
+        elif isinstance(
+            exc, requests.exceptions.MissingSchema | requests.exceptions.InvalidURL
+        ):
+            reason = "The URL is malformed."
+        elif isinstance(exc, requests.exceptions.ConnectionError):
+            reason = "Could not connect. Check the host name, the port and the network."
+        else:
+            reason = "The request could not be completed."
+
+        return (
+            f"Failed to report the score to '{report_url}'.\n"
+            f"{reason}\n"
+            f"Underlying error: {type(exc).__name__}: {exc}\n"
+            f"{ManytaskPlugin._REPORT_URL_HINT}"
+        )
+
+    @staticmethod
+    def _describe_http_error(response: requests.Response, report_url: AnyUrl) -> str:
+        """Build a readable report from a Manytask error response."""
+        status = response.status_code
+        try:
+            reason = HTTPStatus(status).phrase
+        except ValueError:
+            reason = response.reason or "Unknown"
+
+        parts = [
+            f"Manytask rejected the report: HTTP {status} {reason} (from '{report_url}').",
+            f"Server said: {ManytaskPlugin._describe_response_body(response)}",
+        ]
+
+        hint = ManytaskPlugin._hint_for_status(status)
+        if hint:
+            parts.append(f"Hint: {hint}")
+
+        return "\n".join(parts)
+
+    @staticmethod
+    def _hint_for_status(status: int) -> str:
+        """Map a status code onto the most likely misconfiguration."""
+        if status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
+            return (
+                "the course token was not accepted. Check that `report_token` "
+                "holds the token of this exact course (usually the "
+                "MANYTASK_TOKEN secret of the CI job)."
+            )
+        if status == HTTPStatus.NOT_FOUND:
+            return (
+                "Manytask has no such endpoint, course, task or user. Check "
+                "that `report_url` is "
+                "'https://<manytask-host>/api/<course_name>/report', that the "
+                "task exists and is enabled in .manytask.yml, and that the "
+                "student is signed up for the course."
+            )
+        if status == HTTPStatus.CONFLICT:
+            return "the course is already finished, so scores cannot be changed."
+        if status == HTTPStatus.BAD_REQUEST:
+            return (
+                "Manytask could not parse the submission. Check `score` "
+                "(must be a number in [0.0, 2.0]) and `task_name`."
+            )
+        if status == HTTPStatus.REQUEST_ENTITY_TOO_LARGE:
+            return "the attached files are too big; narrow down `patterns`."
+        if status >= HTTPStatus.INTERNAL_SERVER_ERROR:
+            return "this is a server-side failure; check the Manytask instance logs."
+        return ""
+
+    @staticmethod
+    def _describe_response_body(response: requests.Response) -> str:
+        """Extract the message from a JSON or HTML error body."""
+        content_type = response.headers.get("Content-Type", "")
+        text = response.text or ""
+
+        if "json" in content_type.lower():
+            try:
+                payload = response.json()
+            except (json.JSONDecodeError, ValueError):
+                payload = None
+            if isinstance(payload, dict):
+                for key in ("error", "message", "description"):
+                    value = payload.get(key)
+                    if isinstance(value, str) and value.strip():
+                        return value.strip()
+
+        if "html" in content_type.lower() or "<html" in text.lower():
+            # Flask renders abort(code, "msg") as an HTML page; drop the markup
+            # so the actual message stays visible.
+            text = re.sub(r"(?is)<(script|style)\b.*?</\1>", " ", text)
+            text = re.sub(r"(?s)<[^>]+>", " ", text)
+            text = unescape(text)
+
+        text = " ".join(text.split())
+        if len(text) > MAX_ERROR_BODY_LEN:
+            text = f"{text[:MAX_ERROR_BODY_LEN]}... (truncated)"
+        return text or "<empty response body>"
+
+    @staticmethod
+    def _collect_files_to_send(
+        origin: str, patterns: list[str]
+    ) -> dict[str, tuple[str, IO[bytes]]]:
         source_dir = Path(origin)
         return {
             path.name: (str(path.relative_to(source_dir)), open(path, "rb"))

--- a/checker/tests/plugins/test_manytask_plugins.py
+++ b/checker/tests/plugins/test_manytask_plugins.py
@@ -283,7 +283,13 @@ class TestManytaskPlugin:
         args_dict = self.get_default_args_dict()
 
         mocker.patch.object(ManytaskPlugin, "_post_with_retries")
-        ManytaskPlugin._post_with_retries.return_value.json.return_value = {}  # type: ignore[attr-defined]
+        response = ManytaskPlugin._post_with_retries.return_value  # type: ignore[attr-defined]
+        response.json.return_value = {}
+        # A real Response always has a str body and real headers; keep the mock
+        # faithful so the body formatting is exercised rather than mocked away.
+        response.status_code = 200
+        response.text = "score is missing"
+        response.headers = {"Content-Type": "application/json"}
 
         with pytest.raises(PluginExecutionFailed) as exc:
             ManytaskPlugin().run(args_dict)
@@ -296,20 +302,19 @@ class TestManytaskPlugin:
         assert exc.value.output == exc.value.message
 
     @pytest.mark.parametrize(
-        "status_code, body, expected_hint",
+        "status_code, body",
         [
-            (401, "Invalid course token", "report_token"),
-            (403, "Invalid course token", "report_token"),
-            (404, "Task 'x' not found", "report_url"),
-            (409, "course is already finished", "already finished"),
-            (400, "Cannot parse `score`", "score"),
-            (500, "Internal Server Error", "server-side"),
+            (403, "Invalid course token\nHint: check `report_token`."),
+            (404, "Task 'x' not found in course 'test'"),
+            (409, "Cannot update score: course is already finished."),
+            (400, "Cannot parse `score` <abc> to a number"),
+            (500, "Internal Server Error"),
         ],
     )
-    def test_http_error_explains_the_cause(
-        self, status_code: int, body: str, expected_hint: str
+    def test_http_error_reports_status_url_and_server_message(
+        self, status_code: int, body: str
     ) -> None:
-        """Every error response must name the status, the body and a likely cause."""
+        """Manytask answers in plain text, so its message is passed through as-is."""
         with Mocker() as mocker:
             mocker.post(f"{self.REPORT_URL}", status_code=status_code, text=body)
 
@@ -321,19 +326,36 @@ class TestManytaskPlugin:
         output = exc.value.output or ""
         assert str(status_code) in output
         assert body in output
-        assert expected_hint in output
         assert str(self.REPORT_URL) in output
 
+    def test_angle_bracketed_values_survive(self) -> None:
+        """Manytask quotes bad values in <>; markup stripping must not eat them."""
+        body = "Reported `score` <9.5> is too large. Should be between 0.0 and 2.0."
+        with Mocker() as mocker:
+            mocker.post(
+                f"{self.REPORT_URL}",
+                status_code=400,
+                text=body,
+                headers={"Content-Type": "text/plain; charset=utf-8"},
+            )
+
+            with pytest.raises(PluginExecutionFailed) as exc:
+                ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
+
+        assert "<9.5>" in (exc.value.output or "")
+
     def test_html_error_page_is_stripped_of_markup(self) -> None:
-        """Flask renders abort(403, "msg") as HTML; the message must stay readable."""
+        """A proxy or gateway may still answer HTML; keep the message readable."""
         html = (
-            "<!DOCTYPE HTML><html><head><title>403 Forbidden</title></head>"
-            "<body><h1>Forbidden</h1><p>Invalid course token</p></body></html>"
+            "<!DOCTYPE HTML><html><head><title>502 Bad Gateway</title></head>"
+            "<body><h1>Bad Gateway</h1><p>nginx could not reach the backend</p></body></html>"
         )
         with Mocker() as mocker:
             mocker.post(
                 f"{self.REPORT_URL}",
-                status_code=403,
+                status_code=502,
                 text=html,
                 headers={"Content-Type": "text/html; charset=utf-8"},
             )
@@ -344,26 +366,9 @@ class TestManytaskPlugin:
                 )
 
         output = exc.value.output or ""
-        assert "Invalid course token" in output
+        assert "nginx could not reach the backend" in output
         assert "<h1>" not in output
         assert "<html" not in output
-
-    def test_json_error_body_is_unwrapped(self) -> None:
-        """A JSON {"error": ...} body must be shown as the message, not as raw JSON."""
-        with Mocker() as mocker:
-            mocker.post(
-                f"{self.REPORT_URL}",
-                status_code=404,
-                json={"error": "Task 'nonexistent' not found in course 'test'"},
-            )
-
-            with pytest.raises(PluginExecutionFailed) as exc:
-                ManytaskPlugin._post_with_retries(
-                    self.REPORT_URL, {"key": "value"}, None
-                )
-
-        output = exc.value.output or ""
-        assert "Task 'nonexistent' not found in course 'test'" in output
 
     def test_connection_error_is_reported_not_raised_raw(self) -> None:
         """A wrong host must fail the stage with a hint, not with a bare traceback."""

--- a/checker/tests/plugins/test_manytask_plugins.py
+++ b/checker/tests/plugins/test_manytask_plugins.py
@@ -6,6 +6,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any, Type
 
 import pytest
+import requests
 from pydantic import HttpUrl, ValidationError
 from pytest_mock import MockFixture
 from requests_mock import Mocker
@@ -106,7 +107,9 @@ class TestManytaskPlugin:
             ({"report_url": "invalidurl"}, ValidationError),
         ],
     )
-    def test_plugin_args(self, parameters: dict[str, Any], expected_exception: Type[BaseException] | None) -> None:
+    def test_plugin_args(
+        self, parameters: dict[str, Any], expected_exception: Type[BaseException] | None
+    ) -> None:
         args = self.get_default_args_dict()
         args.update(parameters)
         if expected_exception:
@@ -174,7 +177,9 @@ class TestManytaskPlugin:
 
             assert result is not None, "Didn't collect files"
             assert len(result) == taken_files_num, "Wrong file quantity are collected"
-            assert sorted(result.keys()) == sorted(expected_filenames), "Wrong files are collected"
+            assert sorted(result.keys()) == sorted(expected_filenames), (
+                "Wrong files are collected"
+            )
 
             if taken_files_num:
                 open.assert_called_with(mocker.ANY, "rb")  # type: ignore[attr-defined]
@@ -202,16 +207,30 @@ class TestManytaskPlugin:
 
             if expected_exception:
                 with pytest.raises(expected_exception) as exc:
-                    ManytaskPlugin._post_with_retries(self.REPORT_URL, {"key": "value"}, None)
-                assert str(response_status_code) in str(exc.value), "Status code wasn't provided in exception message"
-                assert response_text in str(exc.value), "Error text wasn't provided in exception message"
+                    ManytaskPlugin._post_with_retries(
+                        self.REPORT_URL, {"key": "value"}, None
+                    )
+                assert str(response_status_code) in str(exc.value), (
+                    "Status code wasn't provided in exception message"
+                )
+                assert response_text in str(exc.value), (
+                    "Error text wasn't provided in exception message"
+                )
                 # The full response body must also be stored in `output` so the pipeline
                 # prints it unconditionally (not just in verbose mode).
-                assert exc.value.output is not None, "Response body wasn't propagated to PluginExecutionFailed.output"
-                assert response_text in exc.value.output, "Response body missing from PluginExecutionFailed.output"
-                assert str(response_status_code) in exc.value.output, "Status code missing from output"
+                assert exc.value.output is not None, (
+                    "Response body wasn't propagated to PluginExecutionFailed.output"
+                )
+                assert response_text in exc.value.output, (
+                    "Response body missing from PluginExecutionFailed.output"
+                )
+                assert str(response_status_code) in exc.value.output, (
+                    "Status code missing from output"
+                )
             else:
-                result = ManytaskPlugin._post_with_retries(self.REPORT_URL, {"key": "value"}, None)
+                result = ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
                 assert result.status_code == HTTP_OK
                 assert result.text == "Success"
 
@@ -231,7 +250,9 @@ class TestManytaskPlugin:
         mocker.patch.object(ManytaskPlugin, "_collect_files_to_send")
         ManytaskPlugin._collect_files_to_send.return_value = expected_files  # type: ignore[attr-defined]
         mocker.patch.object(ManytaskPlugin, "_post_with_retries")
-        ManytaskPlugin._post_with_retries.return_value.json.return_value = {"score": result_score}  # type: ignore[attr-defined]
+        ManytaskPlugin._post_with_retries.return_value.json.return_value = {
+            "score": result_score
+        }  # type: ignore[attr-defined]
         result = ManytaskPlugin().run(args_dict)
 
         assert result.output == (
@@ -239,7 +260,9 @@ class TestManytaskPlugin:
             f"requested score: {self.TEST_SCORE}, result score: {result_score}"
         )
 
-        ManytaskPlugin._post_with_retries.assert_called_once_with(self.REPORT_URL, expected_data, expected_files)  # type: ignore[attr-defined]
+        ManytaskPlugin._post_with_retries.assert_called_once_with(
+            self.REPORT_URL, expected_data, expected_files
+        )  # type: ignore[attr-defined]
 
     def test_verbose(self, mocker: MockFixture) -> None:
         args_dict = self.get_default_full_args_dict()
@@ -249,7 +272,9 @@ class TestManytaskPlugin:
         mocker.patch.object(ManytaskPlugin, "_collect_files_to_send")
         ManytaskPlugin._collect_files_to_send.return_value = expected_files  # type: ignore[attr-defined]
         mocker.patch.object(ManytaskPlugin, "_post_with_retries")
-        ManytaskPlugin._post_with_retries.return_value.json.return_value = {"score": result_score}  # type: ignore[attr-defined]
+        ManytaskPlugin._post_with_retries.return_value.json.return_value = {
+            "score": result_score
+        }  # type: ignore[attr-defined]
         result = ManytaskPlugin().run(args_dict, verbose=True)
 
         assert str(expected_files) in result.output
@@ -263,4 +288,125 @@ class TestManytaskPlugin:
         with pytest.raises(PluginExecutionFailed) as exc:
             ManytaskPlugin().run(args_dict)
 
-        assert str(exc.value) == "Unable to decode response"
+        # The message must say *what* could not be decoded and *where from*,
+        # and must reach `output` so the pipeline prints it non-verbosely.
+        assert "Unable to decode response" in exc.value.message
+        assert str(self.REPORT_URL) in exc.value.message
+        assert "report_url" in exc.value.message
+        assert exc.value.output == exc.value.message
+
+    @pytest.mark.parametrize(
+        "status_code, body, expected_hint",
+        [
+            (401, "Invalid course token", "report_token"),
+            (403, "Invalid course token", "report_token"),
+            (404, "Task 'x' not found", "report_url"),
+            (409, "course is already finished", "already finished"),
+            (400, "Cannot parse `score`", "score"),
+            (500, "Internal Server Error", "server-side"),
+        ],
+    )
+    def test_http_error_explains_the_cause(
+        self, status_code: int, body: str, expected_hint: str
+    ) -> None:
+        """Every error response must name the status, the body and a likely cause."""
+        with Mocker() as mocker:
+            mocker.post(f"{self.REPORT_URL}", status_code=status_code, text=body)
+
+            with pytest.raises(PluginExecutionFailed) as exc:
+                ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
+
+        output = exc.value.output or ""
+        assert str(status_code) in output
+        assert body in output
+        assert expected_hint in output
+        assert str(self.REPORT_URL) in output
+
+    def test_html_error_page_is_stripped_of_markup(self) -> None:
+        """Flask renders abort(403, "msg") as HTML; the message must stay readable."""
+        html = (
+            "<!DOCTYPE HTML><html><head><title>403 Forbidden</title></head>"
+            "<body><h1>Forbidden</h1><p>Invalid course token</p></body></html>"
+        )
+        with Mocker() as mocker:
+            mocker.post(
+                f"{self.REPORT_URL}",
+                status_code=403,
+                text=html,
+                headers={"Content-Type": "text/html; charset=utf-8"},
+            )
+
+            with pytest.raises(PluginExecutionFailed) as exc:
+                ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
+
+        output = exc.value.output or ""
+        assert "Invalid course token" in output
+        assert "<h1>" not in output
+        assert "<html" not in output
+
+    def test_json_error_body_is_unwrapped(self) -> None:
+        """A JSON {"error": ...} body must be shown as the message, not as raw JSON."""
+        with Mocker() as mocker:
+            mocker.post(
+                f"{self.REPORT_URL}",
+                status_code=404,
+                json={"error": "Task 'nonexistent' not found in course 'test'"},
+            )
+
+            with pytest.raises(PluginExecutionFailed) as exc:
+                ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
+
+        output = exc.value.output or ""
+        assert "Task 'nonexistent' not found in course 'test'" in output
+
+    def test_connection_error_is_reported_not_raised_raw(self) -> None:
+        """A wrong host must fail the stage with a hint, not with a bare traceback."""
+        with Mocker() as mocker:
+            mocker.post(
+                f"{self.REPORT_URL}",
+                exc=requests.exceptions.ConnectionError("nodename nor servname"),
+            )
+
+            with pytest.raises(PluginExecutionFailed) as exc:
+                ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
+
+        output = exc.value.output or ""
+        assert str(self.REPORT_URL) in output
+        assert "Could not connect" in output
+        assert "ConnectionError" in output
+        assert "report_url" in output
+
+    def test_timeout_is_reported(self) -> None:
+        with Mocker() as mocker:
+            mocker.post(
+                f"{self.REPORT_URL}",
+                exc=requests.exceptions.ConnectTimeout("timed out"),
+            )
+
+            with pytest.raises(PluginExecutionFailed) as exc:
+                ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
+
+        assert "Timed out while connecting" in (exc.value.output or "")
+
+    def test_long_error_body_is_truncated(self) -> None:
+        with Mocker() as mocker:
+            mocker.post(f"{self.REPORT_URL}", status_code=500, text="x" * 5000)
+
+            with pytest.raises(PluginExecutionFailed) as exc:
+                ManytaskPlugin._post_with_retries(
+                    self.REPORT_URL, {"key": "value"}, None
+                )
+
+        output = exc.value.output or ""
+        assert "(truncated)" in output
+        assert len(output) < 2000

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,18 +19,17 @@ However, you can implement your own checker just use the Manytask api. Note that
 
 ## Errors
 
-Every endpoint under `/api/` reports failures as JSON, so a failing CI job says what
-actually went wrong instead of returning an HTML error page:
+Every endpoint under `/api/` reports failures as plain text, so a failing CI job says
+what actually went wrong instead of returning an HTML error page. The body is the
+message itself, optionally followed by a `Hint:` line:
 
-```json
-{
-  "error": "Invalid course token",
-  "hint": "The course token was not accepted. Check that it belongs to this exact course (in the checker it is the `report_token` argument, usually the MANYTASK_TOKEN CI secret)."
-}
+```
+Invalid course token
+Hint: The course token was not accepted. Check that it belongs to this exact course (in the checker it is the `report_token` argument, usually the MANYTASK_TOKEN CI secret).
 ```
 
-`error` is always present and holds the specific reason; `hint` is added for the
-statuses below and suggests the likely misconfiguration.
+The first line is the specific reason; the `Hint:` line is added for the statuses
+below and suggests the likely misconfiguration.
 
 | status | typical cause for `/report` |
 |---|---|

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,3 +16,28 @@ However, you can implement your own checker just use the Manytask api. Note that
 | GET    | `/api/<course_name>/ping`                 | validate course-token without side effects        | -                                                                         | -                                                                                                                     | `course`, `ok`                                                       |
 | GET    | `/api/<course_name>/is_admin`             | check whether RMS user is a course admin          | `rms_username` (query string, RMS/GitLab login)                           | -                                                                                                                     | `rms_username`, `is_admin`                                           |
 | GET    | `/api/<course_name>/deadlines`            | machine-readable list of tasks with deadlines     | -                                                                         | -                                                                                                                     | `course`, `tasks` (list of `{task_name, group, deadline, score, is_bonus, is_large}`) |
+
+## Errors
+
+Every endpoint under `/api/` reports failures as JSON, so a failing CI job says what
+actually went wrong instead of returning an HTML error page:
+
+```json
+{
+  "error": "Invalid course token",
+  "hint": "The course token was not accepted. Check that it belongs to this exact course (in the checker it is the `report_token` argument, usually the MANYTASK_TOKEN CI secret)."
+}
+```
+
+`error` is always present and holds the specific reason; `hint` is added for the
+statuses below and suggests the likely misconfiguration.
+
+| status | typical cause for `/report` |
+|---|---|
+| `400 Bad Request` | `score` is not a number in `[0.0, 2.0]`, or a required field (`task`, `username`/`user_id`) is missing. |
+| `403 Forbidden` | Token missing, empty or not matching the course token. |
+| `404 Not Found` | Wrong URL, or unknown course, task or user. The task must exist and be enabled in `.manytask.yml`, and the student must be signed up for the course. |
+| `405 Method Not Allowed` | `/report` was called with something other than `POST`. |
+| `409 Conflict` | The course is finished, so scores can no longer be changed. |
+
+Use `GET /api/<course_name>/ping` to check the URL and the token without side effects.

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ below and suggests the likely misconfiguration.
 
 | status | typical cause for `/report` |
 |---|---|
-| `400 Bad Request` | `score` is not a number in `[0.0, 2.0]`, or a required field (`task`, `username`/`user_id`) is missing. |
+| `400 Bad Request` | `score` is not a number, or is a non-integer above `2.0`, or a required field (`task`, `username`/`user_id`) is missing. |
 | `403 Forbidden` | Token missing, empty or not matching the course token. |
 | `404 Not Found` | Wrong URL, or unknown course, task or user. The task must exist and be enabled in `.manytask.yml`, and the student must be signed up for the course. |
 | `405 Method Not Allowed` | `/report` was called with something other than `POST`. |

--- a/docs/checker_plugins.md
+++ b/docs/checker_plugins.md
@@ -138,7 +138,7 @@ Send the final score to the Manytask platform via its [REST API](./api.md). Used
 | `username` | `str` | yes | — | Student's username in RMS. |
 | `task_name` | `str` | yes | — | Task identifier as registered in `.manytask.yml`. |
 | `score` | `float \| int \| null` | yes | — | Score to report, in `[0.0, 1.0]` (bonus scores may exceed `1.0` but float larger than `2.0` will not be accepted). |
-| `report_url` | `AnyUrl` | yes | — | Base URL of the Manytask instance. |
+| `report_url` | `AnyUrl` | yes | — | Full URL of the report endpoint: `https://<manytask-host>/api/<course_name>/report`. |
 | `report_token` | `str` | yes | — | Authentication token for the Manytask API. |
 | `check_deadline` | `bool` | yes | — | Whether Manytask should apply deadline penalties server-side. |
 | `origin` | `str \| null` | no | `null` | If set, collect files matching `patterns` from this directory and attach them to the report. |

--- a/manytask/manytask/api.py
+++ b/manytask/manytask/api.py
@@ -13,6 +13,7 @@ from flask.typing import ResponseReturnValue
 from enum import Enum
 from pydantic import ValidationError
 from sqlalchemy.exc import IntegrityError, NoResultFound
+from werkzeug.exceptions import HTTPException
 
 from manytask.abstract import RmsApiException, StorageApi, StoredUser
 from manytask.database import TaskDisabledError
@@ -55,6 +56,53 @@ from .utils.generic import (
 logger = logging.getLogger(__name__)
 bp = Blueprint("api", __name__, url_prefix="/api/<course_name>")
 namespace_bp = Blueprint("namespace_api", __name__, url_prefix="/api")
+
+
+# Hints appended to API errors, so a failing CI job says what to fix instead of
+# just which status code came back.
+_ERROR_HINTS: dict[int, str] = {
+    HTTPStatus.UNAUTHORIZED: (
+        "Provide the course token via the 'Authorization: Bearer <token>' header or the 'token' form field."
+    ),
+    HTTPStatus.FORBIDDEN: (
+        "The course token was not accepted. Check that it belongs to this exact course "
+        "(in the checker it is the `report_token` argument, usually the MANYTASK_TOKEN CI secret)."
+    ),
+    HTTPStatus.NOT_FOUND: (
+        "Check the request URL ('/api/<course_name>/report'), and that the course, task and user exist. "
+        "The task must also be enabled and started in the course config."
+    ),
+    HTTPStatus.METHOD_NOT_ALLOWED: "Check the HTTP method: /report expects POST.",
+    HTTPStatus.CONFLICT: "The course is finished, so scores can no longer be changed.",
+}
+
+
+@bp.app_errorhandler(HTTPException)
+def handle_api_error(error: HTTPException) -> ResponseReturnValue:
+    """Render API errors as JSON with an actionable hint.
+
+    Flask serves ``abort(code, "msg")`` as an HTML page by default, which is
+    unreadable in CI logs and impossible to parse by API clients. Under ``/api/``
+    we answer with ``{"error": ..., "hint": ...}`` instead.
+
+    Registered app-wide (not per-blueprint) on purpose: routing errors such as
+    404 on an unknown URL and 405 on a wrong method are raised before blueprint
+    dispatch, so a blueprint-scoped handler would never see them — and those are
+    exactly the errors a misconfigured `report_url` produces.
+    """
+    if not request.path.startswith("/api/"):
+        # Web pages keep the regular HTML error pages.
+        return error.get_response()
+
+    status = error.code or HTTPStatus.INTERNAL_SERVER_ERROR
+    message = error.description or getattr(error, "name", "Error")
+
+    payload: dict[str, Any] = {"error": message}
+    hint = _ERROR_HINTS.get(status)
+    if hint:
+        payload["hint"] = hint
+
+    return jsonify(payload), status
 
 
 def __get_course_or_not_found(storage_api: StorageApi, course_name: str) -> Course:

--- a/manytask/manytask/api.py
+++ b/manytask/manytask/api.py
@@ -79,11 +79,11 @@ _ERROR_HINTS: dict[int, str] = {
 
 @bp.app_errorhandler(HTTPException)
 def handle_api_error(error: HTTPException) -> ResponseReturnValue:
-    """Render API errors as JSON with an actionable hint.
+    """Render API errors as plain text, so the body is the message itself.
 
-    Flask serves ``abort(code, "msg")`` as an HTML page by default, which is
-    unreadable in CI logs and impossible to parse by API clients. Under ``/api/``
-    we answer with ``{"error": ..., "hint": ...}`` instead.
+    Flask serves ``abort(code, "msg")`` as an HTML page by default, which buries
+    the reason in markup. Under ``/api/`` the body is just the message plus an
+    optional hint, readable as-is in CI logs and needing no parsing by clients.
 
     Registered app-wide (not per-blueprint) on purpose: routing errors such as
     404 on an unknown URL and 405 on a wrong method are raised before blueprint
@@ -95,14 +95,12 @@ def handle_api_error(error: HTTPException) -> ResponseReturnValue:
         return error.get_response()
 
     status = error.code or HTTPStatus.INTERNAL_SERVER_ERROR
-    message = error.description or getattr(error, "name", "Error")
+    message: str = error.description or getattr(error, "name", None) or "Error"
 
-    payload: dict[str, Any] = {"error": message}
     hint = _ERROR_HINTS.get(status)
-    if hint:
-        payload["hint"] = hint
+    body = f"{message}\nHint: {hint}" if hint else message
 
-    return jsonify(payload), status
+    return body, status, {"Content-Type": "text/plain; charset=utf-8"}
 
 
 def __get_course_or_not_found(storage_api: StorageApi, course_name: str) -> Course:

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -1034,8 +1034,8 @@ def test_get_requests_invalid_or_disabled_task(app, path, task_name):
 
 # ----- Detailed error responses for /report (and shared helpers) -----
 #
-# API blueprints render aborts as JSON ({"error": ..., "hint": ...}) instead of Flask's
-# default HTML page, so failures are readable in CI logs and parsable by clients.
+# /api/ errors are plain text: the message itself, plus an optional "Hint:" line.
+# No HTML wrapper, so the body is readable as-is in CI logs.
 # Tests check the status code + a distinguishing substring in response.data.
 
 
@@ -1136,17 +1136,18 @@ def test_report_unknown_task_detailed_404(app):
     assert TEST_COURSE_NAME.encode() in response.data
 
 
-def test_report_errors_are_json_with_hint(app):
-    """Errors must be machine-readable JSON, not an HTML page."""
+def test_report_error_is_plain_text_with_hint(app):
+    """The body must be the message itself, with no HTML wrapper to dig through."""
     response = _post_report(app, headers={"Authorization": "Bearer wrong_token"})
 
     assert response.status_code == HTTPStatus.FORBIDDEN
-    assert response.is_json, "API errors must be JSON so clients can parse them"
+    assert response.mimetype == "text/plain"
 
-    data = json.loads(response.data)
-    assert "Invalid course token" in data["error"]
+    body = response.get_data(as_text=True)
+    assert body.startswith("Invalid course token")
+    assert "<html" not in body.lower()
     # The hint must point at the actual misconfiguration.
-    assert "report_token" in data["hint"]
+    assert "report_token" in body
 
 
 def test_report_not_found_error_hint_mentions_url_and_task(app):
@@ -1158,38 +1159,37 @@ def test_report_not_found_error_hint_mentions_url_and_task(app):
     )
 
     assert response.status_code == HTTPStatus.NOT_FOUND
-    data = json.loads(response.data)
-    assert INVALID_TASK_NAME in data["error"]
-    assert "/api/<course_name>/report" in data["hint"]
+    body = response.get_data(as_text=True)
+    assert INVALID_TASK_NAME in body
+    assert "/api/<course_name>/report" in body
 
 
-def test_report_wrong_method_is_json(app):
+def test_report_wrong_method_is_plain_text(app):
     """A GET on /report (a common URL mistake) must explain the method mismatch."""
     response = app.test_client().get(f"/api/{TEST_COURSE_NAME}/report", headers=_valid_token_headers())
 
     assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED
-    data = json.loads(response.data)
-    assert "POST" in data["hint"]
+    assert "POST" in response.get_data(as_text=True)
 
 
-def test_wrong_api_endpoint_is_json_with_hint(app):
-    """A misspelled `report_url` must produce a parsable error, not an HTML 404 page."""
+def test_wrong_api_endpoint_explains_the_endpoint(app):
+    """A misspelled `report_url` must say what the right endpoint looks like."""
     response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/repot", headers=_valid_token_headers())
 
     assert response.status_code == HTTPStatus.NOT_FOUND
-    assert response.is_json
-    assert "/api/<course_name>/report" in json.loads(response.data)["hint"]
+    assert response.mimetype == "text/plain"
+    assert "/api/<course_name>/report" in response.get_data(as_text=True)
 
 
 def test_non_api_404_stays_html(app):
-    """Only /api/ errors become JSON; web pages keep their HTML error pages."""
+    """Only /api/ errors become plain text; web pages keep their HTML error pages."""
     response = app.test_client().get("/no_such_page/deeper/still", follow_redirects=True)
 
     assert response.status_code == HTTPStatus.NOT_FOUND
-    assert not response.is_json
+    assert response.mimetype == "text/html"
 
 
-def test_report_bad_score_error_is_json(app):
+def test_report_bad_score_error_is_plain_text(app):
     app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
     response = _post_report(
         app,
@@ -1198,8 +1198,7 @@ def test_report_bad_score_error_is_json(app):
     )
 
     assert response.status_code == HTTPStatus.BAD_REQUEST
-    data = json.loads(response.data)
-    assert "score" in data["error"]
+    assert "score" in response.get_data(as_text=True)
 
 
 def test_score_endpoint_invalid_token_detailed_403(app):

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -1034,9 +1034,9 @@ def test_get_requests_invalid_or_disabled_task(app, path, task_name):
 
 # ----- Detailed error responses for /report (and shared helpers) -----
 #
-# Following the project pattern, abort(STATUS, "msg") returns Flask's HTML error page
-# with the message embedded in the body. Tests check status code + a distinguishing
-# substring in response.data (same approach as test_report_score_missing_task above).
+# API blueprints render aborts as JSON ({"error": ..., "hint": ...}) instead of Flask's
+# default HTML page, so failures are readable in CI logs and parsable by clients.
+# Tests check the status code + a distinguishing substring in response.data.
 
 
 def _valid_token_headers():
@@ -1134,6 +1134,72 @@ def test_report_unknown_task_detailed_404(app):
     assert response.status_code == HTTPStatus.NOT_FOUND
     assert INVALID_TASK_NAME.encode() in response.data
     assert TEST_COURSE_NAME.encode() in response.data
+
+
+def test_report_errors_are_json_with_hint(app):
+    """Errors must be machine-readable JSON, not an HTML page."""
+    response = _post_report(app, headers={"Authorization": "Bearer wrong_token"})
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+    assert response.is_json, "API errors must be JSON so clients can parse them"
+
+    data = json.loads(response.data)
+    assert "Invalid course token" in data["error"]
+    # The hint must point at the actual misconfiguration.
+    assert "report_token" in data["hint"]
+
+
+def test_report_not_found_error_hint_mentions_url_and_task(app):
+    app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
+    response = _post_report(
+        app,
+        data={"user_id": TEST_RMS_ID, "task": INVALID_TASK_NAME},
+        headers=_valid_token_headers(),
+    )
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    data = json.loads(response.data)
+    assert INVALID_TASK_NAME in data["error"]
+    assert "/api/<course_name>/report" in data["hint"]
+
+
+def test_report_wrong_method_is_json(app):
+    """A GET on /report (a common URL mistake) must explain the method mismatch."""
+    response = app.test_client().get(f"/api/{TEST_COURSE_NAME}/report", headers=_valid_token_headers())
+
+    assert response.status_code == HTTPStatus.METHOD_NOT_ALLOWED
+    data = json.loads(response.data)
+    assert "POST" in data["hint"]
+
+
+def test_wrong_api_endpoint_is_json_with_hint(app):
+    """A misspelled `report_url` must produce a parsable error, not an HTML 404 page."""
+    response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/repot", headers=_valid_token_headers())
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert response.is_json
+    assert "/api/<course_name>/report" in json.loads(response.data)["hint"]
+
+
+def test_non_api_404_stays_html(app):
+    """Only /api/ errors become JSON; web pages keep their HTML error pages."""
+    response = app.test_client().get("/no_such_page/deeper/still", follow_redirects=True)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert not response.is_json
+
+
+def test_report_bad_score_error_is_json(app):
+    app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
+    response = _post_report(
+        app,
+        data={"user_id": TEST_RMS_ID, "task": TEST_TASK_NAME, "score": "not_a_number"},
+        headers=_valid_token_headers(),
+    )
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    data = json.loads(response.data)
+    assert "score" in data["error"]
 
 
 def test_score_endpoint_invalid_token_detailed_403(app):


### PR DESCRIPTION
it is often benefitial to see what waent wrong when the score was reported. This genrates clear message of what happened and reports is back.
Issue #702 