### PR TITLE
fix(sourcecraft): use RMS-native username for project existence check

### DIFF
--- a/manytask/manytask/auth.py
+++ b/manytask/manytask/auth.py
@@ -254,8 +254,14 @@ def requires_course_access(f: Callable[..., Any]) -> Callable[..., Any]:
             flash("course is hidden!", "course_hidden")
             abort(redirect(url_for("root.index")))
 
+        # NOTE: use the RMS-native username (session["rms"]["username"]) rather than the auth-provider
+        # login (auth_user.username): on SourceCraft the two may differ (e.g. when the desired slug is
+        # already taken the platform assigns a fallback like "ps5-1" for a Yandex login "Ps5"), and
+        # student repos are created under the RMS-native username. Passing the auth-provider login here
+        # would produce a false negative on the existence check, redirect the user to /create_project,
+        # and 500 with SlugIsNotAvailable when the create call tries to re-create the existing repo.
         if not handle_course_membership(app, course, username) or not app.rms_api.check_project_exists(
-            project_name=auth_user.username, project_group=course.gitlab_course_students_group
+            project_name=session["rms"]["username"], project_group=course.gitlab_course_students_group
         ):
             logger.info("User %s missing membership or project", username)
             abort(redirect(url_for("course.create_project", course_name=course.course_name)))

--- a/manytask/manytask/sourcecraft.py
+++ b/manytask/manytask/sourcecraft.py
@@ -234,7 +234,11 @@ class SourceCraftApi(RmsApi):
     ) -> bool:
         """Check if a project exists in the given group.
 
-        :param project_name: repo slug suffix
+        :param project_name: repo slug suffix; MUST be the RMS-native username
+            (``RmsUser.username``) rather than the auth-provider login, because
+            :meth:`create_project` derives the slug from ``rms_user.username``
+            and on SourceCraft the two may differ (e.g. fallback slug ``ps5-1``
+            for a Yandex login ``Ps5`` when ``ps5`` is taken).
         :param project_group: repo slug prefix
         :return: True if repo exists, False otherwise
         """

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -259,8 +259,21 @@ def signup_finish() -> ResponseReturnValue:  # noqa: PLR0911
         auth_id=session["auth"]["user_auth_id"],
     )
     if stored_user_or_none is not None:
+        # Resolve the RMS-native username from the RMS API. It may differ from the auth-provider
+        # login (e.g. on SourceCraft, when the desired slug is taken, the platform issues a fallback
+        # like "ps5-1" for the Yandex login "Ps5"). Storing the auth login here poisons downstream
+        # slug lookups (existence checks, repo URLs) that expect the RMS-native username.
+        try:
+            rms_username = app.rms_api.get_rms_user_by_id(stored_user_or_none.rms_id).username
+        except RmsApiException as e:
+            logger.warning(
+                "Failed to resolve RMS user for rms_id=%s (%s); falling back to auth username",
+                stored_user_or_none.rms_id,
+                e,
+            )
+            rms_username = session["auth"]["username"]
         session.setdefault("rms", {}).update(
-            set_rms_session(ClientProfile(rms_id=stored_user_or_none.rms_id, username=session["auth"]["username"]))
+            set_rms_session(ClientProfile(rms_id=stored_user_or_none.rms_id, username=rms_username))
         )
         session.setdefault("manytask", {}).update(
             set_manytask_session(user_id=stored_user_or_none.user_id, username=stored_user_or_none.username)

--- a/manytask/tests/test_sourcecraft.py
+++ b/manytask/tests/test_sourcecraft.py
@@ -1,0 +1,142 @@
+"""Unit tests for SourceCraftApi.
+
+Focus of these tests is the slug construction contract shared between
+``check_project_exists`` and ``create_project``: both must derive the repo
+slug from the same source (the RMS-native ``RmsUser.username``), otherwise
+a user whose auth-provider login differs from their SourceCraft username
+(e.g. Yandex login ``Ps5`` but SourceCraft assigns fallback slug ``ps5-1``)
+will get a false negative from the existence check and a 500
+``SlugIsNotAvailable`` from the follow-up create call.
+"""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manytask.abstract import RmsApiException, RmsUser
+from manytask.sourcecraft import SourceCraftApi, SourceCraftConfig
+
+TEST_ORG = "hsemanytask"
+TEST_STUDENTS_GROUP = "ami-python-basic-st-26f"
+TEST_PUBLIC_REPO = "public-2026-fall"
+YANDEX_LOGIN = "Ps5"
+SOURCECRAFT_USERNAME = "ps5-1"
+TEST_RMS_ID = "rms-uuid-1"
+
+
+@pytest.fixture
+def sourcecraft_api():
+    """Build a SourceCraftApi with the yandex-cloud SDK and IAM-token flow stubbed out."""
+    config = SourceCraftConfig(
+        base_url="https://sourcecraft.dev",
+        api_url="https://api.sourcecraft.tech/",
+        org_slug=TEST_ORG,
+        oauth_token="fake-oauth-token",
+    )
+    with patch("manytask.sourcecraft.SDK"):
+        api = SourceCraftApi(config)
+    with patch.object(SourceCraftApi, "iam_token", new="fake-iam-token"):
+        yield api
+
+
+def _make_response(status_code, json_body=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_body if json_body is not None else {}
+    return response
+
+
+def test_check_project_exists_returns_true_on_200(sourcecraft_api):
+    with patch.object(sourcecraft_api, "_request", return_value=_make_response(HTTPStatus.OK)) as mock_request:
+        assert (
+            sourcecraft_api.check_project_exists(project_name=SOURCECRAFT_USERNAME, project_group=TEST_STUDENTS_GROUP)
+            is True
+        )
+    mock_request.assert_called_once_with("GET", f"repos/{TEST_ORG}/{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}")
+
+
+def test_check_project_exists_returns_false_on_404(sourcecraft_api):
+    with patch.object(sourcecraft_api, "_request", return_value=_make_response(HTTPStatus.NOT_FOUND)):
+        assert (
+            sourcecraft_api.check_project_exists(project_name=SOURCECRAFT_USERNAME, project_group=TEST_STUDENTS_GROUP)
+            is False
+        )
+
+
+def test_check_project_exists_raises_on_unexpected_status(sourcecraft_api):
+    with patch.object(sourcecraft_api, "_request", return_value=_make_response(HTTPStatus.INTERNAL_SERVER_ERROR)):
+        with pytest.raises(RmsApiException):
+            sourcecraft_api.check_project_exists(project_name=SOURCECRAFT_USERNAME, project_group=TEST_STUDENTS_GROUP)
+
+
+def test_create_project_slug_derives_from_rms_user_username(sourcecraft_api):
+    """The create-repo POST body must use the RMS-native username as the slug."""
+    rms_user = RmsUser(id=TEST_RMS_ID, username=SOURCECRAFT_USERNAME, name="Test User")
+
+    def request_side_effect(method, path, **kwargs):
+        if method == "GET" and path == f"repos/{TEST_ORG}/{TEST_PUBLIC_REPO}":
+            return _make_response(HTTPStatus.OK, {"id": 42})
+        if method == "POST" and path == f"orgs/{TEST_ORG}/repos":
+            return _make_response(HTTPStatus.CREATED)
+        if method == "POST" and path.endswith("/roles"):
+            return _make_response(HTTPStatus.OK)
+        raise AssertionError(f"unexpected request {method} {path}")
+
+    with patch.object(sourcecraft_api, "_request", side_effect=request_side_effect) as mock_request:
+        sourcecraft_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+
+    create_calls = [call for call in mock_request.call_args_list if call.args == ("POST", f"orgs/{TEST_ORG}/repos")]
+    assert len(create_calls) == 1
+    payload = create_calls[0].kwargs["json"]
+    expected_slug = f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}"
+    assert payload["slug"] == expected_slug
+    assert payload["name"] == expected_slug
+
+
+def test_existence_check_and_create_use_matching_slug(sourcecraft_api):
+    """Regression: when Yandex login ("Ps5") differs from SC username ("ps5-1"),
+    callers must pass the SC username to ``check_project_exists`` so that the slug
+    it looks up matches the slug ``create_project`` would produce. Passing the
+    Yandex login instead is a false negative and leads to a duplicate-create 500.
+    """
+    rms_user = RmsUser(id=TEST_RMS_ID, username=SOURCECRAFT_USERNAME, name="Test User")
+
+    seen_paths = []
+
+    def record_request(method, path, **kwargs):
+        seen_paths.append((method, path))
+        if method == "GET" and path == f"repos/{TEST_ORG}/{TEST_PUBLIC_REPO}":
+            return _make_response(HTTPStatus.OK, {"id": 42})
+        if method == "POST" and path == f"orgs/{TEST_ORG}/repos":
+            return _make_response(HTTPStatus.CREATED)
+        if method == "POST" and path.endswith("/roles"):
+            return _make_response(HTTPStatus.OK)
+        if method == "GET" and path.startswith(f"repos/{TEST_ORG}/{TEST_STUDENTS_GROUP}-"):
+            return _make_response(HTTPStatus.OK)
+        raise AssertionError(f"unexpected request {method} {path}")
+
+    with patch.object(sourcecraft_api, "_request", side_effect=record_request):
+        # Simulate what create_project (using rms_user.username) would create ...
+        sourcecraft_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+        # ... and then verify that a subsequent existence check with the SAME
+        # (SC-native) username hits the same slug.
+        assert (
+            sourcecraft_api.check_project_exists(project_name=rms_user.username, project_group=TEST_STUDENTS_GROUP)
+            is True
+        )
+
+    created_slug = f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}"
+    assert ("POST", f"orgs/{TEST_ORG}/repos") in seen_paths
+    assert ("GET", f"repos/{TEST_ORG}/{created_slug}") in seen_paths
+    # And critically: no GET was ever issued for the Yandex-login-based slug.
+    assert ("GET", f"repos/{TEST_ORG}/{TEST_STUDENTS_GROUP}-ps5") not in seen_paths
+    assert ("GET", f"repos/{TEST_ORG}/{TEST_STUDENTS_GROUP}-{YANDEX_LOGIN.lower()}") not in seen_paths
+
+
+def test_get_url_for_repo_uses_passed_username(sourcecraft_api):
+    """``get_url_for_repo`` derives the URL from the passed username, so callers
+    must also pass the RMS-native username to point students at the right repo.
+    """
+    url = sourcecraft_api.get_url_for_repo(username=SOURCECRAFT_USERNAME, course_students_group=TEST_STUDENTS_GROUP)
+    assert url.endswith(f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}")

