### PR TITLE
Feat add course admin management to course edit page

### DIFF
--- a/manytask/manytask/abstract.py
+++ b/manytask/manytask/abstract.py
@@ -38,6 +38,26 @@ class StoredUser:
 
 
 @dataclass
+class CourseAccessUser:
+    """A user who has some kind of admin access to a course.
+
+    Access may come from three different scopes, which overlap: a user can be an
+    instance admin *and* a course admin at the same time. ``access_levels`` therefore
+    holds every level that applies, using the role constants from
+    :mod:`manytask.models` (``instance_admin``, ``namespace_admin``,
+    ``program_manager``, ``course_admin``).
+    """
+
+    username: str
+    first_name: str
+    last_name: str
+    access_levels: list[str] = field(default_factory=list)
+
+    def __repr__(self) -> str:
+        return f"CourseAccessUser(username={self.username}, access_levels={self.access_levels})"
+
+
+@dataclass
 class TaskScore:
     """Score of a single task of a single student."""
 
@@ -227,6 +247,9 @@ class StorageApi(ABC):
 
     @abstractmethod
     def get_course_users_with_admin_status(self, course_name: str) -> list[tuple[StoredUser, bool]]: ...
+
+    @abstractmethod
+    def get_course_access_users(self, course_name: str) -> list[CourseAccessUser]: ...
 
     @abstractmethod
     def set_instance_admin_status(

--- a/manytask/manytask/api.py
+++ b/manytask/manytask/api.py
@@ -21,6 +21,9 @@ from .abstract import RmsApi, RmsUser
 from .auth import requires_auth, requires_ready
 from .config import (
     AddUserToNamespaceRequest,
+    AssignProgramManagerRequest,
+    CourseAccessUserItem,
+    CourseAccessUsersResponse,
     CourseResponse,
     CreateCourseRequest,
     CreateNamespaceRequest,
@@ -37,12 +40,14 @@ from .config import (
     NamespaceUsersListResponse,
     NamespaceWithRoleResponse,
     PingResponse,
+    SetCourseAdminRequest,
     UpdateUserRoleRequest,
     UserOnNamespaceResponse,
 )
 from pydantic import BaseModel
 from .course import DEFAULT_TIMEZONE, Course, CourseStatus, get_current_time
 from .main import CustomFlask
+from .models import ROLE_PROGRAM_MANAGER
 from .utils.database import get_database_table_data
 from .utils.generic import (
     calculate_percent,
@@ -70,6 +75,109 @@ def _get_stored_user_or_not_found(storage_api: StorageApi, rms_id: str) -> Store
     if stored_user is None:
         abort(HTTPStatus.NOT_FOUND, f"There is no registered user with rms_id={rms_id}")
     return stored_user
+
+
+def _add_namespace_role(
+    *,
+    namespace_id: int,
+    namespace: Any,
+    username: str,
+    role: str,
+    assigned_by_username: str,
+) -> tuple[Any, ResponseReturnValue | None]:
+    """Give a user a role in a namespace, in the database and in the RMS group.
+
+    Shared by the namespace users endpoint and the course access table, so both
+    paths perform exactly the same two steps in the same order and cannot drift.
+
+    :param namespace_id: id of the target namespace
+    :param namespace: the namespace object (needs ``gitlab_group_id``)
+    :param username: manytask username of the user to add
+    :param role: 'namespace_admin' or 'program_manager'
+    :param assigned_by_username: manytask username of the acting admin
+    :return: tuple of (user_on_namespace, error_response); exactly one is not None
+    """
+    app: CustomFlask = current_app  # type: ignore
+    storage_api = app.storage_api
+    rms_api = app.rms_api
+
+    try:
+        user_on_namespace = storage_api.add_user_to_namespace(
+            namespace_id=namespace_id,
+            username=username,
+            role=role,
+            assigned_by_username=assigned_by_username,
+        )
+    except NoResultFound as e:
+        logger.warning("User %s not registered in manytask: %s", sanitize_log_data(username), str(e))
+        return None, (
+            jsonify(
+                ErrorResponse(
+                    error=f"User {username} is not registered in manytask. The user must log in at least once."
+                ).model_dump()
+            ),
+            HTTPStatus.NOT_FOUND,
+        )
+    except IntegrityError:
+        logger.warning("User %s already has a role in namespace id=%s", sanitize_log_data(username), namespace_id)
+        return None, (
+            jsonify(ErrorResponse(error="User already has a role in this namespace").model_dump()),
+            HTTPStatus.CONFLICT,
+        )
+    except ValueError as e:
+        logger.error("Invalid role %s: %s", role, str(e))
+        return None, (jsonify(ErrorResponse(error=str(e)).model_dump()), HTTPStatus.BAD_REQUEST)
+
+    # The RMS group membership is added only after the database row exists.
+    # TODO: откатить добавление в локальную БД, если добавление в группу RMS не удалось
+    try:
+        stored_user = storage_api.get_stored_user_by_username(username)
+        rms_api.add_user_to_namespace_group(
+            gitlab_group_id=namespace.gitlab_group_id,
+            rms_id=stored_user.rms_id,
+        )
+        logger.info(
+            "Added RMS user id=%s to group id=%s",
+            stored_user.rms_id,
+            namespace.gitlab_group_id,
+        )
+    except Exception as e:
+        logger.error("Failed to add user %s to RMS group: %s", sanitize_log_data(username), str(e))
+        return None, (
+            jsonify(ErrorResponse(error="Failed to add user to GitLab group").model_dump()),
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+        )
+
+    return user_on_namespace, None
+
+
+def _check_course_admin_access(course_name: str) -> ResponseReturnValue | None:
+    """Ensure the session user may administer the given course.
+
+    Instance admins pass unconditionally; otherwise the user must be a course admin
+    of this course. Returns ``None`` when access is allowed, or a ready-to-return
+    error response when it is not.
+    """
+    app: CustomFlask = current_app  # type: ignore
+
+    if app.debug:
+        return None
+
+    username = session["manytask"]["username"]
+    storage_api = app.storage_api
+
+    if storage_api.check_if_instance_admin(username) or storage_api.check_if_course_admin(course_name, username):
+        return None
+
+    logger.warning(
+        "User %s attempted to administer course %s without permission",
+        sanitize_log_data(username),
+        sanitize_log_data(course_name),
+    )
+    return (
+        jsonify(ErrorResponse(error="Only course admins can perform this action").model_dump()),
+        HTTPStatus.FORBIDDEN,
+    )
 
 
 T = TypeVar("T", bound=BaseModel)
@@ -1038,46 +1146,23 @@ def add_user_to_namespace(
                 return jsonify(
                     ErrorResponse(error=f"User with id={user_id} not found").model_dump()
                 ), HTTPStatus.NOT_FOUND
-            rms_user = rms_api.get_rms_user_by_id(stored_user.rms_id)
+            rms_api.get_rms_user_by_id(stored_user.rms_id)
         except Exception as e:
             logger.error("User with id=%s not found in RMS: %s", user_id, str(e))
             return jsonify(ErrorResponse(error=f"User with id={user_id} not found").model_dump()), HTTPStatus.NOT_FOUND
 
-        # Сначала проверяем, что пользователь существует в локальной БД
-        # (пользователь должен был хотя бы раз залогиниться в manytask)
-        try:
-            user_on_namespace = storage_api.add_user_to_namespace(
-                namespace_id=namespace_id,
-                username=stored_user.username,
-                role=role,
-                assigned_by_username=username,
-            )
-        except NoResultFound as e:
-            logger.warning("User id=%s not registered in manytask: %s", user_id, str(e))
-            return jsonify(
-                ErrorResponse(
-                    error=f"User with id={user_id} is not registered in manytask. The user must log in at least once."
-                ).model_dump()
-            ), HTTPStatus.NOT_FOUND
-        except IntegrityError:
-            logger.warning("User id=%s already has a role in namespace id=%s", user_id, namespace_id)
-            return jsonify(
-                ErrorResponse(error="User already has a role in this namespace").model_dump()
-            ), HTTPStatus.CONFLICT
-        except ValueError as e:
-            logger.error("Invalid role %s: %s", role, str(e))
-            return jsonify(ErrorResponse(error=str(e)).model_dump()), HTTPStatus.BAD_REQUEST
-
-        # Добавляем в GitLab группу только после успешного добавления в БД
-        try:
-            rms_api.add_user_to_namespace_group(gitlab_group_id=namespace.gitlab_group_id, rms_id=rms_user.id)
-            logger.info("Added RMS user id=%s to GitLab group id=%s", rms_user.id, namespace.gitlab_group_id)
-        except Exception as e:
-            # TODO: откатить добавление в локальную БД
-            logger.error("Failed to add RMS user id=%s to GitLab group: %s", rms_user.id, str(e))
-            return jsonify(
-                ErrorResponse(error="Failed to add user to GitLab group").model_dump()
-            ), HTTPStatus.INTERNAL_SERVER_ERROR
+        # Сначала добавляем в локальную БД (пользователь должен был хотя бы раз
+        # залогиниться в manytask), затем в группу RMS — обе операции выполняет
+        # общий помощник, который также используется таблицей доступа к курсу.
+        user_on_namespace, error = _add_namespace_role(
+            namespace_id=namespace_id,
+            namespace=namespace,
+            username=stored_user.username,
+            role=role,
+            assigned_by_username=username,
+        )
+        if error:
+            return error
 
         logger.info(
             "User %s added user_id=%s to namespace id=%s with role %s",
@@ -1693,3 +1778,189 @@ def clear_grade_override(course_name: str) -> ResponseReturnValue:
         return jsonify(
             {"success": False, "message": "Internal error when clearing grade override"}
         ), HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@bp.get("/access_users")
+@requires_auth
+def get_course_access_users(course_name: str) -> ResponseReturnValue:
+    """List every user with admin access to the course, from any scope.
+
+    Includes instance admins, namespace admins and program managers of the course's
+    namespace, and course admins of the course itself. A user holding several of
+    these appears once, with all levels listed.
+
+    Returns:
+        200: List of users with their access levels
+        403: Forbidden (not a course admin nor an instance admin)
+        404: Course not found
+    """
+    app: CustomFlask = current_app  # type: ignore
+
+    error = _check_course_admin_access(course_name)
+    if error:
+        return error
+
+    __get_course_or_not_found(app.storage_api, course_name)
+
+    access_users = app.storage_api.get_course_access_users(course_name)
+    response = CourseAccessUsersResponse(
+        users=[
+            CourseAccessUserItem(
+                username=access_user.username,
+                first_name=access_user.first_name,
+                last_name=access_user.last_name,
+                access_levels=access_user.access_levels,
+            )
+            for access_user in access_users
+        ]
+    )
+    return jsonify(response.model_dump()), HTTPStatus.OK
+
+
+@bp.post("/course_admin")
+@requires_auth
+@requires_json_validation(SetCourseAdminRequest)
+def set_course_admin(course_name: str, validated_data: SetCourseAdminRequest) -> ResponseReturnValue:
+    """Grant or revoke course admin rights for a member of the course.
+
+    The target user must already be enrolled on the course: course admin status lives
+    on the users_on_courses row, so there is nothing to update for a non-member.
+
+    Request JSON:
+    {
+        "username": "student",
+        "is_admin": true
+    }
+
+    Returns:
+        200: Status updated
+        403: Forbidden (not a course admin nor an instance admin)
+        404: Course or user not found, or the user is not enrolled on the course
+    """
+    app: CustomFlask = current_app  # type: ignore
+    storage_api = app.storage_api
+
+    error = _check_course_admin_access(course_name)
+    if error:
+        return error
+
+    __get_course_or_not_found(storage_api, course_name)
+
+    target_username = validated_data.username
+    try:
+        # DataBaseApi raises, other implementations may return None.
+        target_user = storage_api.get_stored_user_by_username(target_username)
+    except NoResultFound:
+        target_user = None
+    if target_user is None:
+        logger.warning("User %s not found when setting course admin status", sanitize_log_data(target_username))
+        return jsonify(ErrorResponse(error=f"User {target_username} not found").model_dump()), HTTPStatus.NOT_FOUND
+
+    if not storage_api.check_user_on_course(course_name, target_username):
+        logger.warning(
+            "User %s is not enrolled on course %s, cannot change course admin status",
+            sanitize_log_data(target_username),
+            sanitize_log_data(course_name),
+        )
+        return jsonify(
+            ErrorResponse(
+                error=f"User {target_username} is not enrolled on this course and cannot be made a course admin"
+            ).model_dump()
+        ), HTTPStatus.NOT_FOUND
+
+    storage_api.set_course_admin_status(course_name, target_username, validated_data.is_admin)
+
+    acting_username = "guest" if app.debug else session["manytask"]["username"]
+    logger.warning(
+        "User %s %s course admin status for %s in course %s",
+        sanitize_log_data(acting_username),
+        "granted" if validated_data.is_admin else "revoked",
+        sanitize_log_data(target_username),
+        sanitize_log_data(course_name),
+    )
+    return jsonify({"success": True}), HTTPStatus.OK
+
+
+@bp.post("/program_manager")
+@requires_auth
+@requires_json_validation(AssignProgramManagerRequest)
+def assign_program_manager(course_name: str, validated_data: AssignProgramManagerRequest) -> ResponseReturnValue:
+    """Assign a user as program manager of the course's namespace.
+
+    Program manager is a *namespace*-scoped role, so being a course admin is not
+    enough: the acting user must be an instance admin or a namespace admin of the
+    course's namespace, otherwise a course admin could grant access reaching beyond
+    their own course.
+
+    Request JSON:
+    {
+        "username": "manager"
+    }
+
+    Returns:
+        201: User assigned as program manager
+        400: The course has no namespace
+        403: Forbidden (not an instance admin nor a namespace admin of the namespace)
+        404: Course or user not found
+        409: The user already has a role in the namespace
+    """
+    app: CustomFlask = current_app  # type: ignore
+    storage_api = app.storage_api
+
+    course = __get_course_or_not_found(storage_api, course_name)
+    namespace_id = course.namespace_id
+    if namespace_id is None:
+        logger.warning("Course %s has no namespace, cannot assign a program manager", sanitize_log_data(course_name))
+        return jsonify(
+            ErrorResponse(
+                error="This course does not belong to a namespace, so it has no program managers"
+            ).model_dump()
+        ), HTTPStatus.BAD_REQUEST
+
+    acting_username = "guest" if app.debug else session["manytask"]["username"]
+
+    if not app.debug:
+        if not storage_api.check_if_instance_admin(acting_username):
+            if namespace_id not in storage_api.get_namespace_admin_namespaces(acting_username):
+                logger.warning(
+                    "User %s attempted to assign a program manager in namespace id=%s without admin rights",
+                    sanitize_log_data(acting_username),
+                    namespace_id,
+                )
+                return jsonify(
+                    ErrorResponse(
+                        error="Only Instance Admin or Namespace Admin can assign program managers"
+                    ).model_dump()
+                ), HTTPStatus.FORBIDDEN
+
+    try:
+        namespace, _ = storage_api.get_namespace_by_id(namespace_id, acting_username)
+    except (PermissionError, NoResultFound):
+        logger.warning("Namespace id=%s not accessible when assigning a program manager", namespace_id)
+        return jsonify(ErrorResponse(error="Namespace not found").model_dump()), HTTPStatus.NOT_FOUND
+
+    user_on_namespace, error = _add_namespace_role(
+        namespace_id=namespace_id,
+        namespace=namespace,
+        username=validated_data.username,
+        role=ROLE_PROGRAM_MANAGER,
+        assigned_by_username=acting_username,
+    )
+    if error:
+        return error
+
+    logger.info(
+        "User %s assigned %s as program manager of namespace id=%s (course %s)",
+        sanitize_log_data(acting_username),
+        sanitize_log_data(validated_data.username),
+        namespace_id,
+        sanitize_log_data(course_name),
+    )
+
+    response = UserOnNamespaceResponse(
+        id=user_on_namespace.id,
+        user_id=user_on_namespace.user_id,
+        namespace_id=user_on_namespace.namespace_id,
+        role=ROLE_PROGRAM_MANAGER,
+    )
+    return jsonify(response.model_dump()), HTTPStatus.CREATED

--- a/manytask/manytask/config.py
+++ b/manytask/manytask/config.py
@@ -96,6 +96,36 @@ class NamespaceUsersListResponse(BaseModel):
     users: list[NamespaceUserItem]
 
 
+class CourseAccessUserItem(BaseModel):
+    """A single row of the course access table.
+
+    ``access_levels`` may hold several entries at once, because the scopes overlap:
+    an instance admin can also be a course admin of the same course.
+    """
+
+    username: str
+    first_name: str
+    last_name: str
+    access_levels: list[str]
+
+
+class CourseAccessUsersResponse(BaseModel):
+    users: list[CourseAccessUserItem]
+
+
+class SetCourseAdminRequest(BaseModel):
+    """Request to grant or revoke course admin rights for a course member."""
+
+    username: str
+    is_admin: bool
+
+
+class AssignProgramManagerRequest(BaseModel):
+    """Request to assign a user as program manager of the course's namespace."""
+
+    username: str
+
+
 class CreateCourseRequest(BaseModel):
     namespace_id: int
     course_name: str

--- a/manytask/manytask/database.py
+++ b/manytask/manytask/database.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session, joinedload, selectinload, sessionmaker
 from sqlalchemy.sql.functions import coalesce, func
 
 from . import models
-from .abstract import StorageApi, StoredUser, StudentCourseScores, TaskScore
+from .abstract import CourseAccessUser, StorageApi, StoredUser, StudentCourseScores, TaskScore
 from .config import (
     ManytaskConfig,
     ManytaskDeadlinesConfig,
@@ -29,6 +29,8 @@ from .course import Course as AppCourse
 from .course import CourseConfig as AppCourseConfig
 from .course import CourseStatus
 from .models import (
+    ROLE_COURSE_ADMIN,
+    ROLE_INSTANCE_ADMIN,
     ROLE_NAMESPACE_ADMIN,
     ROLE_PROGRAM_MANAGER,
     Course,
@@ -1104,6 +1106,78 @@ class DataBaseApi(StorageApi):
             )
             logger.info("Fetched users for course '%s': count=%s", course_name, len(users_on_courses))
             return [(self._to_stored_user(uoc.user), uoc.is_course_admin) for uoc in users_on_courses]
+
+    def get_course_access_users(self, course_name: str) -> list[CourseAccessUser]:
+        """Get every user with admin access to a course, from any scope.
+
+        Collects four independent sources and merges them by user, so a user holding
+        several levels (e.g. an instance admin who is also a course admin) appears
+        once with all levels listed:
+
+        * instance admins (:attr:`models.User.is_instance_admin`)
+        * namespace admins of the course's namespace
+        * program managers of the course's namespace
+        * course admins of the course itself
+
+        The namespace-scoped sources are skipped when the course has no namespace.
+
+        :param course_name: course name
+        :return: list of :class:`CourseAccessUser`, ordered by username
+        """
+        with self._session_create() as session:
+            try:
+                course = self._get(session, models.Course, name=course_name)
+            except NoResultFound:
+                logger.warning("Course '%s' not found when fetching course access users", course_name)
+                return []
+
+            access_users: dict[int, CourseAccessUser] = {}
+
+            def add(user: models.User, access_level: str) -> None:
+                entry = access_users.get(user.id)
+                if entry is None:
+                    entry = CourseAccessUser(
+                        username=user.username,
+                        first_name=user.first_name,
+                        last_name=user.last_name,
+                    )
+                    access_users[user.id] = entry
+                if access_level not in entry.access_levels:
+                    entry.access_levels.append(access_level)
+
+            for user in session.query(models.User).filter(models.User.is_instance_admin.is_(True)).all():
+                add(user, ROLE_INSTANCE_ADMIN)
+
+            if course.namespace_id is not None:
+                namespace_roles = {
+                    models.UserOnNamespaceRole.NAMESPACE_ADMIN: ROLE_NAMESPACE_ADMIN,
+                    models.UserOnNamespaceRole.PROGRAM_MANAGER: ROLE_PROGRAM_MANAGER,
+                }
+                users_on_namespace = (
+                    session.query(models.UserOnNamespace)
+                    .filter(models.UserOnNamespace.namespace_id == course.namespace_id)
+                    .options(joinedload(models.UserOnNamespace.user))
+                    .all()
+                )
+                for user_on_namespace in users_on_namespace:
+                    access_level = namespace_roles.get(user_on_namespace.role)
+                    if access_level is not None:
+                        add(user_on_namespace.user, access_level)
+
+            users_on_course = (
+                session.query(models.UserOnCourse)
+                .filter(
+                    models.UserOnCourse.course_id == course.id,
+                    models.UserOnCourse.is_course_admin.is_(True),
+                )
+                .options(joinedload(models.UserOnCourse.user))
+                .all()
+            )
+            for user_on_course in users_on_course:
+                add(user_on_course.user, ROLE_COURSE_ADMIN)
+
+            logger.info("Fetched access users for course '%s': count=%s", course_name, len(access_users))
+            return sorted(access_users.values(), key=lambda access_user: access_user.username)
 
     def set_instance_admin_status(self, username: str, is_admin: bool) -> None:
         """Change user admin status

--- a/manytask/manytask/models.py
+++ b/manytask/manytask/models.py
@@ -45,6 +45,13 @@ def _validate_gitlab_slug(slug: str) -> str:
 ROLE_NAMESPACE_ADMIN = "namespace_admin"
 ROLE_PROGRAM_MANAGER = "program_manager"
 
+# Access levels that are not stored in UserOnNamespace.role, but are still
+# reported as "access to a course" by StorageApi.get_course_access_users().
+# Kept next to the namespace roles so all access-level strings have a single
+# definition shared by the backend, the templates and the tests.
+ROLE_INSTANCE_ADMIN = "instance_admin"
+ROLE_COURSE_ADMIN = "course_admin"
+
 
 class UserOnNamespaceRole(enum.Enum):
     NAMESPACE_ADMIN = ROLE_NAMESPACE_ADMIN

--- a/manytask/manytask/static/css/course_access.css
+++ b/manytask/manytask/static/css/course_access.css
@@ -1,0 +1,47 @@
+/* Course access table on the course edit page.
+   Mirrors the filter-control shape of courses.css so the two tables look the
+   same; colors come from Bootstrap variables and therefore follow the active
+   light/dark theme automatically. */
+
+.course-access-hint {
+    max-width: 60rem;
+    font-size: 0.9rem;
+}
+
+.course-access-controls {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 0.5rem;
+    align-items: center;
+    width: 100%;
+    max-width: 1100px;
+}
+
+.course-access-search {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.course-access-search .form-control {
+    padding-right: 2rem;
+}
+
+.course-access-search-icon {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--bs-secondary-color);
+    pointer-events: none;
+}
+
+#course-access-table {
+    width: 100%;
+    max-width: 1100px;
+}
+
+.course-access-revoke {
+    line-height: 1;
+    padding: 0.15rem 0.4rem;
+}

--- a/manytask/manytask/static/css/course_access.css
+++ b/manytask/manytask/static/css/course_access.css
@@ -3,18 +3,12 @@
    same; colors come from Bootstrap variables and therefore follow the active
    light/dark theme automatically. */
 
-.course-access-hint {
-    max-width: 60rem;
-    font-size: 0.9rem;
-}
-
 .course-access-controls {
     display: flex;
     flex-wrap: nowrap;
     gap: 0.5rem;
     align-items: center;
     width: 100%;
-    max-width: 1100px;
 }
 
 .course-access-search {
@@ -38,10 +32,21 @@
 
 #course-access-table {
     width: 100%;
-    max-width: 1100px;
+    margin-bottom: 2rem;
 }
 
 .course-access-revoke {
+    background: none;
+    border: none;
+    padding: 0 0 0 0.2em;
     line-height: 1;
-    padding: 0.15rem 0.4rem;
+    color: inherit;
+    opacity: 0.75;
+    cursor: pointer;
+    font-size: 1em;
+    vertical-align: middle;
+}
+
+.course-access-revoke:hover {
+    opacity: 1;
 }

--- a/manytask/manytask/templates/edit_course.html
+++ b/manytask/manytask/templates/edit_course.html
@@ -2,6 +2,10 @@
 
 {% block title %}Edit Course: {{ course.course_name }}{% endblock %}
 
+{% block additional_styles %}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/course_access.css') }}">
+{% endblock %}
+
 {% block body %}
 <div class="container mt-4">
     <h2>Edit Course: {{ course.course_name }}</h2>
@@ -137,18 +141,42 @@
     </form>
 
     <div class="action-group mt-4">
-        <h4><i class="fas fa-user-shield me-2"></i>Course Admin management</h4>
-        <div class="admin-actions">
+        <h4><i class="fas fa-user-shield me-2"></i>Course Access</h4>
+        <p class="text-muted course-access-hint">
+            Everyone who can administer this course, whether their access comes from the instance,
+            from the namespace, or from the course itself. Instance and namespace access is managed
+            elsewhere and is shown here read-only.
+        </p>
+
+        <div class="course-access-controls mb-3">
+            <div class="course-access-search">
+                <input id="access-filter-value" type="text" class="form-control" placeholder="Search users...">
+                <i class="fas fa-search course-access-search-icon"></i>
+            </div>
+            <button id="access-filter-clear" type="button" class="btn btn-outline-secondary">
+                <i class="fas fa-times"></i> Clear
+            </button>
+        </div>
+
+        <div id="course-access-table"></div>
+
+        <div class="admin-actions mt-3">
             <button type="button" class="btn btn-warning admin-btn" data-bs-toggle="modal"
                     data-bs-target="#grantCourseAdminModal">
                 <i class="fas fa-user-shield"></i>
                 <span>Grant course admin rights</span>
             </button>
 
-            <button type="button" class="btn btn-danger admin-btn" data-bs-toggle="modal"
-                    data-bs-target="#revokeCourseAdminModal">
-                <i class="fas fa-user-slash"></i>
-                <span>Revoke course admin rights</span>
+            <button type="button" class="btn btn-info admin-btn" data-bs-toggle="modal"
+                    data-bs-target="#assignProgramManagerModal"
+                    {% if not can_assign_namespace_roles %}disabled{% endif %}
+                    {% if not namespace_id %}
+                        title="This course does not belong to a namespace, so it has no program managers"
+                    {% elif not can_assign_namespace_roles %}
+                        title="Only Instance Admin or Namespace Admin can assign program managers"
+                    {% endif %}>
+                <i class="fas fa-user-tie"></i>
+                <span>Assign program manager</span>
             </button>
         </div>
     </div>
@@ -163,103 +191,311 @@
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <form id="grantCourseAdminForm"
-                      action="{{ url_for('instance_admin.edit_course', course_name=course.course_name) }}"
-                      method="POST">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="action" value="grant_course_admin">
-                    <div class="mb-3">
-                        <label for="userToGrant" class="form-label">Select new course admin</label>
+                <div class="mb-3">
+                    <label for="userToGrant" class="form-label">Select new course admin</label>
+                    <div class="form-text mb-2">Only users enrolled on this course can be made course admins.</div>
 
-                        <div class="search-box">
-                            <label for="grantSearchInput"></label>
-                            <input type="text" class="form-control" placeholder="Search users..."
-                                   id="grantSearchInput" autocomplete="off">
-                        </div>
-
-                        <select class="form-select" id="userToGrant" name="username" required size="5">
-                            {% for stored_user, is_admin in course_users|default([]) %}
-                                {% if not is_admin %}
-                                    <option value="{{ stored_user.username }}">{{ stored_user.username }}
-                                        ({{ stored_user.first_name }} {{ stored_user.last_name }})
-                                    </option>
-                                {% endif %}
-                            {% endfor %}
-                        </select>
+                    <div class="search-box">
+                        <label for="grantSearchInput"></label>
+                        <input type="text" class="form-control" placeholder="Search users..."
+                               id="grantSearchInput" autocomplete="off">
                     </div>
-                </form>
+
+                    <select class="form-select" id="userToGrant" required size="5">
+                        {% for stored_user, is_admin in course_users|default([]) %}
+                            {% if not is_admin %}
+                                <option value="{{ stored_user.username }}">{{ stored_user.username }}
+                                    ({{ stored_user.first_name }} {{ stored_user.last_name }})
+                                </option>
+                            {% endif %}
+                        {% endfor %}
+                    </select>
+                </div>
+                <div id="grantCourseAdminError" class="alert alert-danger d-none" role="alert"></div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="submit" form="grantCourseAdminForm" class="btn btn-warning">Grant Rights</button>
+                <button type="button" id="grantCourseAdminSubmit" class="btn btn-warning">Grant Rights</button>
             </div>
         </div>
     </div>
 </div>
 
-<div class="modal fade" id="revokeCourseAdminModal" tabindex="-1" aria-labelledby="revokeCourseAdminModalLabel"
+<div class="modal fade" id="assignProgramManagerModal" tabindex="-1" aria-labelledby="assignProgramManagerModalLabel"
      aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="revokeCourseAdminModalLabel">Revoke Course Admin Rights</h5>
+                <h5 class="modal-title" id="assignProgramManagerModalLabel">Assign Program Manager</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
-                <form id="revokeCourseAdminForm"
-                      action="{{ url_for('instance_admin.edit_course', course_name=course.course_name) }}"
-                      method="POST">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="action" value="revoke_course_admin">
-                    <div class="mb-3">
-                        <label for="userToRevoke" class="form-label">Remove the course admin</label>
-
-                        <div class="search-box">
-                            <label for="revokeSearchInput"></label>
-                            <input type="text" class="form-control" placeholder="Search admins..."
-                                   id="revokeSearchInput" autocomplete="off">
-                        </div>
-
-                        <select class="form-select" id="userToRevoke" name="username" required size="5">
-                            <option value="" disabled>Select a user</option>
-                            {% for stored_user, is_admin in course_users|default([]) %}
-                                {% if is_admin %}
-                                    <option value="{{ stored_user.username }}">{{ stored_user.username }}
-                                        ({{ stored_user.first_name }} {{ stored_user.last_name }})
-                                    </option>
-                                {% endif %}
-                            {% endfor %}
-                        </select>
+                <div class="mb-3">
+                    <label for="userToAssign" class="form-label">Select new program manager</label>
+                    <div class="form-text mb-2">
+                        Program manager is a namespace-level role: the user is added to this course's
+                        namespace and gains the role on every course in it.
                     </div>
-                </form>
+
+                    <div class="search-box">
+                        <label for="assignSearchInput"></label>
+                        <input type="text" class="form-control" placeholder="Search users..."
+                               id="assignSearchInput" autocomplete="off">
+                    </div>
+
+                    <select class="form-select" id="userToAssign" required size="5">
+                        {% for stored_user, is_admin in course_users|default([]) %}
+                            <option value="{{ stored_user.username }}">{{ stored_user.username }}
+                                ({{ stored_user.first_name }} {{ stored_user.last_name }})
+                            </option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div id="assignProgramManagerError" class="alert alert-danger d-none" role="alert"></div>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="submit" form="revokeCourseAdminForm" class="btn btn-danger">Revoke Rights</button>
+                <button type="button" id="assignProgramManagerSubmit" class="btn btn-info">Assign</button>
             </div>
         </div>
     </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/tabulator-tables@5/dist/js/tabulator.min.js"></script>
+<script src="{{ url_for('static', filename='js/tabulator-theme.js') }}"></script>
+<script src="{{ url_for('static', filename='js/search-normalize.js') }}"></script>
+<link href="https://cdn.jsdelivr.net/npm/tabulator-tables@5/dist/css/tabulator.min.css" rel="stylesheet"
+      id="light-theme">
+<link href="https://cdn.jsdelivr.net/npm/tabulator-tables@5/dist/css/tabulator_midnight.min.css" rel="stylesheet"
+      id="dark-theme" disabled>
+
 <script>
-    function filterUsers(type) {
-        const inputId = `${type}SearchInput`;
-        const selectId = `userTo${type.charAt(0).toUpperCase() + type.slice(1)}`;
+    const accessUsersUrl = '{{ url_for("api.get_course_access_users", course_name=course.course_name) }}';
+    const setCourseAdminUrl = '{{ url_for("api.set_course_admin", course_name=course.course_name) }}';
+    const assignProgramManagerUrl = '{{ url_for("api.assign_program_manager", course_name=course.course_name) }}';
 
+    // Privilege order, widest scope first, so the Access column sorts by reach
+    // rather than alphabetically.
+    const ACCESS_ORDER = ['instance_admin', 'namespace_admin', 'program_manager', 'course_admin'];
+    const ACCESS_LABELS = {
+        instance_admin: 'Instance',
+        namespace_admin: 'Namespace',
+        program_manager: 'Program Manager',
+        course_admin: 'Course'
+    };
+    const ACCESS_BADGES = {
+        instance_admin: 'bg-danger',
+        namespace_admin: 'bg-warning',
+        program_manager: 'bg-info',
+        course_admin: 'bg-primary'
+    };
+
+    function accessRank(levels) {
+        // Rank a row by its widest access level.
+        let best = ACCESS_ORDER.length;
+        (levels || []).forEach(level => {
+            const idx = ACCESS_ORDER.indexOf(level);
+            if (idx !== -1 && idx < best) {
+                best = idx;
+            }
+        });
+        return best;
+    }
+
+    // Blank-last string sorter, so users without a name sink to the bottom.
+    function blankLastSorter(a, b) {
+        if (!a && !b) return 0;
+        if (!a) return 1;
+        if (!b) return -1;
+        return a.toLowerCase().localeCompare(b.toLowerCase());
+    }
+
+    function filterSelectOptions(inputId, selectId) {
         const input = document.getElementById(inputId);
-        const filter = input.value.toLowerCase();
         const select = document.getElementById(selectId);
-        const options = select.getElementsByTagName('option');
-
-        for (let i = 0; i < options.length; i++) {
-            const text = options[i].textContent || options[i].innerText;
-            options[i].style.display = text.toLowerCase().includes(filter) ? '' : 'none';
+        if (!input || !select) {
+            return;
         }
+        input.addEventListener('input', () => {
+            const filter = input.value.toLowerCase();
+            const options = select.getElementsByTagName('option');
+            for (let i = 0; i < options.length; i++) {
+                const text = options[i].textContent || options[i].innerText;
+                options[i].style.display = text.toLowerCase().includes(filter) ? '' : 'none';
+            }
+        });
+    }
+
+    function loadAccessUsers() {
+        return fetch(accessUsersUrl)
+            .then(response => response.json())
+            .then(data => {
+                if (window.accessTable) {
+                    window.accessTable.setData(data.users || []);
+                }
+                return data.users || [];
+            });
+    }
+
+    function postJson(url, payload) {
+        return fetch(url, {
+            method: 'POST',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(payload)
+        }).then(response => response.json().then(data => ({ok: response.ok, data})));
+    }
+
+    function setCourseAdmin(username, isAdmin) {
+        return postJson(setCourseAdminUrl, {username: username, is_admin: isAdmin});
+    }
+
+    function showModalError(elementId, message) {
+        const errorDiv = document.getElementById(elementId);
+        errorDiv.textContent = message;
+        errorDiv.classList.remove('d-none');
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        document.getElementById('grantSearchInput').addEventListener('input', () => filterUsers('grant'));
-        document.getElementById('revokeSearchInput').addEventListener('input', () => filterUsers('revoke'));
+        filterSelectOptions('grantSearchInput', 'userToGrant');
+        filterSelectOptions('assignSearchInput', 'userToAssign');
+
+        const columns = [
+            {
+                title: "Login",
+                field: "username",
+                sorter: "string",
+                headerTooltip: "Manytask login"
+            },
+            {
+                title: "First Name",
+                field: "first_name",
+                sorter: blankLastSorter,
+                headerTooltip: "First name"
+            },
+            {
+                title: "Last Name",
+                field: "last_name",
+                sorter: blankLastSorter,
+                headerTooltip: "Last name"
+            },
+            {
+                title: "Access",
+                field: "access_levels",
+                headerTooltip: "Where this user's access comes from",
+                sorter: function (a, b) {
+                    return accessRank(a) - accessRank(b);
+                },
+                formatter: function (cell) {
+                    const levels = cell.getValue() || [];
+                    return ACCESS_ORDER
+                        .filter(level => levels.includes(level))
+                        .map(level => `<span class="badge ${ACCESS_BADGES[level]} me-1">${ACCESS_LABELS[level]}</span>`)
+                        .join('');
+                }
+            },
+            {
+                title: "Actions",
+                field: "actions",
+                headerSort: false,
+                hozAlign: "center",
+                width: 110,
+                headerTooltip: "Revoke course admin rights",
+                formatter: function (cell) {
+                    const data = cell.getRow().getData();
+                    if (!(data.access_levels || []).includes('course_admin')) {
+                        return "";
+                    }
+                    return `<button type="button" class="btn btn-sm btn-outline-danger course-access-revoke"`
+                        + ` title="Revoke course admin rights"><i class="fas fa-user-slash"></i></button>`;
+                },
+                cellClick: function (e, cell) {
+                    if (!e.target.closest('.course-access-revoke')) {
+                        return;
+                    }
+                    const data = cell.getRow().getData();
+                    if (!confirm(`Revoke course admin rights from "${data.username}"?`)) {
+                        return;
+                    }
+                    setCourseAdmin(data.username, false).then(({ok, data: body}) => {
+                        if (ok) {
+                            loadAccessUsers();
+                        } else {
+                            alert(body.error || 'Failed to revoke course admin rights');
+                        }
+                    });
+                }
+            }
+        ];
+
+        window.accessTable = new Tabulator("#course-access-table", {
+            data: [],
+            columns: columns,
+            layout: "fitColumns",
+            initialSort: [{column: "username", dir: "asc"}],
+            pagination: false,
+            placeholder: "Nobody has admin access to this course yet.",
+        });
+
+        initTabulatorTheme(() => window.accessTable);
+        loadAccessUsers();
+
+        // Transliteration-aware search over login and full name, matching the
+        // course database page.
+        const valueEl = document.getElementById("access-filter-value");
+
+        function accessFilter(data) {
+            const term = normalizeForSearch(valueEl.value.trim());
+            if (!term) {
+                return true;
+            }
+            if (normalizeForSearch(data.username).includes(term)) {
+                return true;
+            }
+            const firstName = data.first_name ? data.first_name : "";
+            const lastName = data.last_name ? data.last_name : "";
+            const theVeryFullName = `${firstName} ${lastName} ${firstName}`;
+            return normalizeForSearch(theVeryFullName).includes(term);
+        }
+
+        valueEl.addEventListener("keyup", function () {
+            window.accessTable.setFilter(accessFilter);
+        });
+        document.getElementById("access-filter-clear").addEventListener("click", function () {
+            valueEl.value = "";
+            window.accessTable.clearFilter();
+        });
+
+        document.getElementById('grantCourseAdminSubmit').addEventListener('click', function () {
+            const username = document.getElementById('userToGrant').value;
+            if (!username) {
+                showModalError('grantCourseAdminError', 'Select a user first');
+                return;
+            }
+            setCourseAdmin(username, true).then(({ok, data}) => {
+                if (ok) {
+                    bootstrap.Modal.getInstance(document.getElementById('grantCourseAdminModal')).hide();
+                    location.reload();
+                } else {
+                    showModalError('grantCourseAdminError', data.error || 'Failed to grant course admin rights');
+                }
+            });
+        });
+
+        document.getElementById('assignProgramManagerSubmit').addEventListener('click', function () {
+            const username = document.getElementById('userToAssign').value;
+            if (!username) {
+                showModalError('assignProgramManagerError', 'Select a user first');
+                return;
+            }
+            postJson(assignProgramManagerUrl, {username: username}).then(({ok, data}) => {
+                if (ok) {
+                    bootstrap.Modal.getInstance(document.getElementById('assignProgramManagerModal')).hide();
+                    loadAccessUsers();
+                } else {
+                    showModalError('assignProgramManagerError', data.error || 'Failed to assign program manager');
+                }
+            });
+        });
     });
 </script>
 

--- a/manytask/manytask/templates/edit_course.html
+++ b/manytask/manytask/templates/edit_course.html
@@ -166,18 +166,6 @@
                 <i class="fas fa-user-shield"></i>
                 <span>Grant course admin rights</span>
             </button>
-
-            <button type="button" class="btn btn-info admin-btn" data-bs-toggle="modal"
-                    data-bs-target="#assignProgramManagerModal"
-                    {% if not can_assign_namespace_roles %}disabled{% endif %}
-                    {% if not namespace_id %}
-                        title="This course does not belong to a namespace, so it has no program managers"
-                    {% elif not can_assign_namespace_roles %}
-                        title="Only Instance Admin or Namespace Admin can assign program managers"
-                    {% endif %}>
-                <i class="fas fa-user-tie"></i>
-                <span>Assign program manager</span>
-            </button>
         </div>
     </div>
 </div>
@@ -221,46 +209,6 @@
     </div>
 </div>
 
-<div class="modal fade" id="assignProgramManagerModal" tabindex="-1" aria-labelledby="assignProgramManagerModalLabel"
-     aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="assignProgramManagerModalLabel">Assign Program Manager</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <div class="mb-3">
-                    <label for="userToAssign" class="form-label">Select new program manager</label>
-                    <div class="form-text mb-2">
-                        Program manager is a namespace-level role: the user is added to this course's
-                        namespace and gains the role on every course in it.
-                    </div>
-
-                    <div class="search-box">
-                        <label for="assignSearchInput"></label>
-                        <input type="text" class="form-control" placeholder="Search users..."
-                               id="assignSearchInput" autocomplete="off">
-                    </div>
-
-                    <select class="form-select" id="userToAssign" required size="5">
-                        {% for stored_user, is_admin in course_users|default([]) %}
-                            <option value="{{ stored_user.username }}">{{ stored_user.username }}
-                                ({{ stored_user.first_name }} {{ stored_user.last_name }})
-                            </option>
-                        {% endfor %}
-                    </select>
-                </div>
-                <div id="assignProgramManagerError" class="alert alert-danger d-none" role="alert"></div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                <button type="button" id="assignProgramManagerSubmit" class="btn btn-info">Assign</button>
-            </div>
-        </div>
-    </div>
-</div>
-
 <script src="https://cdn.jsdelivr.net/npm/tabulator-tables@5/dist/js/tabulator.min.js"></script>
 <script src="{{ url_for('static', filename='js/tabulator-theme.js') }}"></script>
 <script src="{{ url_for('static', filename='js/search-normalize.js') }}"></script>
@@ -272,7 +220,6 @@
 <script>
     const accessUsersUrl = '{{ url_for("api.get_course_access_users", course_name=course.course_name) }}';
     const setCourseAdminUrl = '{{ url_for("api.set_course_admin", course_name=course.course_name) }}';
-    const assignProgramManagerUrl = '{{ url_for("api.assign_program_manager", course_name=course.course_name) }}';
 
     // Privilege order, widest scope first, so the Access column sorts by reach
     // rather than alphabetically.
@@ -357,7 +304,6 @@
 
     document.addEventListener('DOMContentLoaded', function () {
         filterSelectOptions('grantSearchInput', 'userToGrant');
-        filterSelectOptions('assignSearchInput', 'userToAssign');
 
         const columns = [
             {
@@ -477,22 +423,6 @@
                     location.reload();
                 } else {
                     showModalError('grantCourseAdminError', data.error || 'Failed to grant course admin rights');
-                }
-            });
-        });
-
-        document.getElementById('assignProgramManagerSubmit').addEventListener('click', function () {
-            const username = document.getElementById('userToAssign').value;
-            if (!username) {
-                showModalError('assignProgramManagerError', 'Select a user first');
-                return;
-            }
-            postJson(assignProgramManagerUrl, {username: username}).then(({ok, data}) => {
-                if (ok) {
-                    bootstrap.Modal.getInstance(document.getElementById('assignProgramManagerModal')).hide();
-                    loadAccessUsers();
-                } else {
-                    showModalError('assignProgramManagerError', data.error || 'Failed to assign program manager');
                 }
             });
         });

--- a/manytask/manytask/templates/edit_course.html
+++ b/manytask/manytask/templates/edit_course.html
@@ -141,12 +141,7 @@
     </form>
 
     <div class="action-group mt-4">
-        <h4><i class="fas fa-user-shield me-2"></i>Course Access</h4>
-        <p class="text-muted course-access-hint">
-            Everyone who can administer this course, whether their access comes from the instance,
-            from the namespace, or from the course itself. Instance and namespace access is managed
-            elsewhere and is shown here read-only.
-        </p>
+        <h4>Course Access</h4>
 
         <div class="course-access-controls mb-3">
             <div class="course-access-search">
@@ -156,18 +151,15 @@
             <button id="access-filter-clear" type="button" class="btn btn-outline-secondary">
                 <i class="fas fa-times"></i> Clear
             </button>
-        </div>
-
-        <div id="course-access-error" class="alert alert-danger d-none" role="alert"></div>
-        <div id="course-access-table"></div>
-
-        <div class="admin-actions mt-3">
             <button type="button" class="btn btn-warning admin-btn" data-bs-toggle="modal"
                     data-bs-target="#grantCourseAdminModal">
                 <i class="fas fa-user-shield"></i>
                 <span>Grant course admin rights</span>
             </button>
         </div>
+
+        <div id="course-access-error" class="alert alert-danger d-none" role="alert"></div>
+        <div id="course-access-table"></div>
     </div>
 </div>
 
@@ -365,36 +357,33 @@
                 },
                 formatter: function (cell) {
                     const levels = cell.getValue() || [];
+                    const row = cell.getRow();
                     return ACCESS_ORDER
                         .filter(level => levels.includes(level))
-                        .map(level => `<span class="badge ${ACCESS_BADGES[level]} me-1">${ACCESS_LABELS[level]}</span>`)
+                        .map(level => {
+                            if (level === 'course_admin') {
+                                const username = row.getData().username;
+                                return `<span class="badge ${ACCESS_BADGES[level]} me-1">`
+                                    + `${ACCESS_LABELS[level]}`
+                                    + `<button type="button" class="course-access-revoke ms-1"`
+                                    + ` data-username="${username}"`
+                                    + ` title="Revoke course admin rights">&times;</button>`
+                                    + `</span>`;
+                            }
+                            return `<span class="badge ${ACCESS_BADGES[level]} me-1">${ACCESS_LABELS[level]}</span>`;
+                        })
                         .join('');
-                }
-            },
-            {
-                title: "Actions",
-                field: "actions",
-                headerSort: false,
-                hozAlign: "center",
-                width: 110,
-                headerTooltip: "Revoke course admin rights",
-                formatter: function (cell) {
-                    const data = cell.getRow().getData();
-                    if (!(data.access_levels || []).includes('course_admin')) {
-                        return "";
-                    }
-                    return `<button type="button" class="btn btn-sm btn-outline-danger course-access-revoke"`
-                        + ` title="Revoke course admin rights"><i class="fas fa-user-slash"></i></button>`;
                 },
                 cellClick: function (e, cell) {
-                    if (!e.target.closest('.course-access-revoke')) {
+                    const btn = e.target.closest('.course-access-revoke');
+                    if (!btn) {
                         return;
                     }
-                    const data = cell.getRow().getData();
-                    if (!confirm(`Revoke course admin rights from "${data.username}"?`)) {
+                    const username = btn.dataset.username;
+                    if (!confirm(`Revoke course admin rights from "${username}"?`)) {
                         return;
                     }
-                    setCourseAdmin(data.username, false).then(({ok, data: body}) => {
+                    setCourseAdmin(username, false).then(({ok, data: body}) => {
                         if (ok) {
                             loadAccessUsers();
                         } else {

--- a/manytask/manytask/templates/edit_course.html
+++ b/manytask/manytask/templates/edit_course.html
@@ -158,6 +158,7 @@
             </button>
         </div>
 
+        <div id="course-access-error" class="alert alert-danger d-none" role="alert"></div>
         <div id="course-access-table"></div>
 
         <div class="admin-actions mt-3">
@@ -275,12 +276,24 @@
 
     function loadAccessUsers() {
         return fetch(accessUsersUrl)
-            .then(response => response.json())
-            .then(data => {
-                if (window.accessTable) {
-                    window.accessTable.setData(data.users || []);
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`${accessUsersUrl} returned HTTP ${response.status}`);
                 }
-                return data.users || [];
+                return response.json();
+            })
+            .then(data => {
+                const users = data.users || [];
+                if (window.accessTable) {
+                    window.accessTable.setData(users);
+                }
+                return users;
+            })
+            .catch(error => {
+                // Surface the failure instead of leaving a silently empty table,
+                // which is indistinguishable from "nobody has access".
+                showAccessError(`Could not load the access list: ${error.message}`);
+                return [];
             });
     }
 
@@ -302,8 +315,27 @@
         errorDiv.classList.remove('d-none');
     }
 
+    function showAccessError(message) {
+        console.error('Course access table:', message);
+        const container = document.getElementById('course-access-error');
+        if (container) {
+            container.textContent = message;
+            container.classList.remove('d-none');
+        }
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         filterSelectOptions('grantSearchInput', 'userToGrant');
+
+        // Tabulator comes from a CDN; without it the table cannot be built, and
+        // failing silently here would look identical to "nobody has access".
+        if (typeof Tabulator === 'undefined') {
+            showAccessError(
+                'Could not load the table library (Tabulator) from the CDN, '
+                + 'so the access list cannot be displayed. Check your network connection.'
+            );
+            return;
+        }
 
         const columns = [
             {
@@ -382,8 +414,13 @@
             placeholder: "Nobody has admin access to this course yet.",
         });
 
-        initTabulatorTheme(() => window.accessTable);
-        loadAccessUsers();
+        // Tabulator builds asynchronously. initTabulatorTheme() redraws the table
+        // immediately, and setData() on a table that is not built yet throws, so
+        // both must wait for `tableBuilt` - otherwise the rows never arrive.
+        window.accessTable.on("tableBuilt", function () {
+            initTabulatorTheme(() => window.accessTable);
+            loadAccessUsers();
+        });
 
         // Transliteration-aware search over login and full name, matching the
         // course database page.

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -582,29 +582,6 @@ def create_course() -> ResponseReturnValue:  # noqa: PLR0911
     )
 
 
-def _can_assign_namespace_roles(app: CustomFlask, namespace_id: int | None) -> bool:
-    """Whether the current user may grant namespace-scoped roles for this course.
-
-    Program manager is a namespace-level role, so being a course admin is not enough:
-    only instance admins and admins of the course's own namespace may assign it.
-    Mirrors the authorization enforced by :func:`manytask.api.assign_program_manager`,
-    so the UI never offers a control that the endpoint would reject.
-
-    :param app: Flask application instance (debug mode grants access)
-    :param namespace_id: id of the course's namespace, or ``None``
-    :return: True if the current user may assign program managers
-    """
-    if app.debug:
-        return True
-    if namespace_id is None:
-        return False
-
-    username = session["manytask"]["username"]
-    if app.storage_api.check_if_instance_admin(username):
-        return True
-    return namespace_id in app.storage_api.get_namespace_admin_namespaces(username)
-
-
 @instance_admin_bp.route("/courses/<course_name>/edit", methods=["GET", "POST"])
 @requires_course_admin
 def edit_course(course_name: str) -> ResponseReturnValue:
@@ -655,8 +632,6 @@ def edit_course(course_name: str) -> ResponseReturnValue:
         course=course,
         course_users=course_users,
         rms=app.app_config.rms,
-        namespace_id=course.namespace_id,
-        can_assign_namespace_roles=_can_assign_namespace_roles(app, course.namespace_id),
     )
 
 

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -582,34 +582,27 @@ def create_course() -> ResponseReturnValue:  # noqa: PLR0911
     )
 
 
-def _handle_course_admin_action(app: CustomFlask, course_name: str, grant_course_admin: bool) -> None:
-    """Grant or revoke course admin status based on the submitted form action.
+def _can_assign_namespace_roles(app: CustomFlask, namespace_id: int | None) -> bool:
+    """Whether the current user may grant namespace-scoped roles for this course.
 
-    Only instance admins or course admins of this course may perform this action.
+    Program manager is a namespace-level role, so being a course admin is not enough:
+    only instance admins and admins of the course's own namespace may assign it.
+    Mirrors the authorization enforced by :func:`manytask.api.assign_program_manager`,
+    so the UI never offers a control that the endpoint would reject.
+
+    :param app: Flask application instance (debug mode grants access)
+    :param namespace_id: id of the course's namespace, or ``None``
+    :return: True if the current user may assign program managers
     """
     if app.debug:
-        current_user = "guest"
-    else:
-        current_user = session["manytask"]["username"]
+        return True
+    if namespace_id is None:
+        return False
 
-        if not app.storage_api.check_if_course_admin(course_name, current_user):
-            safe_course_name = sanitize_log_data(course_name)
-            logger.warning(
-                "User %s attempted to change course admin status in course %s without permission",
-                current_user,
-                safe_course_name,
-            )
-            abort(HTTPStatus.FORBIDDEN)
-
-    target_username = request.form.get("username", "")
-    app.storage_api.set_course_admin_status(course_name, target_username, grant_course_admin)
-    app.logger.warning(
-        "User %s %s course admin status for %s in course %s",
-        current_user,
-        "granted" if grant_course_admin else "revoked",
-        target_username,
-        course_name,
-    )
+    username = session["manytask"]["username"]
+    if app.storage_api.check_if_instance_admin(username):
+        return True
+    return namespace_id in app.storage_api.get_namespace_admin_namespaces(username)
 
 
 @instance_admin_bp.route("/courses/<course_name>/edit", methods=["GET", "POST"])
@@ -628,11 +621,6 @@ def edit_course(course_name: str) -> ResponseReturnValue:
         except ValidationError as e:
             app.logger.error("CSRF validation failed: %s", e)
             return render_template("edit_course.html", error_message="CSRF Error", rms=app.app_config.rms)
-
-        action = request.form.get("action", "")
-        if action in ("grant_course_admin", "revoke_course_admin"):
-            _handle_course_admin_action(app, course_name, action == "grant_course_admin")
-            return redirect(url_for("instance_admin.edit_course", course_name=course_name))
 
         updated_settings = CourseConfig(
             course_name=course_name,
@@ -662,7 +650,14 @@ def edit_course(course_name: str) -> ResponseReturnValue:
         )
 
     course_users = app.storage_api.get_course_users_with_admin_status(course_name)
-    return render_template("edit_course.html", course=course, course_users=course_users, rms=app.app_config.rms)
+    return render_template(
+        "edit_course.html",
+        course=course,
+        course_users=course_users,
+        rms=app.app_config.rms,
+        namespace_id=course.namespace_id,
+        can_assign_namespace_roles=_can_assign_namespace_roles(app, course.namespace_id),
+    )
 
 
 @instance_admin_bp.route("/", methods=["GET"])

--- a/manytask/tests/helpers.py
+++ b/manytask/tests/helpers.py
@@ -285,6 +285,10 @@ class MockStorageApiBase:
         return True
 
     @staticmethod
+    def check_if_instance_admin(_username):
+        return False
+
+    @staticmethod
     def get_grades(*_args, **_kwargs):
         return MockFinalGradeConfig()
 

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -11,7 +11,7 @@ from flask import json, url_for
 from pytest import approx
 from werkzeug.exceptions import HTTPException
 
-from manytask.abstract import RmsUser
+from manytask.abstract import CourseAccessUser, RmsUser
 from manytask.api import _parse_flags, _process_score, _update_score, _validate_and_extract_params
 from manytask.api import bp as api_bp
 from manytask.config import ManytaskConfig, ManytaskDeadlinesType, ManytaskGroupConfig, ManytaskTaskConfig
@@ -1485,3 +1485,166 @@ def test_deadlines_invalid_token(app):
     response = client.get(f"/api/{TEST_COURSE_NAME}/deadlines", headers=headers)
 
     assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+# ----- Course access table -----
+
+
+ACCESS_USERS_URL = f"/api/{TEST_COURSE_NAME}/access_users"
+COURSE_ADMIN_URL = f"/api/{TEST_COURSE_NAME}/course_admin"
+PROGRAM_MANAGER_URL = f"/api/{TEST_COURSE_NAME}/program_manager"
+
+
+def _stub_access_users(app, access_users):
+    app.storage_api.get_course_access_users = lambda _course_name: access_users
+
+
+def test_get_access_users_returns_levels(app, authenticated_client):
+    _stub_access_users(
+        app,
+        [
+            CourseAccessUser(
+                username=TEST_USERNAME,
+                first_name=TEST_FIRST_NAME,
+                last_name=TEST_LAST_NAME,
+                access_levels=["instance_admin", "course_admin"],
+            )
+        ],
+    )
+
+    response = authenticated_client.get(ACCESS_USERS_URL)
+
+    assert response.status_code == HTTPStatus.OK
+    body = json.loads(response.data)
+    assert body["users"] == [
+        {
+            "username": TEST_USERNAME,
+            "first_name": TEST_FIRST_NAME,
+            "last_name": TEST_LAST_NAME,
+            "access_levels": ["instance_admin", "course_admin"],
+        }
+    ]
+
+
+def test_get_access_users_empty(app, authenticated_client):
+    _stub_access_users(app, [])
+
+    response = authenticated_client.get(ACCESS_USERS_URL)
+
+    assert response.status_code == HTTPStatus.OK
+    assert json.loads(response.data)["users"] == []
+
+
+def test_get_access_users_forbidden_for_non_admin(app, authenticated_client):
+    app.storage_api.non_admin_users.add(TEST_USERNAME)
+    app.storage_api.check_if_instance_admin = lambda _username: False
+    _stub_access_users(app, [])
+
+    response = authenticated_client.get(ACCESS_USERS_URL)
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_set_course_admin_grants(app, authenticated_client):
+    calls = []
+    app.storage_api.set_course_admin_status = lambda *args: calls.append(args)
+
+    response = authenticated_client.post(COURSE_ADMIN_URL, json={"username": TEST_USERNAME, "is_admin": True})
+
+    assert response.status_code == HTTPStatus.OK
+    assert calls == [(TEST_COURSE_NAME, TEST_USERNAME, True)]
+
+
+def test_set_course_admin_revokes(app, authenticated_client):
+    calls = []
+    app.storage_api.set_course_admin_status = lambda *args: calls.append(args)
+
+    response = authenticated_client.post(COURSE_ADMIN_URL, json={"username": TEST_USERNAME, "is_admin": False})
+
+    assert response.status_code == HTTPStatus.OK
+    assert calls == [(TEST_COURSE_NAME, TEST_USERNAME, False)]
+
+
+def test_set_course_admin_unknown_user(app, authenticated_client):
+    response = authenticated_client.post(COURSE_ADMIN_URL, json={"username": "nobody", "is_admin": True})
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_set_course_admin_rejects_non_member(app, authenticated_client):
+    """Course admin status lives on the enrollment row, so non-members are rejected."""
+    app.storage_api.check_user_on_course = lambda *_args, **_kwargs: False
+    calls = []
+    app.storage_api.set_course_admin_status = lambda *args: calls.append(args)
+
+    response = authenticated_client.post(COURSE_ADMIN_URL, json={"username": TEST_USERNAME, "is_admin": True})
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert "not enrolled" in json.loads(response.data)["error"]
+    assert calls == []
+
+
+def test_set_course_admin_forbidden_for_non_admin(app, authenticated_client):
+    app.storage_api.non_admin_users.add(TEST_USERNAME)
+    app.storage_api.check_if_instance_admin = lambda _username: False
+
+    response = authenticated_client.post(COURSE_ADMIN_URL, json={"username": TEST_USERNAME, "is_admin": True})
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_set_course_admin_requires_json(app, authenticated_client):
+    response = authenticated_client.post(COURSE_ADMIN_URL, data="not json", content_type="text/plain")
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_assign_program_manager_without_namespace(app, authenticated_client, mock_course):
+    """A course outside any namespace has no program managers to assign."""
+    assert mock_course.namespace_id is None
+
+    response = authenticated_client.post(PROGRAM_MANAGER_URL, json={"username": TEST_USERNAME})
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert "namespace" in json.loads(response.data)["error"]
+
+
+def test_assign_program_manager_forbidden_for_course_admin(app, authenticated_client, mock_course):
+    """Being a course admin must not be enough to grant a namespace-level role."""
+    mock_course.namespace_id = 1
+    app.storage_api.check_if_instance_admin = lambda _username: False
+    app.storage_api.get_namespace_admin_namespaces = lambda _username: []
+
+    response = authenticated_client.post(PROGRAM_MANAGER_URL, json={"username": TEST_USERNAME})
+
+    assert response.status_code == HTTPStatus.FORBIDDEN
+    assert "Namespace Admin" in json.loads(response.data)["error"]
+
+
+def test_assign_program_manager_allowed_for_namespace_admin(app, authenticated_client, mock_course):
+    mock_course.namespace_id = 1
+    app.storage_api.check_if_instance_admin = lambda _username: False
+    app.storage_api.get_namespace_admin_namespaces = lambda _username: [1]
+
+    namespace = MagicMock()
+    namespace.gitlab_group_id = 1
+    app.storage_api.get_namespace_by_id = lambda _namespace_id, _username: (namespace, "namespace_admin")
+
+    user_on_namespace = MagicMock()
+    user_on_namespace.id = 1
+    user_on_namespace.user_id = 2
+    user_on_namespace.namespace_id = 1
+    added = []
+
+    def add_user_to_namespace(*, namespace_id, username, role, assigned_by_username):
+        added.append((namespace_id, username, role))
+        return user_on_namespace
+
+    app.storage_api.add_user_to_namespace = add_user_to_namespace
+    app.rms_api.add_user_to_namespace_group = lambda **_kwargs: None
+
+    response = authenticated_client.post(PROGRAM_MANAGER_URL, json={"username": TEST_USERNAME})
+
+    assert response.status_code == HTTPStatus.CREATED
+    assert added == [(1, TEST_USERNAME, "program_manager")]
+    assert json.loads(response.data)["role"] == "program_manager"

--- a/manytask/tests/test_db_api.py
+++ b/manytask/tests/test_db_api.py
@@ -1375,6 +1375,136 @@ def test_get_course_users_with_admin_status_unknown_course(db_api_with_two_initi
     assert db_api_with_two_initialized_courses.get_course_users_with_admin_status("nonexistent_course") == []
 
 
+def _access_levels_by_username(access_users) -> dict[str, set[str]]:
+    return {access_user.username: set(access_user.access_levels) for access_user in access_users}
+
+
+def test_get_course_access_users_instance_admin(db_api_with_initialized_first_course):
+    """The bootstrap instance admin has access to every course."""
+    result = db_api_with_initialized_first_course.get_course_access_users(FIRST_COURSE_NAME)
+
+    assert _access_levels_by_username(result) == {"instance_admin": {"instance_admin"}}
+
+
+def test_get_course_access_users_course_admin(db_api_with_initialized_first_course, session):
+    add_user_on_course(session, is_course_admin=True)
+
+    result = db_api_with_initialized_first_course.get_course_access_users(FIRST_COURSE_NAME)
+
+    assert _access_levels_by_username(result)[TEST_USERNAME] == {"course_admin"}
+
+
+def test_get_course_access_users_excludes_plain_students(db_api_with_initialized_first_course, session):
+    """A course member without the admin flag must not appear in the access table."""
+    add_user_on_course(session, is_course_admin=False)
+
+    result = db_api_with_initialized_first_course.get_course_access_users(FIRST_COURSE_NAME)
+
+    assert TEST_USERNAME not in _access_levels_by_username(result)
+
+
+def test_get_course_access_users_namespace_roles(db_api_with_initialized_first_course, session):
+    """Namespace admins and program managers of the course's namespace are included."""
+    owner_id = session.query(User).filter_by(username="instance_admin").one().id
+    namespace_admin, _ = add_user_on_course(session, student=STUDENT_1, user_id=3, is_course_admin=False)
+    program_manager, _ = add_user_on_course(session, student=STUDENT_2, user_id=4, is_course_admin=False)
+
+    _create_namespace_with_course(session, created_by_id=owner_id)
+    session.add(
+        UserOnNamespace(
+            user_id=namespace_admin.id,
+            namespace_id=1,
+            role=UserOnNamespaceRole.NAMESPACE_ADMIN,
+            assigned_by_id=owner_id,
+        )
+    )
+    session.add(
+        UserOnNamespace(
+            user_id=program_manager.id,
+            namespace_id=1,
+            role=UserOnNamespaceRole.PROGRAM_MANAGER,
+            assigned_by_id=owner_id,
+        )
+    )
+    session.commit()
+
+    result = _access_levels_by_username(db_api_with_initialized_first_course.get_course_access_users(FIRST_COURSE_NAME))
+
+    assert result[TEST_USERNAME_1] == {"namespace_admin"}
+    assert result[TEST_USERNAME_2] == {"program_manager"}
+
+
+def test_get_course_access_users_merges_levels_of_one_user(db_api_with_initialized_first_course, session):
+    """A user holding several levels appears once, with all of them listed."""
+    owner_id = session.query(User).filter_by(username="instance_admin").one().id
+    user, _ = add_user_on_course(session, is_course_admin=True)
+
+    _create_namespace_with_course(session, created_by_id=owner_id)
+    session.add(
+        UserOnNamespace(
+            user_id=user.id,
+            namespace_id=1,
+            role=UserOnNamespaceRole.NAMESPACE_ADMIN,
+            assigned_by_id=owner_id,
+        )
+    )
+    session.commit()
+
+    result = db_api_with_initialized_first_course.get_course_access_users(FIRST_COURSE_NAME)
+
+    matching = [access_user for access_user in result if access_user.username == TEST_USERNAME]
+    assert len(matching) == 1
+    assert set(matching[0].access_levels) == {"namespace_admin", "course_admin"}
+
+
+def test_get_course_access_users_ignores_other_namespace(db_api_with_two_initialized_courses, session):
+    """Roles in a namespace the course does not belong to must not leak in."""
+    owner_id = session.query(User).filter_by(username="instance_admin").one().id
+    other_user, _ = add_user_on_course(session, student=STUDENT_1, user_id=3, is_course_admin=False)
+
+    # The namespace is attached to the *second* course only.
+    _create_namespace_with_course(session, created_by_id=owner_id, course_id=2, namespace_id=2)
+    session.add(
+        UserOnNamespace(
+            user_id=other_user.id,
+            namespace_id=2,
+            role=UserOnNamespaceRole.NAMESPACE_ADMIN,
+            assigned_by_id=owner_id,
+        )
+    )
+    session.commit()
+
+    result = _access_levels_by_username(db_api_with_two_initialized_courses.get_course_access_users(FIRST_COURSE_NAME))
+
+    assert TEST_USERNAME_1 not in result
+
+
+def test_get_course_access_users_course_without_namespace(db_api_with_initialized_first_course, session):
+    """A course with no namespace still reports instance and course admins."""
+    add_user_on_course(session, is_course_admin=True)
+
+    course = session.query(Course).filter_by(name=FIRST_COURSE_NAME).one()
+    assert course.namespace_id is None
+
+    result = _access_levels_by_username(db_api_with_initialized_first_course.get_course_access_users(FIRST_COURSE_NAME))
+
+    assert result == {"instance_admin": {"instance_admin"}, TEST_USERNAME: {"course_admin"}}
+
+
+def test_get_course_access_users_sorted_by_username(db_api_with_initialized_first_course, session):
+    add_user_on_course(session, student=STUDENT_2, user_id=4, is_course_admin=True)
+    add_user_on_course(session, student=STUDENT_1, user_id=3, is_course_admin=True)
+
+    result = db_api_with_initialized_first_course.get_course_access_users(FIRST_COURSE_NAME)
+
+    usernames = [access_user.username for access_user in result]
+    assert usernames == sorted(usernames)
+
+
+def test_get_course_access_users_unknown_course(db_api_with_two_initialized_courses):
+    assert db_api_with_two_initialized_courses.get_course_access_users("nonexistent_course") == []
+
+
 def test_check_user_on_course(db_api_with_two_initialized_courses, session):
     add_user_on_course(session, is_course_admin=True)
 

--- a/manytask/tests/test_web.py
+++ b/manytask/tests/test_web.py
@@ -625,28 +625,15 @@ def test_edit_course_renders_access_table(app, mock_gitlab_oauth):
     assert soup.find(id="access-filter-clear") is not None
 
 
-def test_edit_course_renders_access_modals(app, mock_gitlab_oauth):
+def test_edit_course_renders_grant_course_admin_modal(app, mock_gitlab_oauth):
     soup = _get_edit_course_page(app, mock_gitlab_oauth)
 
     assert soup.find(id="grantCourseAdminModal") is not None
-    assert soup.find(id="assignProgramManagerModal") is not None
 
 
-def test_edit_course_program_manager_disabled_without_namespace(app, mock_gitlab_oauth, mock_course):
-    """A course outside a namespace has no program managers, so the control is disabled."""
-    assert mock_course.namespace_id is None
-
+def test_edit_course_has_no_program_manager_control(app, mock_gitlab_oauth):
+    """Program managers are managed on the namespace panel, not from the course page."""
     soup = _get_edit_course_page(app, mock_gitlab_oauth)
 
-    button = soup.find("button", {"data-bs-target": "#assignProgramManagerModal"})
-    assert button.has_attr("disabled")
-
-
-def test_edit_course_program_manager_enabled_for_namespace_admin(app, mock_gitlab_oauth, mock_course):
-    mock_course.namespace_id = 1
-    app.storage_api.get_namespace_admin_namespaces = lambda _username: [1]
-
-    soup = _get_edit_course_page(app, mock_gitlab_oauth)
-
-    button = soup.find("button", {"data-bs-target": "#assignProgramManagerModal"})
-    assert not button.has_attr("disabled")
+    assert soup.find(id="assignProgramManagerModal") is None
+    assert soup.find("button", {"data-bs-target": "#assignProgramManagerModal"}) is None

--- a/manytask/tests/test_web.py
+++ b/manytask/tests/test_web.py
@@ -597,3 +597,56 @@ def test_signup_finish_with_new_user_in_db(app, mock_gitlab_oauth):
                 rms_id=rms_id,
                 auth_id=TEST_USER_ID,
             )
+
+
+# ----- Course access table on the edit page -----
+
+
+def _get_edit_course_page(app, mock_gitlab_oauth):
+    """Open the course edit page as an instance admin and return the parsed HTML."""
+    CSRFProtect(app)  # the settings form renders a csrf_token
+    app.storage_api.stored_user.instance_admin = True
+    app.storage_api.course_admin = True  # required by the requires_course_admin guard
+    app.storage_api.get_course_users_with_admin_status = lambda _course_name: []
+
+    with app.test_request_context(), app.test_client() as client:
+        app.oauth = mock_gitlab_oauth
+        set_session(client, build_test_session(include_manytask=True))
+        response = client.get(url_for("instance_admin.edit_course", course_name=TEST_COURSE_NAME))
+        assert response.status_code == HTTPStatus.OK
+        return BeautifulSoup(response.data, "html.parser")
+
+
+def test_edit_course_renders_access_table(app, mock_gitlab_oauth):
+    soup = _get_edit_course_page(app, mock_gitlab_oauth)
+
+    assert soup.find(id="course-access-table") is not None
+    assert soup.find(id="access-filter-value") is not None
+    assert soup.find(id="access-filter-clear") is not None
+
+
+def test_edit_course_renders_access_modals(app, mock_gitlab_oauth):
+    soup = _get_edit_course_page(app, mock_gitlab_oauth)
+
+    assert soup.find(id="grantCourseAdminModal") is not None
+    assert soup.find(id="assignProgramManagerModal") is not None
+
+
+def test_edit_course_program_manager_disabled_without_namespace(app, mock_gitlab_oauth, mock_course):
+    """A course outside a namespace has no program managers, so the control is disabled."""
+    assert mock_course.namespace_id is None
+
+    soup = _get_edit_course_page(app, mock_gitlab_oauth)
+
+    button = soup.find("button", {"data-bs-target": "#assignProgramManagerModal"})
+    assert button.has_attr("disabled")
+
+
+def test_edit_course_program_manager_enabled_for_namespace_admin(app, mock_gitlab_oauth, mock_course):
+    mock_course.namespace_id = 1
+    app.storage_api.get_namespace_admin_namespaces = lambda _username: [1]
+
+    soup = _get_edit_course_page(app, mock_gitlab_oauth)
+
+    button = soup.find("button", {"data-bs-target": "#assignProgramManagerModal"})
+    assert not button.has_attr("disabled")


### PR DESCRIPTION
The table shows everyone who can administer a course in one table, regardless of
where the access comes from: instance admins, namespace admins, program
managers and course admins. Also added a management for course admins directly
from this page so one can add/remove teachers there.