### PR TITLE
feat: Allow to hide students from the list of scores

### DIFF
--- a/manytask/manytask/abstract.py
+++ b/manytask/manytask/abstract.py
@@ -56,6 +56,7 @@ class StudentCourseScores:
     final_grade: int | None = None
     final_grade_override: int | None = None
     comment: str | None = None
+    hidden: bool = False
 
     def __repr__(self) -> str:
         return f"StudentCourseScores(username={self.username}, tasks={len(self.task_scores)})"
@@ -136,10 +137,15 @@ class StorageApi(ABC):
     def sync_user_on_course(self, course_name: str, username: str, course_admin: bool) -> None: ...
 
     @abstractmethod
-    def get_all_scores_with_names(self, course_name: str) -> dict[str, StudentCourseScores]: ...
+    def get_all_scores_with_names(
+        self, course_name: str, include_hidden: bool = False
+    ) -> dict[str, StudentCourseScores]: ...
 
     @abstractmethod
     def update_student_comment(self, course_name: str, username: str, comment: str | None) -> None: ...
+
+    @abstractmethod
+    def update_student_hidden(self, course_name: str, username: str, hidden: bool) -> None: ...
 
     @abstractmethod
     def get_grades(self, course_name: str) -> ManytaskFinalGradeConfig: ...

--- a/manytask/manytask/api.py
+++ b/manytask/manytask/api.py
@@ -645,24 +645,28 @@ def get_database(course_name: str, auth_method: AuthMethod) -> ResponseReturnVal
     return jsonify(table_data)
 
 
-@bp.post("/database/update")
+@bp.route("/database/update", methods=["POST", "PATCH"])
 @requires_auth_or_token
 @requires_ready
 def update_database(course_name: str, auth_method: AuthMethod) -> ResponseReturnValue:
     """
     Update student scores in the database via API endpoint and recalculate grade.
+
+    Course admins may additionally set the ``hidden`` flag on the student, which
+    removes them from score listings and statistics for non-admins.
     """
     app: CustomFlask = current_app  # type: ignore
     course: Course = app.storage_api.get_course(course_name)  # type: ignore
 
     storage_api = app.storage_api
 
+    is_course_admin = True
     if auth_method == AuthMethod.SESSION:
         username = session["manytask"]["username"]
         logger.info("Request by user=%s for course=%s", username, course_name)
-        student_course_admin = storage_api.check_if_course_admin(course_name, username)
+        is_course_admin = storage_api.check_if_course_admin(course_name, username)
 
-        if not student_course_admin:
+        if not is_course_admin:
             return jsonify({"success": False, "message": "Only course admins can update scores"}), HTTPStatus.FORBIDDEN
 
     if not request.is_json:
@@ -682,6 +686,19 @@ def update_database(course_name: str, auth_method: AuthMethod) -> ResponseReturn
     student_username = row_data.username
     total_score = row_data.total_score
     logger.info("Updating scores for user=%s: %s", sanitize_log_data(student_username), new_scores)
+
+    if row_data.hidden is not None:
+        if not is_course_admin:
+            return jsonify({"success": False, "message": "Only course admins can hide students"}), HTTPStatus.FORBIDDEN
+
+        try:
+            storage_api.update_student_hidden(course.course_name, student_username, row_data.hidden)
+            logger.info("Set hidden=%s for user=%s", row_data.hidden, sanitize_log_data(student_username))
+        except Exception as e:
+            logger.error("Error updating hidden flag: %s", str(e))
+            return jsonify(
+                {"success": False, "message": "Internal error when updating hidden flag"}
+            ), HTTPStatus.INTERNAL_SERVER_ERROR
 
     try:
         for task_name, new_score in new_scores.items():

--- a/manytask/manytask/config.py
+++ b/manytask/manytask/config.py
@@ -21,10 +21,12 @@ class RowData(BaseModel):
     grade: int
     scores: dict[str, int]
     grade_is_override: bool = False  # Indicates if grade is manually overridden by admin
+    # None means "leave unchanged"; only course admins may set it
+    hidden: Optional[bool] = None
 
 
 class ManytaskUpdateDatabasePayload(BaseModel):
