### PR TITLE
feat(gitlab): grant students reporter access to the course public repo

### DIFF
--- a/manytask/manytask/glab.py
+++ b/manytask/manytask/glab.py
@@ -547,6 +547,17 @@ class GitLabApi(RmsApi, AuthApi):
         except gitlab.GitlabCreateError:
             logger.warning("Access already granted or conflict on forked project user=%s", rms_user.username)
 
+        try:
+            member = course_public_project.members.create(
+                {
+                    "user_id": _validate_and_convert_user_id(rms_user.id),
+                    "access_level": gitlab.const.AccessLevel.REPORTER,
+                }
+            )
+            logger.info("Access granted for course public project user=%s", member.username)
+        except gitlab.GitlabCreateError:
+            logger.warning("Access already granted or conflict on course public project user=%s", rms_user.username)
+
     def _construct_rms_user(
         self,
         user: dict[str, Any],

--- a/manytask/tests/test_glab.py
+++ b/manytask/tests/test_glab.py
@@ -325,6 +325,9 @@ def test_create_project_no_existing_project_creates_fork(
     mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=mock_rms_user.username)
     rms_api._get_project_by_name.assert_called_with(TEST_GROUP_PUBLIC_NAME)
     rms_api._get_group_by_name.assert_called_with(TEST_GROUP_STUDENT_NAME)
+    mock_gitlab_student_project.members.create.assert_called_once_with(
+        {"user_id": int(mock_rms_user.id), "access_level": const.AccessLevel.REPORTER}
+    )
 
 
 def test_construct_rms_user(gitlab, mock_rms_user):


### PR DESCRIPTION
On instances where the course public repo lives in a private GitLab, students otherwise have no access to it once their personal fork is created. Explicit REPORTER membership on the public project lets them read task statements and the shared CI config referenced via ci_config_path. The grant is idempotent: a GitlabCreateError (already a member) is swallowed, mirroring the neighboring DEVELOPER grant on the forked project.