--- a/manytask/tests/test_web.py
+++ b/manytask/tests/test_web.py
@@ -218,6 +218,44 @@ def test_course_page_only_with_valid_session(app, mock_gitlab_oauth):
             assert response.location == f"/{TEST_COURSE_NAME}/create_project"
 
 
+def test_course_page_uses_rms_username_for_project_existence_check(app, mock_gitlab_oauth):
+    """Regression for the SourceCraft ``SlugIsNotAvailable`` 500 on enrollment.
+
+    ``check_project_exists`` must be called with the RMS-native username (as stored in
+    ``session['rms']['username']``), not the auth-provider login (``session['auth']['username']``).
+    Otherwise, for users whose SC username differs from their Yandex login (e.g. Yandex ``Ps5``
+    -> SC ``ps5-1``), the existence check produces a false negative and the flow redirects to
+    ``create_project``, which 500s trying to re-create the already-existing repo.
+    """
+    CSRFProtect(app)
+    with app.test_request_context():
+        with (
+            app.test_client() as client,
+            patch.object(app.rms_api, "check_project_exists", return_value=False) as mock_check,
+        ):
+            # Simulate divergent identities: auth session has Yandex login, RMS session has SC username.
+            session_data = build_test_session()
+            session_data["rms"]["username"] = "ps5-1"
+            session_data["auth"]["username"] = "Ps5"
+            session_data["manytask"] = {
+                "version": 1.0,
+                "user_id": TEST_USER_ID,
+                "username": "Ps5",  # stored username is auth login
+            }
+            with client.session_transaction() as sess:
+                sess.update(session_data)
+            app.oauth = mock_gitlab_oauth
+
+            client.get(f"/{TEST_COURSE_NAME}/")
+
+            mock_check.assert_called_once()
+            call_kwargs = mock_check.call_args.kwargs
+            assert call_kwargs["project_name"] == "ps5-1", (
+                "Existence check must use the RMS-native username so the slug matches what "
+                "create_project builds; got the auth login instead, which is the reported bug."
+            )
+
+
 def test_signup_get(app):
     CSRFProtect(app)
     with app.test_request_context():