-    new_scores: dict[str, Any] = Field(...)
+    new_scores: dict[str, Any] = Field(default_factory=dict)
     row_data: RowData
 
 

--- a/manytask/manytask/database.py
+++ b/manytask/manytask/database.py
@@ -431,13 +431,16 @@ class DataBaseApi(StorageApi):
 
             session.commit()
 
-    def get_all_scores_with_names(self, course_name: str) -> dict[str, StudentCourseScores]:
+    def get_all_scores_with_names(
+        self, course_name: str, include_hidden: bool = False
+    ) -> dict[str, StudentCourseScores]:
         """Get all users' scores with names and grade data for the given course.
 
         Returns:
             dict mapping username to a StudentCourseScores object.
 
         Excludes users with PROGRAM_MANAGER role in the course's namespace.
+        Excludes students hidden by a course admin unless ``include_hidden`` is set.
         """
 
         with self._session_create() as session:
@@ -462,6 +465,7 @@ class DataBaseApi(StorageApi):
                     UserOnCourse.final_grade,
                     UserOnCourse.final_grade_override,
                     UserOnCourse.comment,
+                    UserOnCourse.hidden,
                 )
                 .join(UserOnCourse, UserOnCourse.user_id == User.id)
                 .join(Course, Course.id == UserOnCourse.course_id)
@@ -475,6 +479,9 @@ class DataBaseApi(StorageApi):
 
             if program_managers_subquery is not None:
                 statement = statement.where(~User.id.in_(program_managers_subquery))
+
+            if not include_hidden:
+                statement = statement.where(UserOnCourse.hidden.is_(False))
 
             rows = session.execute(statement).all()
 
@@ -490,6 +497,7 @@ class DataBaseApi(StorageApi):
                         final_grade=row.final_grade,
                         final_grade_override=row.final_grade_override,
                         comment=row.comment,
+                        hidden=row.hidden,
                     )
                     scores_and_names[row.username] = student
                 if row.task_name is not None:
@@ -526,7 +534,7 @@ class DataBaseApi(StorageApi):
     def get_stats(self, course_name: str) -> dict[str, float]:
         """Method for getting stats of all tasks
 
-        Excludes users with PROGRAM_MANAGER role from statistics.
+        Excludes users with PROGRAM_MANAGER role and hidden students from statistics.
 
         :param course_name: course name
 
@@ -547,7 +555,7 @@ class DataBaseApi(StorageApi):
             users_count_query = (
                 session.query(func.count(UserOnCourse.id))
                 .join(Course, Course.id == UserOnCourse.course_id)
-                .filter(Course.name == course_name)
+                .filter(Course.name == course_name, UserOnCourse.hidden.is_(False))
             )
             if program_managers_subquery is not None:
                 users_count_query = users_count_query.filter(~UserOnCourse.user_id.in_(program_managers_subquery))
@@ -1824,25 +1832,24 @@ class DataBaseApi(StorageApi):
         course_name: str,
         program_managers_subquery: Select[tuple[int]] | None = None,
     ) -> list[Row[tuple[int, str, int]]]:
-        """Get count of task submits, optionally excluding program managers.
+        """Get count of task submits, excluding hidden students and optionally program managers.
 
         :param session: Database session
         :param course_name: Name of the course
         :param program_managers_subquery: Subquery to select user IDs to exclude (program managers)
         :return: List of (task_id, task_name, submits_count) tuples
         """
-        join_conditions = [Grade.task_id == Task.id]
+        counted_users_conditions = [
+            UserOnCourse.course_id == Course.id,
+            UserOnCourse.hidden.is_(False),
+        ]
         if program_managers_subquery is not None:
-            join_conditions.append(
-                Grade.user_on_course_id.in_(
-                    select(UserOnCourse.id).where(
-                        and_(
-                            UserOnCourse.course_id == Course.id,
-                            ~UserOnCourse.user_id.in_(program_managers_subquery),
-                        )
-                    )
-                )
-            )
+            counted_users_conditions.append(~UserOnCourse.user_id.in_(program_managers_subquery))
+
+        join_conditions = [
+            Grade.task_id == Task.id,
+            Grade.user_on_course_id.in_(select(UserOnCourse.id).where(and_(*counted_users_conditions))),
+        ]
 
         query = (
             session.query(
@@ -1877,6 +1884,25 @@ class DataBaseApi(StorageApi):
                 session.commit()
 
                 logger.info(f"Updated comment for user {username} in course {course_name}: -> '{comment}'")
+            except NoResultFound:
+                logger.error(f"User {username} not found in course {course_name}")
+                raise
+
+    def update_student_hidden(self, course_name: str, username: str, hidden: bool) -> None:
+        """Hide or unhide a student on a course.
+
+        Hidden students are excluded from scores listings and statistics for everyone
+        except course admins.
+        """
+        with self._session_create() as session:
+            try:
+                course = self._get(session, models.Course, name=course_name)
+                user_on_course = self._get_or_create_user_on_course(session, username, course)
+
+                user_on_course.hidden = hidden
+                session.commit()
+
+                logger.info(f"Updated hidden flag for user {username} in course {course_name}: -> {hidden}")
             except NoResultFound:
                 logger.error(f"User {username} not found in course {course_name}")
                 raise
@@ -2476,8 +2502,11 @@ class DataBaseApi(StorageApi):
 
         Call after changing grade configuration to keep saved grades in sync.
         Skips students with final_grade_override.
+
+        Includes hidden students: hiding a student must not stop their own grade
+        from being kept up to date.
         """
-        scores_and_names = self.get_all_scores_with_names(course_name)
+        scores_and_names = self.get_all_scores_with_names(course_name, include_hidden=True)
         grades_config = self.get_grades(course_name)
         course = self.get_course(course_name)
         if course is None:

--- a/manytask/manytask/migrations/versions/c9f4e1a7b2d3_add_hidden_to_user_on_course.py
+++ b/manytask/manytask/migrations/versions/c9f4e1a7b2d3_add_hidden_to_user_on_course.py
@@ -1,0 +1,29 @@
+"""add_hidden_to_user_on_course
+
+Revision ID: c9f4e1a7b2d3
+Revises: a1b2c3d4e5f6
+Create Date: 2026-08-25 20:24:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c9f4e1a7b2d3'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'users_on_courses',
+        sa.Column('hidden', sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('users_on_courses', 'hidden')

--- a/manytask/manytask/models.py
+++ b/manytask/manytask/models.py
@@ -291,6 +291,7 @@ class UserOnCourse(Base):
     course_id: Mapped[int] = mapped_column(ForeignKey(Course.id))
     join_date: Mapped[datetime] = mapped_column(server_default=func.now())
     is_course_admin: Mapped[bool] = mapped_column(default=False)
+    hidden: Mapped[bool] = mapped_column(default=False, server_default="false")
     comment: Mapped[Optional[str]] = mapped_column(default=None)
     final_grade: Mapped[Optional[int]] = mapped_column(default=None)
     final_grade_override: Mapped[Optional[int]] = mapped_column(default=None)

--- a/manytask/manytask/static/css/database.css
+++ b/manytask/manytask/static/css/database.css
@@ -24,6 +24,21 @@
     pointer-events: none;
 }
 
+.tabulator-row.row-hidden,
+.tabulator-row.row-hidden .tabulator-cell {
+    color: #8a8a8a;
+}
+
+.tabulator-row.row-hidden .tabulator-cell a {
+    color: #8a8a8a;
+}
+
+[data-bs-theme="dark"] .tabulator-row.row-hidden,
+[data-bs-theme="dark"] .tabulator-row.row-hidden .tabulator-cell,
+[data-bs-theme="dark"] .tabulator-row.row-hidden .tabulator-cell a {
+    color: #7a7a7a;
+}
+
 .db-filter-clear {
   transition: all 0.3s ease;
 }

--- a/manytask/manytask/templates/database.html
+++ b/manytask/manytask/templates/database.html
@@ -11,9 +11,15 @@
             <h2 class="mb-0">Course Database</h2>
             
             {% if is_course_admin %}
-            <button id="toggle-personal-info" class="btn btn-outline-secondary btn-sm" title="Toggle personal info columns">
-                <i class="fas fa-eye"></i> Toggle Personal Info
-            </button>
+            <div class="d-flex gap-2">
+                <button id="toggle-hidden-students" class="btn btn-outline-secondary btn-sm"
+                        title="Show or hide students hidden by an admin" aria-pressed="true">
+                    <i class="fas fa-eye"></i> Toggle Hidden Students
+                </button>
+                <button id="toggle-personal-info" class="btn btn-outline-secondary btn-sm" title="Toggle personal info columns">
+                    <i class="fas fa-eye"></i> Toggle Personal Info
+                </button>
+            </div>
             {% endif %}
         </div>
 
@@ -264,6 +270,40 @@
                 });
         }
 
