### PR TITLE
feat: allow disabling self-signup via MANYTASK_DISABLE_SIGNUP

### DIFF
--- a/manytask/manytask/local_config.py
+++ b/manytask/manytask/local_config.py
@@ -30,6 +30,8 @@ class LocalConfig:
     yandex_id_client_secret: str
     yandex_id_oauth_base: str
 
+    disable_signup: bool
+
     @classmethod
     def from_env(cls) -> LocalConfig:
         gitlab_url = os.environ.get("GITLAB_URL", "https://gitlab.manytask2.org")
@@ -53,6 +55,7 @@ class LocalConfig:
             yandex_id_client_id=os.environ.get("YANDEX_ID_CLIENT_ID", ""),
             yandex_id_client_secret=os.environ.get("YANDEX_ID_CLIENT_SECRET", ""),
             yandex_id_oauth_base=os.environ.get("YANDEX_ID_OAUTH_BASE", "https://oauth.yandex.com"),
+            disable_signup=os.environ.get("MANYTASK_DISABLE_SIGNUP", "false").lower() in ("true", "1", "yes"),
         )
 
 
@@ -80,6 +83,8 @@ class DebugLocalConfig(LocalConfig):
     yandex_id_client_id: str = ""
     yandex_id_client_secret: str = ""
     yandex_id_oauth_base: str = "https://oauth.yandex.com"
+
+    disable_signup: bool = False
 
     show_allscores: bool = True
 

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -180,6 +180,9 @@ def course_page(course_name: str) -> ResponseReturnValue:
 def signup() -> ResponseReturnValue:
     app: CustomFlask = current_app  # type: ignore
 
+    if app.app_config.disable_signup:
+        return redirect(url_for("root.login"))
+
     # ---- render page ---- #
     if request.method == "GET":
         return render_template(

--- a/manytask/tests/test_web.py
+++ b/manytask/tests/test_web.py
@@ -225,6 +225,15 @@ def test_signup_get(app):
         assert response.status_code == HTTPStatus.OK
 
 
+def test_signup_get_disabled_redirects_to_login(app):
+    CSRFProtect(app)
+    app.app_config.disable_signup = True
+    with app.test_request_context():
+        response = app.test_client().get("/signup")
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.location == url_for("root.login")
+
+
 def test_signup_post_password_mismatch(app, mock_course):
     CSRFProtect(app)
     with app.test_client() as client:


### PR DESCRIPTION
Instances that provision accounts through an external process (bots, whitelists, SSO) need a way to prevent self-signup, since it currently creates users directly in GitLab. Adding MANYTASK_DISABLE_SIGNUP redirects GET/POST /signup to the login page when set.