@@ -558,6 +596,34 @@ def test_signup_finish_with_existing_user_in_db(app, mock_gitlab_oauth):
             with client.session_transaction() as sess:
                 assert "version" in sess["rms"]
                 assert sess["rms"]["username"] == TEST_USERNAME
+
+
+def test_signup_finish_existing_user_uses_rms_username_not_auth_login(app, mock_gitlab_oauth):
+    """Regression: on stale-session restoration, ``session['rms']['username']`` must be the
+    RMS-native username (fetched from the RMS API by ``rms_id``), not the auth-provider login.
+
+    On SourceCraft the two can differ (e.g. Yandex login ``Ps5`` vs SC username ``ps5-1`` when
+    the natural slug is taken). Aliasing the auth login here poisons downstream slug lookups
+    such as ``check_project_exists`` and eventually surfaces as a 500 ``SlugIsNotAvailable``
+    from ``create_project``.
+    """
+    from manytask.abstract import RmsUser as _RmsUser
+    from tests.constants import TEST_RMS_ID as _TEST_RMS_ID
+
+    # Simulate SourceCraft assigning a fallback slug: auth login differs from RMS username.
+    app.rms_api.users[_TEST_RMS_ID] = _RmsUser(id=_TEST_RMS_ID, username="ps5-1", name="Test User")
+
+    with app.test_request_context():
+        with app.test_client() as client:
+            set_session(client, build_test_session(include_rms=False))
+            app.oauth = mock_gitlab_oauth
+            response = client.post(url_for("root.signup_finish"))
+            assert response.status_code == HTTPStatus.FOUND
+
+            with client.session_transaction() as sess:
+                # RMS-native username was fetched from the API, not aliased from auth session.
+                assert sess["rms"]["username"] == "ps5-1"
+                assert sess["auth"]["username"] == TEST_USERNAME  # sanity: auth login unchanged
 
 
 def test_signup_finish_with_new_user_in_db(app, mock_gitlab_oauth):


### PR DESCRIPTION
Enrolling in a course on a SourceCraft-backed manytask instance 500s with
SlugIsNotAvailable for any user whose auth-provider (Yandex) login differs
from their SourceCraft username. Prod log excerpt (user Ps5 whose SC
username is ps5-1):

    sourcecraft.py:246 Project ami-python-basic-st-26f-Ps5 not found
    auth.py:260 User Ps5 missing membership or project
    [user clicks Create Project]
    sourcecraft.py:280 Creating repo for user ps5-1
    POST orgs/hsemanytask/repos -> 400 SlugIsNotAvailable

Root cause: two operations on the same resource used two different
"username" sources.

* auth.py:257 called `check_project_exists(project_name=auth_user.username,
  ...)` -- the Yandex login. Slug: ami-python-basic-st-26f-ps5.
* web.py:377 called `create_project(rms_user, ...)` where
  sourcecraft.py:282 builds the slug from `rms_user.username` -- the SC
  username. Slug: ami-python-basic-st-26f-ps5-1.

On SourceCraft the two identifiers can legitimately differ: when the
natural slug is taken, the platform assigns a fallback like `ps5-1`.
The existence check thus produced a false negative on repeat visits,
redirected the user to /create_project, and the create call 500'd trying
to re-create the already-existing repo.

Fix (unify slug source to the RMS-native username):

* auth.py: pass `session["rms"]["username"]` (the SC username, populated
  from `rms_user.username` in signup_finish) to `check_project_exists`
  instead of `auth_user.username`.
* web.py: in the stale-session restoration branch of signup_finish,
  resolve the RMS-native username from the RMS API via
  `get_rms_user_by_id` instead of aliasing the auth login into the RMS
  session. On failure fall back to the auth login and log a warning.
* sourcecraft.py: clarify docstring on `check_project_exists` that
  `project_name` must be the RMS-native `RmsUser.username`.

Tests: new tests/test_sourcecraft.py unit-tests the slug construction
contract of SourceCraftApi (existence check + create derive from the
same source). New regression tests in tests/test_web.py exercise both
call-site fixes with divergent auth/RMS usernames.

Backwards-compatible: no interface changes, GitLab backend unaffected
(GitLab usernames coincide with the auth login in practice), no new
dependencies.