+        // Hide/unhide a student (course admins only).
+        function toggleHidden(cell, hidden) {
+            const row = cell.getRow();
+            const rowData = row.getData();
+
+            fetch('{{ url_for("api.update_database", course_name=course_name) }}', {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest'
+                },
+                body: JSON.stringify({
+                    new_scores: {},
+                    row_data: Object.assign({}, rowData, {hidden: hidden})
+                })
+            })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        row.update({hidden: hidden});
+                        row.reformat();
+                        window.tabulatorTable.setFilter(window.customFilter);
+                    } else {
+                        alert('Failed to update hidden flag: ' + data.message);
+                        cell.getElement().querySelector('.hide-student-checkbox').checked = !hidden;
+                    }
+                })
+                .catch(error => {
+                    console.error('Error updating hidden flag:', error);
+                    alert('Failed to update hidden flag');
+                    cell.getElement().querySelector('.hide-student-checkbox').checked = !hidden;
+                });
+        }
+
         function editGrade(cell) {
             const isAdmin = {{ is_course_admin|tojson }};
             if (!isAdmin) {
@@ -400,9 +440,21 @@
 
             const valueEl = document.getElementById("filter-value");
 
-            // Transliteration-aware search uses the shared normalizeForSearch()
-            // helper (static/js/search-normalize.js).
+            {% if is_course_admin %}
+            // Admins see hidden students by default; the toggle above the table flips this.
+            window.showHiddenStudents = true;
+            {% endif %}
+
+            // Exposed on window so handlers defined outside this scope (e.g. toggleHidden)
+            // can re-apply the active filter.
+            window.customFilter = customFilter;
+
             function customFilter(data) {
+                {% if is_course_admin %}
+                if (data.hidden && !window.showHiddenStudents) return false;
+                {% endif %}
+                // Transliteration-aware search uses the shared normalizeForSearch()
+                // helper (static/js/search-normalize.js).
                 const searchTerm = normalizeForSearch(valueEl.value);
                 if (!searchTerm) return true;
                 if (normalizeForSearch(data.username).includes(searchTerm)) {
@@ -436,7 +488,12 @@
 
             document.getElementById("filter-clear").addEventListener('click', function (event) {
                 valueEl.value = "";
+                {% if is_course_admin %}
+                // Keep the hidden-students rule applied when clearing the text search.
+                window.tabulatorTable.setFilter(customFilter);
+                {% else %}
                 window.tabulatorTable.clearFilter();
+                {% endif %}
             })
 
             fetch('{{ url_for("api.get_database", course_name=course_name) }}')
@@ -558,8 +615,29 @@
                         }
                     ];
 
-                    // Add comment column only for course admins
+                    // Add hide/unhide + comment columns only for course admins
                     {% if is_course_admin %}
+                    columns.push({
+                        title: "Hide",
+                        field: "hidden",
+                        frozen: true,
+                        minWidth: 1,
+                        width: 60,
+                        hozAlign: "center",
+                        headerSort: false,
+                        headerTooltip: "Hide this student from non-admins",
+                        formatter: function (cell) {
+                            const checked = cell.getValue() ? "checked" : "";
+                            const username = cell.getRow().getData().username;
+                            return `<input type="checkbox" class="form-check-input hide-student-checkbox" ${checked}`
+                                + ` aria-label="Hide ${username}" title="${cell.getValue() ? "Unhide" : "Hide"} ${username}">`;
+                        },
+                        cellClick: function (e, cell) {
+                            // Only react to the checkbox itself, so clicking the cell padding does nothing.
+                            if (!e.target.classList.contains('hide-student-checkbox')) return;
+                            toggleHidden(cell, e.target.checked);
+                        }
+                    });
                     columns.push({
                         title: "Comment",
                         field: "comment",
@@ -710,6 +788,8 @@
 
                             const data = row.getData();
 
+                            row.getElement().classList.toggle('row-hidden', !!data.hidden);
+
                             // Add individual task scores and group totals
                             const groupColumns = window.tabulatorTable.getColumns().filter(col => col.getDefinition().columns);
                             groupColumns.forEach(groupCol => {
@@ -775,6 +855,26 @@
 
                     window.tabulatorTable.on("tableBuilt", function () {
                         document.getElementById("loader").style.display = "none"
+
+                        {% if is_course_admin %}
+                        // Admins see hidden students by default.
+                        window.tabulatorTable.setFilter(customFilter);
+
+                        const hiddenToggle = document.getElementById('toggle-hidden-students');
+                        if (hiddenToggle) {
+                            hiddenToggle.addEventListener('click', function () {
+                                window.showHiddenStudents = !window.showHiddenStudents;
+
+                                hiddenToggle.setAttribute('aria-pressed', String(window.showHiddenStudents));
+                                // Swap only the icon; the label lives in the button markup.
+                                const hiddenIcon = hiddenToggle.querySelector('i');
+                                hiddenIcon.classList.toggle('fa-eye', window.showHiddenStudents);
+                                hiddenIcon.classList.toggle('fa-eye-slash', !window.showHiddenStudents);
+
+                                window.tabulatorTable.setFilter(customFilter);
+                            });
+                        }
+                        {% endif %}
                     });
 
                     // Wait for a short delay to ensure table is rendered

--- a/manytask/manytask/utils/database.py
+++ b/manytask/manytask/utils/database.py
@@ -16,11 +16,13 @@ def get_database_table_data(
 
     Set include_admin_data=True to include per-student repo URLs, comments, and full names (for admins-only views).
     Set is_program_manager=True to include student full names (for program managers).
+
+    Students hidden by a course admin are only returned when include_admin_data is set.
     """
 
     course_name = course.course_name
     storage_api = app.storage_api
-    scores_and_names = storage_api.get_all_scores_with_names(course_name)
+    scores_and_names = storage_api.get_all_scores_with_names(course_name, include_hidden=include_admin_data)
     grades_config = storage_api.get_grades(course_name)
 
     all_tasks = []
@@ -60,6 +62,7 @@ def get_database_table_data(
                         course_students_group=course.gitlab_course_students_group,
                     ),
                     "comment": student.comment,
+                    "hidden": student.hidden,
                 }
             )
 

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -524,6 +524,48 @@ def test_update_database_success(app, authenticated_client):
     assert data["success"]
 
 
+def test_update_database_sets_hidden_for_admin(app, authenticated_client):
+    """Course admins can flip the hidden flag through /database/update."""
+    test_data = {
+        "row_data": {
+            "username": TEST_USERNAME,
+            "total_score": 0,
+            "grade": 0,
+            "percent": 0,
+            "large_count": 0,
+            "scores": {},
+            "hidden": True,
+        },
+        "new_scores": {},
+    }
+    with patch.object(app.storage_api, "update_student_hidden", create=True) as mock_hidden:
+        response = authenticated_client.patch(f"/api/{TEST_COURSE_NAME}/database/update", json=test_data)
+
+    assert response.status_code == HTTPStatus.OK
+    assert json.loads(response.data)["success"]
+    mock_hidden.assert_called_once_with(TEST_COURSE_NAME, TEST_USERNAME, True)
+
+
+def test_update_database_hidden_omitted_leaves_flag_untouched(app, authenticated_client):
+    """A plain score update must not change the hidden flag."""
+    test_data = {
+        "row_data": {
+            "username": TEST_USERNAME,
+            "total_score": 0,
+            "grade": 0,
+            "percent": 0,
+            "large_count": 0,
+            "scores": {},
+        },
+        "new_scores": {"task1": 90},
+    }
+    with patch.object(app.storage_api, "update_student_hidden", create=True) as mock_hidden:
+        response = authenticated_client.post(f"/api/{TEST_COURSE_NAME}/database/update", json=test_data)
+
+    assert response.status_code == HTTPStatus.OK
+    mock_hidden.assert_not_called()
+
+
 def test_update_database_invalid_score_type(app, authenticated_client):
     test_data = {
         "row_data": {

--- a/manytask/tests/test_database_utils.py
+++ b/manytask/tests/test_database_utils.py
@@ -96,7 +96,7 @@ def app():  # noqa: C901
             return datetime.datetime.now() + datetime.timedelta(hours=1)
 
         @staticmethod
-        def get_all_scores_with_names(_course_name):
+        def get_all_scores_with_names(_course_name, include_hidden=False):
             return {
                 STUDENT_1: StudentCourseScores(
                     username=STUDENT_1,
@@ -184,6 +184,33 @@ def test_get_database_table_data(app):
             assert student["grade_is_override"] is expected_overrides[student_id]
 
 
+def test_get_database_table_data_hidden_only_requested_by_admins(app):
+    """Hidden students are only fetched for admin views, and `hidden` is admin-only data."""
+    calls = []
+    original = app.storage_api.get_all_scores_with_names
+
+    def recording_get_all_scores_with_names(course_name, include_hidden=False):
+        calls.append(include_hidden)
+        students = original(course_name)
+        students[STUDENT_2].hidden = True
+        return students
+
+    app.storage_api.get_all_scores_with_names = recording_get_all_scores_with_names
+
+    with app.test_request_context():
+        test_course = app.storage_api.get_course("test_course")
+
+        non_admin = get_database_table_data(app, test_course, include_admin_data=False)
+        # Non-admins must not ask for hidden students, nor see the flag
+        assert calls == [False]
+        assert all("hidden" not in student for student in non_admin["students"])
+
+        admin = get_database_table_data(app, test_course, include_admin_data=True)
+        assert calls == [False, True]
+        hidden_flags = {student["username"]: student["hidden"] for student in admin["students"]}
+        assert hidden_flags == {STUDENT_1: False, STUDENT_2: True}
+
+
 def test_get_database_table_data_with_admin_data(app):
     """Test database table data with admin data (admin view)"""
     expected_tasks_count = 3
@@ -233,7 +260,7 @@ def test_get_database_table_data_no_scores(app):
     expected_tasks_count = 3
 
     with app.test_request_context():
-        app.storage_api.get_all_scores_with_names = lambda _course_name: {}
+        app.storage_api.get_all_scores_with_names = lambda _course_name, include_hidden=False: {}
         test_course = app.storage_api.get_course("test_course")
         result = get_database_table_data(app, test_course)
 
@@ -256,7 +283,7 @@ def test_get_database_table_data_uses_displayed_percent_for_grade(app):
             3: [{Path(""): 0}],
         }
     )
-    app.storage_api.get_all_scores_with_names = lambda _course_name: {
+    app.storage_api.get_all_scores_with_names = lambda _course_name, include_hidden=False: {
         STUDENT_1: StudentCourseScores(
             username=STUDENT_1,
             first_name=STUDENT_DATA[STUDENT_1][0],

--- a/manytask/tests/test_db_api.py
+++ b/manytask/tests/test_db_api.py
@@ -816,6 +816,64 @@ def test_store_bonus_score(db_api_with_initialized_first_course, session):
     assert scores == {"bonus_score": 1, "task_0_0": 1}
 
 
+def test_hidden_student_excluded_from_scores_and_stats(db_api_with_initialized_first_course):
+    """Hidden students disappear from listings and stats, but remain visible to admins."""
+    # One of the two counted students solved the task
+    half_solved = 0.5
+    db_api = db_api_with_initialized_first_course
+
+    create_user(db_api, STUDENT_1)
+    create_user(db_api, STUDENT_2)
+    db_api.sync_user_on_course(FIRST_COURSE_NAME, TEST_USERNAME_1, course_admin=False)
+    db_api.sync_user_on_course(FIRST_COURSE_NAME, TEST_USERNAME_2, course_admin=False)
+
+    # Only student 1 solved the task, so the mean is 1/2 while both are visible.
+    db_api.store_score(FIRST_COURSE_NAME, TEST_USERNAME_1, "task_0_0", update_func(1))
+
+    assert set(db_api.get_all_scores_with_names(FIRST_COURSE_NAME)) == {TEST_USERNAME_1, TEST_USERNAME_2}
+    assert db_api.get_stats(FIRST_COURSE_NAME)["task_0_0"] == half_solved
+
+    db_api.update_student_hidden(FIRST_COURSE_NAME, TEST_USERNAME_2, True)
+
+    # Default listing hides the student; admins can still request them.
+    visible = db_api.get_all_scores_with_names(FIRST_COURSE_NAME)
+    assert set(visible) == {TEST_USERNAME_1}
+
+    with_hidden = db_api.get_all_scores_with_names(FIRST_COURSE_NAME, include_hidden=True)
+    assert set(with_hidden) == {TEST_USERNAME_1, TEST_USERNAME_2}
+    assert with_hidden[TEST_USERNAME_2].hidden is True
+    assert with_hidden[TEST_USERNAME_1].hidden is False
+
+    # The hidden student leaves the denominator entirely: 1 solver of 1 counted student.
+    assert db_api.get_stats(FIRST_COURSE_NAME)["task_0_0"] == 1.0
+
+    # Unhiding restores the previous state.
+    db_api.update_student_hidden(FIRST_COURSE_NAME, TEST_USERNAME_2, False)
+    assert set(db_api.get_all_scores_with_names(FIRST_COURSE_NAME)) == {TEST_USERNAME_1, TEST_USERNAME_2}
+    assert db_api.get_stats(FIRST_COURSE_NAME)["task_0_0"] == half_solved
+
+
+def test_hidden_student_excluded_from_stats_numerator(db_api_with_initialized_first_course):
+    """A hidden student's own submits must not count towards task statistics."""
+    # One of the two counted students solved the task
+    half_solved = 0.5
+    db_api = db_api_with_initialized_first_course
+
+    create_user(db_api, STUDENT_1)
+    create_user(db_api, STUDENT_2)
+    db_api.sync_user_on_course(FIRST_COURSE_NAME, TEST_USERNAME_1, course_admin=False)
+    db_api.sync_user_on_course(FIRST_COURSE_NAME, TEST_USERNAME_2, course_admin=False)
+
+    # Only the soon-to-be-hidden student has a grade for this task.
+    db_api.store_score(FIRST_COURSE_NAME, TEST_USERNAME_2, "task_0_0", update_func(1))
+    assert db_api.get_stats(FIRST_COURSE_NAME)["task_0_0"] == half_solved
+
+    db_api.update_student_hidden(FIRST_COURSE_NAME, TEST_USERNAME_2, True)
+
+    # Their submit is dropped from the numerator too, leaving 0 of 1.
+    assert db_api.get_stats(FIRST_COURSE_NAME)["task_0_0"] == 0.0
+
+
 def test_store_score_bonus_task(db_api_with_initialized_first_course, session):
     expected_score = 22
 

--- a/manytask/tests/test_web.py
+++ b/manytask/tests/test_web.py
@@ -90,7 +90,7 @@ def mock_storage_api(mock_course):  # noqa: C901
             return {"task1": 100, "task2": 90}
 
         @staticmethod
-        def get_all_scores_with_names(_course_name):
+        def get_all_scores_with_names(_course_name, include_hidden=False):
             return {
                 TEST_USERNAME: StudentCourseScores(
                     username=TEST_USERNAME,


### PR DESCRIPTION
Adds a checkbox for each student on the course that allows hiding them from the rest of the students. Useful for teachers as they want to test the tasks but should not be on the students table. This also:
1. Adds a toggle for the teachers/admins to hide or show the "hidden students"
2. Remove the hidden students from the statistics

Closes #634

#1079 is lighter and better solution