### PR TITLE
draft: feat: store submission history and recalculate scores on config update

### DIFF
--- a/checker/checker/configs/checker.py
+++ b/checker/checker/configs/checker.py
@@ -113,6 +113,8 @@ class CheckerTestingConfig(CustomBaseModel):
 
     search_plugins: list[str] = Field(default_factory=list)
 
+    report_on_failure: bool = False
+
     global_pipeline: list[PipelineStageConfig] = Field(default_factory=list)
     tasks_pipeline: list[PipelineStageConfig] = Field(default_factory=list)
     report_pipeline: list[PipelineStageConfig] = Field(default_factory=list)

--- a/checker/checker/plugins/manytask.py
+++ b/checker/checker/plugins/manytask.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import IO, Any, Optional
@@ -57,6 +58,14 @@ class ManytaskPlugin(PluginABC):
             "allow_reduction": args.allow_reduction,
             "submit_time": send_time_formatted,
         }
+
+        commit_sha = os.environ.get("CI_COMMIT_SHA")
+        if commit_sha:
+            data["commit_sha"] = commit_sha
+
+        job_id = os.environ.get("CI_JOB_ID")
+        if job_id:
+            data["job_id"] = job_id
 
         files = None
         if args.origin is not None:

--- a/checker/checker/tester.py
+++ b/checker/checker/tester.py
@@ -248,10 +248,18 @@ class Tester:
             print_info(str(task_pipeline_result), color="pink")
             print_separator("-")
 
-            # Report score if task pipeline succeeded
-            if task_pipeline_result:
+            if not task_pipeline_result:
+                failed_tasks.append(task.name)
+
+            if task_pipeline_result or self.testing_config.report_on_failure:
                 report_pipeline = self._get_task_report_pipeline_runner(task)
-                print_info(f"Reporting <{task.name}> task tests:", color="pink")
+                if task_pipeline_result:
+                    print_info(f"Reporting <{task.name}> task tests:", color="pink")
+                else:
+                    print_info(
+                        f"Reporting <{task.name}> task tests (task failed, report_on_failure enabled):",
+                        color="pink",
+                    )
                 if report:
                     task_report_result: PipelineResult = report_pipeline.run(context, dry_run=self.dry_run)
                     if task_report_result:
@@ -263,11 +271,9 @@ class Tester:
                     _: PipelineResult = report_pipeline.run(context, dry_run=True)
                     print_info("->Reporting disabled (dry-run)")
                 print_separator("-")
-            else:
-                failed_tasks.append(task.name)
 
         if failed_tasks:
             raise TestingError(f"Task pipelines failed: {failed_tasks}")
 
         if failed_reports:
-            raise TestingError(f"Reporting score failed for: {failed_tasks}")
+            raise TestingError(f"Reporting score failed for: {failed_reports}")

--- a/checker/tests/test_tester.py
+++ b/checker/tests/test_tester.py
@@ -1,5 +1,6 @@
 import typing
 from datetime import datetime
+from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -12,7 +13,8 @@ from checker.configs.checker import (
     PipelineStageConfig,
 )
 from checker.course import FileSystemTask
-from checker.pipeline import ParametersResolver
+from checker.exceptions import TestingError
+from checker.pipeline import ParametersResolver, PipelineResult
 from checker.tester import Tester
 
 # Test constants
@@ -68,8 +70,8 @@ class CourseMock:
 
 
 class CheckerConfigMock:
-    def __init__(self):
-        pass
+    def __init__(self, testing_config: CheckerTestingConfig | None = None):
+        self._testing_config = testing_config or CheckerTestingConfig()
 
     @property
     def structure(self):
@@ -81,7 +83,7 @@ class CheckerConfigMock:
 
     @property
     def testing(self):
-        return CheckerTestingConfig()
+        return self._testing_config
 
 
 def _get_timestamp(ts: str) -> datetime:
@@ -216,3 +218,41 @@ class TestTester:
             expected = global_pipeline
 
         assert mock_runner.call_args[0][0] == expected
+
+    @typing.no_type_check
+    @pytest.mark.parametrize(
+        "task_pipeline_failed, report_on_failure, report_runner_called",
+        [
+            (True, False, False),
+            (True, True, True),
+            (False, False, True),
+        ],
+    )
+    def test_run_reports_on_failure_flag(self, mocker, task_pipeline_failed, report_on_failure, report_runner_called):
+        mocker.patch("pkgutil.iter_modules", return_value=[])
+        testing_config = CheckerTestingConfig(report_on_failure=report_on_failure)
+        tester = Tester(CourseMock(), CheckerConfigMock(testing_config))
+        mocker.patch.object(tester, "_get_group_config", return_value=None)
+        tester.reference_dir = Path(".")
+        tester.repository_dir = Path(".")
+        tester.default_params = CheckerParametersConfig(root={})
+
+        task_pipeline_runner = mocker.Mock()
+        task_pipeline_runner.run.return_value = PipelineResult(failed=task_pipeline_failed, stage_results=[])
+        mocker.patch.object(tester, "_get_task_pipeline_runner", return_value=task_pipeline_runner)
+
+        report_pipeline_runner = mocker.Mock()
+        report_pipeline_runner.run.return_value = PipelineResult(failed=False, stage_results=[])
+        mocker.patch.object(tester, "_get_task_report_pipeline_runner", return_value=report_pipeline_runner)
+
+        task = FileSystemTask(name="task1_1", relative_path="group1/task1_1", config=CheckerSubConfig(version=1))
+
+        if task_pipeline_failed:
+            with pytest.raises(TestingError, match="task1_1"):
+                tester.run(Path(), tasks=[task])
+        else:
+            tester.run(Path(), tasks=[task])
+
+        assert report_pipeline_runner.run.called == report_runner_called
+        if report_runner_called:
+            assert report_pipeline_runner.run.call_args.kwargs["dry_run"] is False

--- a/docs/checker_yml_reference.md
+++ b/docs/checker_yml_reference.md
@@ -153,6 +153,7 @@ This section controlls how the checker runs tests, the general structure is:
 testing:
   changes_detection: last_commit_changes
   search_plugins: ["tools/plugins"]
+  report_on_failure: false
 
   global_pipeline:
     - ...
@@ -168,9 +169,10 @@ testing:
 |---|---|---|---|---|
 | `changes_detection` | `str` | ➖ | `last_commit_changes` | Strategy for detecting which tasks changed. The full list of options are `branch_name`, `commit_message`, `last_commit_changes`, `files_changed`. See details [below](#changes_detection). |
 | `search_plugins` | `list[str]` | ➖ | `[]` | Paths (relative to repo root) to search for custom plugin Python files. |
+| `report_on_failure` | `bool` | ➖ | `false` | If `true`, `report_pipeline` also runs for tasks whose `tasks_pipeline` failed (failed stages expose `percentage: 0.0` in `outputs`), so failed submissions are reported too. The task is still considered failed. |
 | `global_pipeline` | `list[stage]` | ➖ | `[]` | Pipeline executed **once** per checker run, before any task pipeline. |
 | `tasks_pipeline` | `list[stage]` | ➖ | `[]` | Pipeline executed **once per task**. Can be overridden in `.task.yml`. |
-| `report_pipeline` | `list[stage]` | ➖ | `[]` | Pipeline executed **once per task** only if `tasks_pipeline` succeeded. Can be overridden in `.task.yml`. |
+| `report_pipeline` | `list[stage]` | ➖ | `[]` | Pipeline executed **once per task**, only if `tasks_pipeline` succeeded (unless `report_on_failure` is set). Can be overridden in `.task.yml`. |
 
 ### `changes_detection`
 

--- a/manytask/manytask/abstract.py
+++ b/manytask/manytask/abstract.py
@@ -151,6 +151,20 @@ class StorageApi(ABC):
     def store_score(self, course_name: str, username: str, task_name: str, update_fn: Callable[..., Any]) -> int: ...
 
     @abstractmethod
+    def store_submission(  # noqa: PLR0913
+        self,
+        course_name: str,
+        username: str,
+        task_name: str,
+        raw_score: float,
+        submit_time: datetime,
+        check_deadline: bool,
+        flags: str | None,
+        commit_sha: str | None,
+        job_id: int | None,
+    ) -> None: ...
+
+    @abstractmethod
     def create_course(
         self,
         settings_config: CourseConfig,
@@ -309,6 +323,12 @@ class StorageApi(ABC):
 
     @abstractmethod
     def recalculate_all_grades(self, course_name: str) -> None: ...
+
+    @abstractmethod
+    def recalculate_all_scores(self, course_name: str) -> None: ...
+
+    @abstractmethod
+    def recalculate_grade_score(self, course_name: str, username: str, task_name: str) -> int: ...
 
     @abstractmethod
     def calculate_and_save_grade(

--- a/manytask/manytask/api.py
+++ b/manytask/manytask/api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime
 from http import HTTPStatus
 from typing import Any, Callable, TypeVar
 
@@ -40,8 +40,9 @@ from .config import (
     UpdateUserRoleRequest,
     UserOnNamespaceResponse,
 )
+from .config import parse_flags as _parse_flags
 from pydantic import BaseModel
-from .course import DEFAULT_TIMEZONE, Course, CourseStatus, get_current_time
+from .course import Course, CourseStatus
 from .main import CustomFlask
 from .utils.database import get_database_table_data
 from .utils.generic import (
@@ -248,26 +249,6 @@ def requires_auth_or_token(f: Callable[..., Any]) -> Callable[..., Any]:
     return decorated
 
 
-def _parse_flags(flags: str | None) -> timedelta:
-    flags = flags or ""
-
-    extra_time = timedelta()
-    left_colon = flags.find(":")
-    right_colon = flags.find(":", left_colon + 1)
-    if right_colon > -1 and left_colon > 0:
-        parsed = None
-        date_string = flags[right_colon + 1 :]
-        try:
-            parsed = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=DEFAULT_TIMEZONE)
-        except ValueError:
-            logger.error("Could not parse date from flag %s", flags)
-        if parsed is not None and get_current_time() <= parsed:
-            days = int(flags[left_colon + 1 : right_colon])
-            extra_time = timedelta(days=days)
-            logger.debug("Parsed extra_time=%s from flags=%s", extra_time, flags)
-    return extra_time
-
-
 # ruff: noqa PLR0913
 def _update_score(
     course: Course,
@@ -288,7 +269,7 @@ def _update_score(
         return old_score
 
     if check_deadline:
-        extra_time = _parse_flags(flags)
+        extra_time = _parse_flags(flags, submit_time)
 
         multiplier = group.get_current_percent_multiplier(
             now=submit_time - extra_time,
@@ -409,7 +390,10 @@ def report_score(course_name: str) -> ResponseReturnValue:
     reported_score = _process_score(request.form, task.score)
     if reported_score is None:
         reported_score = task.score
+        raw_score = 1.0
         logger.info("Got score=None; set max score for %s of %s", task.name, task.score)
+    else:
+        raw_score = float(request.form["score"])
 
     check_deadline = True
     if "check_deadline" in request.form:
@@ -418,6 +402,14 @@ def report_score(course_name: str) -> ResponseReturnValue:
     allow_reduction = False
     if "allow_reduction" in request.form:
         allow_reduction = request.form["allow_reduction"] is True or request.form["allow_reduction"] == "True"
+
+    flags = request.form.get("flags")
+    commit_sha = request.form.get("commit_sha")
+    job_id_str = request.form.get("job_id")
+    try:
+        job_id = int(job_id_str) if job_id_str is not None else None
+    except ValueError:
+        job_id = None
 
     submit_time_str = request.form.get("submit_time")
     submit_time = _process_submit_time(submit_time_str, app.storage_api.get_now_with_timezone(course.course_name))
@@ -432,17 +424,32 @@ def report_score(course_name: str) -> ResponseReturnValue:
         f"reported_score={reported_score}, submit_time={submit_time}, check_deadline={check_deadline}"
     )
 
-    update_function = functools.partial(
-        _update_score,
-        course,
-        group,
-        task,
-        reported_score,
-        submit_time=submit_time,
-        check_deadline=check_deadline,
-        allow_reduction=allow_reduction,
+    app.storage_api.store_submission(
+        course.course_name,
+        manytask_username,
+        task.name,
+        raw_score,
+        submit_time,
+        check_deadline,
+        flags,
+        commit_sha,
+        job_id,
     )
-    final_score = app.storage_api.store_score(course.course_name, manytask_username, task.name, update_function)
+
+    if group.run_penalty > 0:
+        final_score = app.storage_api.recalculate_grade_score(course.course_name, manytask_username, task.name)
+    else:
+        update_function = functools.partial(
+            _update_score,
+            course,
+            group,
+            task,
+            reported_score,
+            submit_time=submit_time,
+            check_deadline=check_deadline,
+            allow_reduction=allow_reduction,
+        )
+        final_score = app.storage_api.store_score(course.course_name, manytask_username, task.name, update_function)
 
     logger.info("Stored final_score=%s for user=%s, task=%s", final_score, manytask_username, task.name)
 
@@ -616,7 +623,11 @@ def update_config(course_name: str) -> ResponseReturnValue:
         logger.exception("Error while updating config for course=%s", course_name)
         return f"Invalid config for course={course_name}", HTTPStatus.BAD_REQUEST
 
-    # Recalculate grades for all students using the new config
+    try:
+        app.storage_api.recalculate_all_scores(course_name)
+    except Exception:
+        logger.exception("Failed to recalculate scores after config update for course=%s", course_name)
+
     try:
         app.storage_api.recalculate_all_grades(course_name)
     except Exception:

--- a/manytask/manytask/config.py
+++ b/manytask/manytask/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Literal, Optional, Union
@@ -7,10 +8,32 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pydantic import AnyUrl, BaseModel, Field, field_validator, model_validator
 
-from manytask.course import CourseStatus, ManytaskDeadlinesType
+from manytask.course import DEFAULT_TIMEZONE, CourseStatus, ManytaskDeadlinesType
 from manytask.utils.generic import lerp
 
+logger = logging.getLogger(__name__)
+
 MAX_COURSE_NAME_LENGTH = 100
+
+
+def parse_flags(flags: str | None, submit_time: datetime) -> timedelta:
+    flags = flags or ""
+
+    extra_time = timedelta()
+    left_colon = flags.find(":")
+    right_colon = flags.find(":", left_colon + 1)
+    if right_colon > -1 and left_colon > 0:
+        parsed = None
+        date_string = flags[right_colon + 1 :]
+        try:
+            parsed = datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=DEFAULT_TIMEZONE)
+        except ValueError:
+            logger.error("Could not parse date from flag %s", flags)
+        if parsed is not None and submit_time <= parsed:
+            days = int(flags[left_colon + 1 : right_colon])
+            extra_time = timedelta(days=days)
+            logger.debug("Parsed extra_time=%s from flags=%s", extra_time, flags)
+    return extra_time
 
 
 class RowData(BaseModel):
@@ -201,11 +224,20 @@ class ManytaskGroupConfig(BaseModel):
     steps: dict[float, Union[datetime, timedelta]] = Field(default_factory=dict)
     end: Union[datetime, timedelta]
 
+    run_penalty: int = 0
+
     tasks: list[ManytaskTaskConfig] = Field(default_factory=list)
 
     @property
     def name(self) -> str:
         return self.group
+
+    @field_validator("run_penalty")
+    @classmethod
+    def check_run_penalty(cls, data: int) -> int:
+        if data < 0:
+            raise ValueError("run_penalty should be non-negative")
+        return data
 
     def get_percents_before_deadline(self) -> list[tuple[datetime, float]]:
         return list(zip(map(self.get_deadline, [*self.steps.values(), self.end]), [1.0, *self.steps.keys()]))

--- a/manytask/manytask/database.py
+++ b/manytask/manytask/database.py
@@ -25,9 +25,10 @@ from .config import (
     ManytaskGroupConfig,
     ManytaskTaskConfig,
 )
+from .config import parse_flags as _parse_flags
 from .course import Course as AppCourse
 from .course import CourseConfig as AppCourseConfig
-from .course import CourseStatus
+from .course import CourseStatus, ManytaskDeadlinesType
 from .models import (
     ROLE_NAMESPACE_ADMIN,
     ROLE_PROGRAM_MANAGER,
@@ -89,6 +90,39 @@ def calculate_effective_grade(
     return calculated_grade
 
 
+def _compute_grade_score(
+    submissions: Iterable[models.GradeSubmission],
+    task_score: int,
+    group_config: ManytaskGroupConfig,
+    deadlines_type: ManytaskDeadlinesType,
+) -> int:
+    """Compute a grade's score over its non-ignored submissions. Pure function, no DB access.
+
+    Score is the max over non-ignored submissions of int(raw_score * task_score * deadline_multiplier),
+    minus (n_submissions - 1) * group_config.run_penalty when run_penalty is set, floored at 0.
+    Returns 0 when there are no non-ignored submissions.
+    """
+    non_ignored = [submission for submission in submissions if not submission.ignored]
+    if not non_ignored:
+        return 0
+
+    submission_scores = []
+    for submission in non_ignored:
+        if submission.check_deadline:
+            multiplier = group_config.get_current_percent_multiplier(
+                now=submission.submit_time - _parse_flags(submission.flags, submission.submit_time),
+                deadlines_type=deadlines_type,
+            )
+        else:
+            multiplier = 1.0
+        submission_scores.append(int(submission.raw_score * task_score * multiplier))
+
+    score = max(submission_scores)
+    if group_config.run_penalty > 0:
+        score = max(0, score - (len(submission_scores) - 1) * group_config.run_penalty)
+    return score
+
+
 @dataclass
 class DatabaseConfig:
     """Configuration for Database connection and settings."""
@@ -97,6 +131,19 @@ class DatabaseConfig:
     instance_admin_username: str
     apply_migrations: bool = False
     session_factory: Optional[Callable[[], Session]] = None
+
+
+@dataclass
+class SubmissionIgnoreChange:
+    """One grade_submissions row affected by an ignore/unignore operation."""
+
+    course_name: str
+    username: str
+    task_name: str
+    raw_score: float
+    submit_time: datetime
+    ignored_before: bool
+    ignored_after: bool
 
 
 class DataBaseApi(StorageApi):
@@ -611,6 +658,102 @@ class DataBaseApi(StorageApi):
                 logger.error("Failed to update score for '%s' on '%s': %s", username, task_name, str(e))
                 raise
 
+    def store_submission(  # noqa: PLR0913
+        self,
+        course_name: str,
+        username: str,
+        task_name: str,
+        raw_score: float,
+        submit_time: datetime,
+        check_deadline: bool,
+        flags: str | None,
+        commit_sha: str | None,
+        job_id: int | None,
+    ) -> None:
+        """Persist a single submission report for a (student, task) pair.
+
+        :param course_name: course name
+        :param username: user name
+        :param task_name: task name
+        :param raw_score: score ratio as reported by the checker, before scaling
+        :param submit_time: submit time used for deadline multiplier calculation
+        :param check_deadline: whether the deadline multiplier applies to this submission
+        :param flags: raw flags string from the report
+        :param commit_sha: commit sha of the submitted commit, if provided
+        :param job_id: GitLab CI job id that produced this submission, if provided
+        """
+        with self._session_create() as session:
+            try:
+                course = self._get(session, models.Course, name=course_name)
+                user_on_course = self._get_or_create_user_on_course(session, username, course)
+                session.commit()
+
+                try:
+                    task = self._get_task_by_name_and_course_id(session, task_name, course.id)
+                except NoResultFound:
+                    logger.warning("Task '%s' not found in course '%s'", task_name, course_name)
+                    return
+
+                grade = self._get_or_create_sfu_grade(session, user_on_course.id, task.id)
+
+                self._create(
+                    session,
+                    models.GradeSubmission,
+                    grade_id=grade.id,
+                    raw_score=raw_score,
+                    submit_time=submit_time,
+                    check_deadline=check_deadline,
+                    flags=flags,
+                    commit_sha=commit_sha,
+                    job_id=job_id,
+                )
+            except Exception as e:
+                session.rollback()
+                logger.error("Failed to store submission for '%s' on '%s': %s", username, task_name, str(e))
+                raise
+
+    def set_submissions_ignored_by_job_id(self, job_id: int, ignored: bool) -> list[SubmissionIgnoreChange]:
+        """Flip the `ignored` flag on every grade_submissions row reported by a given CI job.
+
+        :param job_id: GitLab CI job id the submissions were reported from
+        :param ignored: new value of the `ignored` flag
+        :return: one SubmissionIgnoreChange per affected row, in no particular order
+        """
+        with self._session_create() as session:
+            submissions = (
+                session.query(models.GradeSubmission)
+                .filter(models.GradeSubmission.job_id == job_id)
+                .options(
+                    joinedload(models.GradeSubmission.grade).joinedload(models.Grade.task),
+                    joinedload(models.GradeSubmission.grade)
+                    .joinedload(models.Grade.user_on_course)
+                    .joinedload(models.UserOnCourse.user),
+                    joinedload(models.GradeSubmission.grade)
+                    .joinedload(models.Grade.user_on_course)
+                    .joinedload(models.UserOnCourse.course),
+                )
+                .all()
+            )
+
+            changes = []
+            for submission in submissions:
+                user_on_course = submission.grade.user_on_course
+                changes.append(
+                    SubmissionIgnoreChange(
+                        course_name=user_on_course.course.name,
+                        username=user_on_course.user.username,
+                        task_name=submission.grade.task.name,
+                        raw_score=submission.raw_score,
+                        submit_time=submission.submit_time,
+                        ignored_before=submission.ignored,
+                        ignored_after=ignored,
+                    )
+                )
+                submission.ignored = ignored
+
+            session.commit()
+            return changes
+
     def get_course(
         self,
         course_name: str,
@@ -771,6 +914,7 @@ class DataBaseApi(StorageApi):
             start=group_deadlines.start,
             steps=cast(dict[float, datetime | timedelta], group_deadlines.steps),
             end=group_deadlines.end,
+            run_penalty=group.run_penalty,
             tasks=[
                 ManytaskTaskConfig(
                     task=group_task.name,
@@ -874,6 +1018,7 @@ class DataBaseApi(StorageApi):
                         start=group.deadline.start,
                         steps=cast(dict[float, datetime | timedelta], group.deadline.steps),
                         end=group.deadline.end,
+                        run_penalty=group.run_penalty,
                         tasks=tasks,
                     )
                 )
@@ -1316,7 +1461,7 @@ class DataBaseApi(StorageApi):
                 task_group = DataBaseApi._update_or_create(
                     session,
                     models.TaskGroup,
-                    defaults={"enabled": group.enabled, "position": group_pos},
+                    defaults={"enabled": group.enabled, "position": group_pos, "run_penalty": group.run_penalty},
                     name=group.name,
                     course_id=course.id,
                 )
@@ -2516,6 +2661,93 @@ class DataBaseApi(StorageApi):
 
         self._batch_update_grades(course_name, grades_to_save)
         logger.info(f"Recalculated all grades for {course_name} ({len(grades_to_save)} students)")
+
+    def recalculate_all_scores(self, course_name: str) -> None:
+        """Recalculate and save task scores from the full submission history.
+
+        Call after changing course config (deadlines, task scores) to make the
+        change apply retroactively. Grades without any recorded submissions
+        are left untouched. Ignored submissions do not count towards the
+        score; a grade whose submissions are all ignored scores 0. Writes the
+        recomputed score directly, without the max(old, new) ratchet used by
+        store_score, so reductions apply too.
+        """
+        with self._session_create() as session:
+            course = self._get(session, models.Course, name=course_name)
+
+            grades = (
+                session.query(models.Grade)
+                .join(models.UserOnCourse, models.Grade.user_on_course_id == models.UserOnCourse.id)
+                .filter(models.UserOnCourse.course_id == course.id)
+                .options(
+                    joinedload(models.Grade.submissions),
+                    joinedload(models.Grade.task).joinedload(models.Task.group).joinedload(models.TaskGroup.deadline),
+                )
+                .all()
+            )
+
+            group_configs: dict[int, ManytaskGroupConfig] = {}
+            updated_count = 0
+
+            for grade in grades:
+                if not grade.submissions:
+                    continue
+
+                task = grade.task
+                task_group = task.group
+                deadline = task_group.deadline
+
+                group_config = group_configs.get(task_group.id)
+                if group_config is None:
+                    group_config = ManytaskGroupConfig(
+                        group=task_group.name,
+                        enabled=task_group.enabled,
+                        start=deadline.start,
+                        steps=cast(dict[float, datetime | timedelta], deadline.steps),
+                        end=deadline.end,
+                        run_penalty=task_group.run_penalty,
+                        tasks=[],
+                    )
+                    group_configs[task_group.id] = group_config
+
+                grade.score = _compute_grade_score(grade.submissions, task.score, group_config, course.deadlines_type)
+                updated_count += 1
+
+            session.commit()
+            logger.info(f"Recalculated scores for {updated_count} grades in {course_name}")
+
+    def recalculate_grade_score(self, course_name: str, username: str, task_name: str) -> int:
+        """Recompute and store one grade's score from its full submission history.
+
+        Used for the live report path when the task's group has run_penalty > 0, where
+        additional attempts must be able to lower the stored score, bypassing the
+        max(old, new) ratchet used by store_score.
+
+        :return: the recomputed and stored score
+        """
+        with self._session_create() as session:
+            course = self._get(session, models.Course, name=course_name)
+            user_on_course = self._get_or_create_user_on_course(session, username, course)
+            session.commit()
+
+            task = self._get_task_by_name_and_course_id(session, task_name, course.id)
+            grade = self._get_or_create_sfu_grade(session, user_on_course.id, task.id)
+
+            task_group = task.group
+            deadline = task_group.deadline
+            group_config = ManytaskGroupConfig(
+                group=task_group.name,
+                enabled=task_group.enabled,
+                start=deadline.start,
+                steps=cast(dict[float, datetime | timedelta], deadline.steps),
+                end=deadline.end,
+                run_penalty=task_group.run_penalty,
+                tasks=[],
+            )
+
+            grade.score = _compute_grade_score(grade.submissions, task.score, group_config, course.deadlines_type)
+            session.commit()
+            return grade.score
 
     def _batch_update_grades(self, course_name: str, grades: dict[str, int]) -> None:
         """Batch update final_grade for multiple students in a single transaction.

--- a/manytask/manytask/database.py
+++ b/manytask/manytask/database.py
@@ -90,6 +90,9 @@ def calculate_effective_grade(
     return calculated_grade
 
 
+_PASSING_RAW_SCORE = 1.0
+
+
 def _compute_grade_score(
     submissions: Iterable[models.GradeSubmission],
     task_score: int,
@@ -98,15 +101,18 @@ def _compute_grade_score(
 ) -> int:
     """Compute a grade's score over its non-ignored submissions. Pure function, no DB access.
 
-    Score is the max over non-ignored submissions of int(raw_score * task_score * deadline_multiplier),
-    minus (n_submissions - 1) * group_config.run_penalty when run_penalty is set, floored at 0.
-    Returns 0 when there are no non-ignored submissions.
+    Max over submissions of their deadline-adjusted score minus run_penalty for each
+    unsuccessful submission before it, floored at 0.
     """
-    non_ignored = [submission for submission in submissions if not submission.ignored]
+    non_ignored = sorted(
+        (submission for submission in submissions if not submission.ignored),
+        key=lambda submission: (submission.submit_time, submission.id),
+    )
     if not non_ignored:
         return 0
 
-    submission_scores = []
+    best = 0
+    prior_failures = 0
     for submission in non_ignored:
         if submission.check_deadline:
             multiplier = group_config.get_current_percent_multiplier(
@@ -115,12 +121,14 @@ def _compute_grade_score(
             )
         else:
             multiplier = 1.0
-        submission_scores.append(int(submission.raw_score * task_score * multiplier))
+        submission_score = int(submission.raw_score * task_score * multiplier)
+        effective_score = submission_score - prior_failures * group_config.run_penalty
+        best = max(best, effective_score)
 
-    score = max(submission_scores)
-    if group_config.run_penalty > 0:
-        score = max(0, score - (len(submission_scores) - 1) * group_config.run_penalty)
-    return score
+        if submission.raw_score < _PASSING_RAW_SCORE:
+            prior_failures += 1
+
+    return max(0, best)
 
 
 @dataclass

--- a/manytask/manytask/migrations/versions/b7d4f9a3e610_add_run_penalty_to_task_groups.py
+++ b/manytask/manytask/migrations/versions/b7d4f9a3e610_add_run_penalty_to_task_groups.py
@@ -1,0 +1,26 @@
+"""Add run_penalty to task_groups
+
+Revision ID: b7d4f9a3e610
+Revises: f4a6c1d0b2e7
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7d4f9a3e610'
+down_revision: Union[str, None] = 'f4a6c1d0b2e7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('task_groups', sa.Column('run_penalty', sa.Integer(), server_default='0', nullable=False))
+
+
+def downgrade() -> None:
+    op.drop_column('task_groups', 'run_penalty')

--- a/manytask/manytask/migrations/versions/f4a6c1d0b2e7_add_grade_submissions.py
+++ b/manytask/manytask/migrations/versions/f4a6c1d0b2e7_add_grade_submissions.py
@@ -1,0 +1,43 @@
+"""Add grade_submissions table
+
+Revision ID: f4a6c1d0b2e7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-08-31 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f4a6c1d0b2e7'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('grade_submissions',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('grade_id', sa.Integer(), nullable=False),
+    sa.Column('raw_score', sa.Float(), nullable=False),
+    sa.Column('submit_time', sa.DateTime(timezone=True), nullable=False),
+    sa.Column('check_deadline', sa.Boolean(), nullable=False),
+    sa.Column('flags', sa.String(), nullable=True),
+    sa.Column('commit_sha', sa.String(length=64), nullable=True),
+    sa.Column('job_id', sa.BigInteger(), nullable=True),
+    sa.Column('ignored', sa.Boolean(), server_default=sa.text('false'), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['grade_id'], ['grades.id'], name=op.f('fk_grade_submissions_grade_id_grades'), ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id', name=op.f('pk_grade_submissions'))
+    )
+    op.create_index(op.f('ix_grade_submissions_grade_id'), 'grade_submissions', ['grade_id'], unique=False)
+    op.create_index(op.f('ix_grade_submissions_job_id'), 'grade_submissions', ['job_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_grade_submissions_job_id'), table_name='grade_submissions')
+    op.drop_index(op.f('ix_grade_submissions_grade_id'), table_name='grade_submissions')
+    op.drop_table('grade_submissions')

--- a/manytask/manytask/models.py
+++ b/manytask/manytask/models.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 from typing import List, Optional
 
-from sqlalchemy import JSON, BigInteger, DateTime, Enum, ForeignKey, MetaData, UniqueConstraint, func
+from sqlalchemy import JSON, BigInteger, DateTime, Enum, ForeignKey, MetaData, String, UniqueConstraint, func
 from sqlalchemy.engine import Dialect
 from sqlalchemy.orm import DeclarativeBase, DynamicMapped, Mapped, mapped_column, relationship, validates
 from sqlalchemy.types import TypeDecorator
@@ -324,6 +324,7 @@ class TaskGroup(Base):
     deadline_id: Mapped[Optional[int]] = mapped_column(ForeignKey(Deadline.id))
     enabled: Mapped[bool] = mapped_column(server_default="true", default=True)
     position: Mapped[int] = mapped_column(server_default="0", default=0)  # order number
+    run_penalty: Mapped[int] = mapped_column(server_default="0", default=0)
 
     # relationships
     course: Mapped["Course"] = relationship(back_populates="task_groups")
@@ -370,6 +371,25 @@ class Grade(Base):
     # relationships
     user_on_course: Mapped["UserOnCourse"] = relationship(back_populates="grades")
     task: Mapped["Task"] = relationship(back_populates="grades")
+    submissions: Mapped[List["GradeSubmission"]] = relationship(back_populates="grade", cascade="all, delete-orphan")
+
+
+class GradeSubmission(Base):
+    __tablename__ = "grade_submissions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    grade_id: Mapped[int] = mapped_column(ForeignKey(Grade.id, ondelete="CASCADE"), index=True)
+    raw_score: Mapped[float]
+    submit_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    check_deadline: Mapped[bool]
+    flags: Mapped[Optional[str]]
+    commit_sha: Mapped[Optional[str]] = mapped_column(String(64))
+    job_id: Mapped[Optional[int]] = mapped_column(BigInteger, index=True)
+    ignored: Mapped[bool] = mapped_column(default=False, server_default="false")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    # relationships
+    grade: Mapped["Grade"] = relationship(back_populates="submissions")
 
 
 class ComplexFormula(Base):

--- a/manytask/manytask/scripts/ignore_submission.py
+++ b/manytask/manytask/scripts/ignore_submission.py
@@ -1,0 +1,67 @@
+"""Mark or unmark grade_submissions rows as ignored by GitLab CI job id.
+
+Usage: python -m manytask.scripts.ignore_submission <job_id> [--unignore]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from manytask.database import DataBaseApi, DatabaseConfig, SubmissionIgnoreChange
+
+
+def build_db_api() -> DataBaseApi:
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url is None:
+        raise EnvironmentError("Unable to find DATABASE_URL env")
+
+    instance_admin_username = os.environ.get("INITIAL_INSTANCE_ADMIN", "admin")
+    return DataBaseApi(
+        DatabaseConfig(
+            database_url=database_url,
+            instance_admin_username=instance_admin_username,
+        )
+    )
+
+
+def ignore_submissions_by_job_id(db_api: DataBaseApi, job_id: int, ignored: bool) -> list[SubmissionIgnoreChange]:
+    changes = db_api.set_submissions_ignored_by_job_id(job_id, ignored)
+
+    for course_name in {change.course_name for change in changes}:
+        db_api.recalculate_all_scores(course_name)
+
+    return changes
+
+
+def _print_change(change: SubmissionIgnoreChange) -> None:
+    print(
+        f"{change.course_name} {change.username} {change.task_name} "
+        f"raw_score={change.raw_score} submit_time={change.submit_time} "
+        f"ignored: {change.ignored_before} -> {change.ignored_after}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("job_id", type=int, help="GitLab CI job id whose submissions should be (un)ignored")
+    parser.add_argument(
+        "--unignore", action="store_true", help="Unmark the matching submissions as ignored instead of marking them"
+    )
+    args = parser.parse_args(argv)
+
+    db_api = build_db_api()
+    changes = ignore_submissions_by_job_id(db_api, args.job_id, not args.unignore)
+
+    if not changes:
+        print(f"No grade_submissions found with job_id={args.job_id}")
+        return 1
+
+    for change in changes:
+        _print_change(change)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -14,7 +14,13 @@ from werkzeug.exceptions import HTTPException
 from manytask.abstract import RmsUser
 from manytask.api import _parse_flags, _process_score, _update_score, _validate_and_extract_params
 from manytask.api import bp as api_bp
-from manytask.config import ManytaskConfig, ManytaskDeadlinesType, ManytaskGroupConfig, ManytaskTaskConfig
+from manytask.config import (
+    DEFAULT_TIMEZONE,
+    ManytaskConfig,
+    ManytaskDeadlinesType,
+    ManytaskGroupConfig,
+    ManytaskTaskConfig,
+)
 from manytask.database import DataBaseApi
 from manytask.mock_auth import MockAuthApi
 from manytask.mock_rms import MockRmsApi
@@ -82,6 +88,7 @@ def mock_group(mock_task):
         def __init__(self):
             self.name = TEST_TASK_GROUP_NAME
             self.tasks = [mock_task]
+            self.run_penalty = 0
 
         @staticmethod
         def get_current_percent_multiplier(now, deadlines_type):
@@ -100,12 +107,38 @@ def mock_storage_api(mock_course, mock_task, mock_group):  # noqa: C901
             super().__init__()
             self.scores = {}
             self.non_admin_users: set[str] = set()
+            self.submissions: list[dict] = []
 
         def store_score(self, _course_name, username, task_name, update_fn):
             old_score = self.scores.get(f"{username}_{task_name}", 0)
             new_score = update_fn("", old_score)
             self.scores[f"{username}_{task_name}"] = new_score
             return new_score
+
+        def store_submission(  # noqa: PLR0913
+            self,
+            _course_name,
+            username,
+            task_name,
+            raw_score,
+            submit_time,
+            check_deadline,
+            flags,
+            commit_sha,
+            job_id,
+        ):
+            self.submissions.append(
+                {
+                    "username": username,
+                    "task_name": task_name,
+                    "raw_score": raw_score,
+                    "submit_time": submit_time,
+                    "check_deadline": check_deadline,
+                    "flags": flags,
+                    "commit_sha": commit_sha,
+                    "job_id": job_id,
+                }
+            )
 
         @staticmethod
         def get_scores(_course_name, _username):
@@ -192,6 +225,15 @@ def mock_storage_api(mock_course, mock_task, mock_group):  # noqa: C901
             raise_for_invalid_task(task_name)
             return mock_course, mock_group, mock_task
 
+        def recalculate_grade_score(self, _course_name, username, task_name):
+            submissions = [s for s in self.submissions if s["username"] == username and s["task_name"] == task_name]
+            submission_scores = [int(s["raw_score"] * mock_task.score) for s in submissions]
+            score = max(submission_scores)
+            if mock_group.run_penalty > 0:
+                score = max(0, score - (len(submission_scores) - 1) * mock_group.run_penalty)
+            self.scores[f"{username}_{task_name}"] = score
+            return score
+
         def get_groups(self, _course_name, enabled=None, started=None, now=None):
             groups = getattr(self, "groups_override", None)
             if groups is None:
@@ -247,20 +289,30 @@ def authenticated_client(app, mock_gitlab_oauth):
 
 
 def test_parse_flags_no_flags():
-    assert _parse_flags(None) == timedelta()
-    assert _parse_flags("") == timedelta()
+    now = datetime.now(DEFAULT_TIMEZONE)
+    assert _parse_flags(None, now) == timedelta()
+    assert _parse_flags("", now) == timedelta()
 
 
 def test_parse_flags_valid():
-    future_date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
+    submit_time = datetime.now(DEFAULT_TIMEZONE)
+    future_date = (submit_time + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
     flags = f"flag:3:{future_date}"
-    assert _parse_flags(flags) == timedelta(days=3)
+    assert _parse_flags(flags, submit_time) == timedelta(days=3)
 
 
 def test_parse_flags_past_date():
-    past_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
+    submit_time = datetime.now(DEFAULT_TIMEZONE)
+    past_date = (submit_time - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
     flags = f"flag:3:{past_date}"
-    assert _parse_flags(flags) == timedelta()
+    assert _parse_flags(flags, submit_time) == timedelta()
+
+
+def test_parse_flags_valid_relative_to_submit_time_not_now():
+    submit_time = datetime.now(DEFAULT_TIMEZONE) - timedelta(days=30)
+    flag_valid_until = (submit_time + timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%S")
+    flags = f"flag:3:{flag_valid_until}"
+    assert _parse_flags(flags, submit_time) == timedelta(days=3)
 
 
 def test_update_score_basic(app):
@@ -440,6 +492,67 @@ def test_report_score_success(app):
         assert data["score"] == expected_data["score"]
 
 
+def test_report_score_records_submission_with_commit_sha(app):
+    rms_user = app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
+    app.storage_api.stored_user.rms_id = rms_user.id
+    with app.test_request_context():
+        data = {
+            "task": TEST_TASK_NAME,
+            "user_id": rms_user.id,
+            "score": "0.9",
+            "check_deadline": "True",
+            "commit_sha": "abc123",
+        }
+        headers = {"Authorization": f"Bearer {os.environ['MANYTASK_COURSE_TOKEN']}"}
+
+        response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/report", data=data, headers=headers)
+        assert response.status_code == HTTPStatus.OK
+
+    assert len(app.storage_api.submissions) == 1
+    submission = app.storage_api.submissions[0]
+    assert submission["username"] == TEST_USERNAME
+    assert submission["task_name"] == TEST_TASK_NAME
+    assert submission["raw_score"] == pytest.approx(0.9)
+    assert submission["commit_sha"] == "abc123"
+
+
+def test_report_score_without_commit_sha(app):
+    rms_user = app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
+    app.storage_api.stored_user.rms_id = rms_user.id
+    with app.test_request_context():
+        data = {
+            "task": TEST_TASK_NAME,
+            "user_id": rms_user.id,
+            "score": "0.5",
+            "check_deadline": "True",
+        }
+        headers = {"Authorization": f"Bearer {os.environ['MANYTASK_COURSE_TOKEN']}"}
+
+        response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/report", data=data, headers=headers)
+        assert response.status_code == HTTPStatus.OK
+
+    assert len(app.storage_api.submissions) == 1
+    assert app.storage_api.submissions[0]["commit_sha"] is None
+
+
+def test_report_score_twice_keeps_both_submissions(app):
+    rms_user = app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
+    app.storage_api.stored_user.rms_id = rms_user.id
+    headers = {"Authorization": f"Bearer {os.environ['MANYTASK_COURSE_TOKEN']}"}
+    with app.test_request_context():
+        for score in ("0.5", "0.9"):
+            data = {
+                "task": TEST_TASK_NAME,
+                "user_id": rms_user.id,
+                "score": score,
+                "check_deadline": "True",
+            }
+            response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/report", data=data, headers=headers)
+            assert response.status_code == HTTPStatus.OK
+
+    assert [s["raw_score"] for s in app.storage_api.submissions] == [pytest.approx(0.5), pytest.approx(0.9)]
+
+
 def test_report_negative_integer_score(app):
     rms_user = app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
     app.storage_api.stored_user.rms_id = rms_user.id
@@ -458,6 +571,30 @@ def test_report_negative_integer_score(app):
 
         assert response.status_code == HTTPStatus.OK
         assert json.loads(response.data)["score"] == negative_score
+
+
+def test_report_score_with_run_penalty_uses_recalculated_history(app):
+    rms_user = app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
+    app.storage_api.stored_user.rms_id = rms_user.id
+    _, group, task = app.storage_api.find_task(TEST_COURSE_NAME, TEST_TASK_NAME)
+    group.run_penalty = 10
+    headers = {"Authorization": f"Bearer {os.environ['MANYTASK_COURSE_TOKEN']}"}
+
+    with app.test_request_context():
+        for score in ("1.0", "1.0"):
+            data = {
+                "task": TEST_TASK_NAME,
+                "user_id": rms_user.id,
+                "score": score,
+                "check_deadline": "True",
+            }
+            response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/report", data=data, headers=headers)
+            assert response.status_code == HTTPStatus.OK
+
+    # task.score=100, run_penalty=10, 2 submissions (1st free): 100 - 1*10 = 90
+    expected_score = task.score - group.run_penalty
+    assert json.loads(response.data)["score"] == expected_score
+    assert app.storage_api.scores[f"{TEST_USERNAME}_{TEST_TASK_NAME}"] == expected_score
 
 
 def test_get_score_success(app):
@@ -579,7 +716,7 @@ def test_requires_token_missing_token(app):
 
 
 def test_parse_flags_invalid_date(app):
-    result = _parse_flags("flag:2024-13-45T25:99:99")  # Invalid date format
+    result = _parse_flags("flag:2024-13-45T25:99:99", datetime.now())  # Invalid date format
     assert result == timedelta()
 
 

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -227,10 +227,14 @@ def mock_storage_api(mock_course, mock_task, mock_group):  # noqa: C901
 
         def recalculate_grade_score(self, _course_name, username, task_name):
             submissions = [s for s in self.submissions if s["username"] == username and s["task_name"] == task_name]
-            submission_scores = [int(s["raw_score"] * mock_task.score) for s in submissions]
-            score = max(submission_scores)
-            if mock_group.run_penalty > 0:
-                score = max(0, score - (len(submission_scores) - 1) * mock_group.run_penalty)
+            best = 0
+            prior_failures = 0
+            for s in submissions:
+                submission_score = int(s["raw_score"] * mock_task.score)
+                best = max(best, submission_score - prior_failures * mock_group.run_penalty)
+                if s["raw_score"] < 1.0:
+                    prior_failures += 1
+            score = max(0, best)
             self.scores[f"{username}_{task_name}"] = score
             return score
 
@@ -581,7 +585,7 @@ def test_report_score_with_run_penalty_uses_recalculated_history(app):
     headers = {"Authorization": f"Bearer {os.environ['MANYTASK_COURSE_TOKEN']}"}
 
     with app.test_request_context():
-        for score in ("1.0", "1.0"):
+        for score in ("0.0", "1.0"):
             data = {
                 "task": TEST_TASK_NAME,
                 "user_id": rms_user.id,
@@ -591,7 +595,6 @@ def test_report_score_with_run_penalty_uses_recalculated_history(app):
             response = app.test_client().post(f"/api/{TEST_COURSE_NAME}/report", data=data, headers=headers)
             assert response.status_code == HTTPStatus.OK
 
-    # task.score=100, run_penalty=10, 2 submissions (1st free): 100 - 1*10 = 90
     expected_score = task.score - group.run_penalty
     assert json.loads(response.data)["score"] == expected_score
     assert app.storage_api.scores[f"{TEST_USERNAME}_{TEST_TASK_NAME}"] == expected_score

--- a/manytask/tests/test_db_api.py
+++ b/manytask/tests/test_db_api.py
@@ -10,6 +10,7 @@ import yaml
 from alembic import command
 from alembic.script import ScriptDirectory
 from psycopg2.errors import DuplicateColumn, DuplicateTable, UndefinedTable, UniqueViolation
+from pydantic import ValidationError
 from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError, NoResultFound, ProgrammingError
 from sqlalchemy.orm import Session
@@ -29,6 +30,7 @@ from manytask.models import (
     Course,
     Deadline,
     Grade,
+    GradeSubmission,
     Namespace,
     Task,
     TaskGroup,
@@ -37,6 +39,7 @@ from manytask.models import (
     UserOnNamespace,
     UserOnNamespaceRole,
 )
+from manytask.scripts.ignore_submission import ignore_submissions_by_job_id
 from tests.constants import (
     BONUS_GROUP,
     BONUS_SCORE,
@@ -69,6 +72,8 @@ from tests.constants import (
     TEST_USERNAME_2,
     USER_EXPECTED,
 )
+
+TEST_JOB_ID = 12345
 
 
 class TestException(Exception):
@@ -1251,6 +1256,344 @@ def test_store_score_update_error(db_api_with_two_initialized_courses, session):
     assert "Update failed" in str(exc_info.value)
 
     assert session.query(Grade).count() == 0
+
+
+def test_store_submission_creates_row(db_api_with_initialized_first_course, session):
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    submit_time = datetime(2000, 2, 1, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(
+        FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.8, submit_time, True, "some_flags", "sha1", TEST_JOB_ID
+    )
+
+    submissions = session.query(GradeSubmission).all()
+    assert len(submissions) == 1
+
+    submission = submissions[0]
+    assert submission.raw_score == pytest.approx(0.8)
+    assert submission.submit_time == submit_time
+    assert submission.check_deadline is True
+    assert submission.flags == "some_flags"
+    assert submission.commit_sha == "sha1"
+    assert submission.job_id == TEST_JOB_ID
+    assert submission.ignored is False
+
+    grade = session.query(Grade).one()
+    assert submission.grade_id == grade.id
+    assert grade.score == 0
+
+
+def test_store_submission_keeps_all_rows(db_api_with_initialized_first_course, session):
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    submit_time = datetime(2000, 2, 1, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.5, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.9, submit_time, True, None, None, None)
+
+    submissions = session.query(GradeSubmission).order_by(GradeSubmission.id).all()
+    assert [s.raw_score for s in submissions] == [pytest.approx(0.5), pytest.approx(0.9)]
+    assert len({s.grade_id for s in submissions}) == 1
+
+
+def test_group_config_run_penalty_defaults_to_zero(first_course_deadlines_config):
+    assert first_course_deadlines_config.schedule[0].run_penalty == 0
+
+
+def test_group_config_run_penalty_rejects_negative():
+    with pytest.raises(ValidationError):
+        ManytaskGroupConfig(
+            group="group_0",
+            start=datetime(2000, 1, 1, tzinfo=ZoneInfo("UTC")),
+            end=datetime(2000, 2, 1, tzinfo=ZoneInfo("UTC")),
+            run_penalty=-1,
+        )
+
+
+def test_recalculate_all_scores_applies_run_penalty(db_api_with_initialized_first_course, first_course_config, session):
+    task_0_0_full_score = 10
+    run_penalty = 3
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    def set_group_0_run_penalty(penalty):
+        deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+        deadlines_data["schedule"][0]["run_penalty"] = penalty
+        update_course(
+            db_api,
+            FIRST_COURSE_NAME,
+            ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+            ManytaskDeadlinesConfig(**deadlines_data),
+        )
+
+    def task_0_0_score():
+        return session.query(Grade).join(Task).filter(Task.name == "task_0_0").one().score
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    set_group_0_run_penalty(run_penalty)
+
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_full_score  # first submission is free
+
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_full_score - run_penalty
+
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_full_score - 2 * run_penalty
+
+
+def test_recalculate_all_scores_clamps_run_penalty_at_zero(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+    deadlines_data["schedule"][0]["run_penalty"] = 100
+    update_course(
+        db_api,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+        ManytaskDeadlinesConfig(**deadlines_data),
+    )
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    for _ in range(5):
+        db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == 0
+
+
+def test_recalculate_all_scores_zero_run_penalty_keeps_previous_behavior(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    task_0_0_full_score = 10
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.5, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.8, submit_time, True, None, None, None)
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == task_0_0_full_score
+
+
+def test_recalculate_grade_score_applies_run_penalty_from_history(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    task_0_0_full_score = 10
+    run_penalty = 4
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+    deadlines_data["schedule"][0]["run_penalty"] = run_penalty
+    update_course(
+        db_api,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+        ManytaskDeadlinesConfig(**deadlines_data),
+    )
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    score = db_api.recalculate_grade_score(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0")
+    assert score == task_0_0_full_score
+
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    score = db_api.recalculate_grade_score(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0")
+    assert score == task_0_0_full_score - run_penalty
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == task_0_0_full_score - run_penalty
+
+
+def test_recalculate_all_scores_applies_deadline_changes(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    task_0_0_full_score = 10
+    task_0_0_half_score = 5
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+
+    def task_0_0_score():
+        return session.query(Grade).join(Task).filter(Task.name == "task_0_0").one().score
+
+    def set_group_0_step(step_date):
+        deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+        deadlines_data["schedule"][0]["steps"] = {0.5: step_date}
+        update_course(
+            db_api,
+            FIRST_COURSE_NAME,
+            ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+            ManytaskDeadlinesConfig(**deadlines_data),
+        )
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_full_score
+
+    set_group_0_step(datetime(2000, 1, 15, 18, 0))
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_half_score
+
+    set_group_0_step(datetime(2000, 4, 1, 18, 0))
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_full_score
+
+
+def test_recalculate_all_scores_honors_flag_valid_at_submit_time(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    task_0_0_full_score = 10
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    step_date = datetime(2000, 3, 1, 18, 0)
+    deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+    deadlines_data["schedule"][0]["steps"] = {0.5: step_date}
+    update_course(
+        db_api,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+        ManytaskDeadlinesConfig(**deadlines_data),
+    )
+
+    submit_time = datetime(2000, 3, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    flag_valid_until = "2000-03-20T00:00:00"
+    flags = f"flag:20:{flag_valid_until}"
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, flags, None, None)
+
+    def task_0_0_score():
+        return session.query(Grade).join(Task).filter(Task.name == "task_0_0").one().score
+
+    # Without the fix, the flag's validity is checked against real wall-clock time (long after
+    # this test's year-2000 dates), so the extension is silently dropped and only half score applies.
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_full_score
+
+
+def test_recalculate_all_scores_skips_grades_without_submissions(db_api_with_initialized_first_course, session):
+    manual_score = 7
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    db_api.store_score(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", update_func(manual_score))
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == manual_score
+
+
+def test_recalculate_all_scores_skips_ignored_submissions(db_api_with_initialized_first_course, session):
+    task_0_0_full_score = 10
+    task_0_0_half_score = 5
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    submit_time = datetime(2000, 2, 1, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.5, submit_time, True, None, None, None)
+
+    session.query(GradeSubmission).filter(GradeSubmission.raw_score == 1.0).update({GradeSubmission.ignored: True})
+    session.commit()
+
+    def task_0_0_score():
+        return session.query(Grade).join(Task).filter(Task.name == "task_0_0").one().score
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_half_score
+
+    session.query(GradeSubmission).filter(GradeSubmission.raw_score == 1.0).update({GradeSubmission.ignored: False})
+    session.commit()
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert task_0_0_score() == task_0_0_full_score
+
+
+def test_recalculate_all_scores_all_submissions_ignored_scores_zero(db_api_with_initialized_first_course, session):
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    submit_time = datetime(2000, 2, 1, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+
+    session.query(GradeSubmission).update({GradeSubmission.ignored: True})
+    session.commit()
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == 0
+
+
+def test_ignore_submissions_by_job_id_marks_rows_and_recalculates(db_api_with_initialized_first_course, session):
+    task_full_score = 10
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    submit_time = datetime(2000, 2, 1, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(
+        FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, TEST_JOB_ID
+    )
+    db_api.store_submission(
+        FIRST_COURSE_NAME, TEST_USERNAME, "task_0_1", 1.0, submit_time, True, None, None, TEST_JOB_ID
+    )
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_2", 1.0, submit_time, True, None, None, None)
+
+    def score(task_name):
+        return session.query(Grade).join(Task).filter(Task.name == task_name).one().score
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+    assert score("task_0_0") == task_full_score
+    assert score("task_0_1") == task_full_score
+    assert score("task_0_2") == task_full_score
+
+    changes = ignore_submissions_by_job_id(db_api, TEST_JOB_ID, True)
+
+    assert {(c.task_name, c.ignored_before, c.ignored_after) for c in changes} == {
+        ("task_0_0", False, True),
+        ("task_0_1", False, True),
+    }
+    assert all(c.course_name == FIRST_COURSE_NAME and c.username == TEST_USERNAME for c in changes)
+
+    assert score("task_0_0") == 0
+    assert score("task_0_1") == 0
+    assert score("task_0_2") == task_full_score
+
+    changes = ignore_submissions_by_job_id(db_api, TEST_JOB_ID, False)
+    assert {(c.task_name, c.ignored_before, c.ignored_after) for c in changes} == {
+        ("task_0_0", True, False),
+        ("task_0_1", True, False),
+    }
+
+    assert score("task_0_0") == task_full_score
+    assert score("task_0_1") == task_full_score
+
+
+def test_ignore_submissions_by_job_id_no_match_returns_empty(db_api_with_initialized_first_course):
+    changes = ignore_submissions_by_job_id(db_api_with_initialized_first_course, 999999, True)
+    assert changes == []
 
 
 def test_get_course_success(db_api_with_two_initialized_courses, first_course_config, second_course_config):

--- a/manytask/tests/test_db_api.py
+++ b/manytask/tests/test_db_api.py
@@ -25,7 +25,7 @@ from manytask.config import (
 )
 from manytask.course import Course as ManytaskCourse
 from manytask.course import CourseConfig, CourseStatus, ManytaskDeadlinesType
-from manytask.database import DataBaseApi, DatabaseConfig, TaskDisabledError
+from manytask.database import DataBaseApi, DatabaseConfig, TaskDisabledError, _compute_grade_score
 from manytask.models import (
     Course,
     Deadline,
@@ -1311,6 +1311,82 @@ def test_group_config_run_penalty_rejects_negative():
         )
 
 
+def _make_submission(id_, raw_score, submit_time, check_deadline=False, ignored=False):
+    return GradeSubmission(
+        id=id_, raw_score=raw_score, submit_time=submit_time, check_deadline=check_deadline, ignored=ignored
+    )
+
+
+def test_compute_grade_score_orders_by_submit_time_not_insertion_order():
+    task_score = 100
+    run_penalty = 10
+    expected_score = 90
+
+    group_config = ManytaskGroupConfig(
+        group="group_0",
+        start=datetime(2000, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end=datetime(2000, 2, 1, tzinfo=ZoneInfo("UTC")),
+        run_penalty=run_penalty,
+    )
+    t0 = datetime(2000, 1, 5, tzinfo=ZoneInfo("UTC"))
+    t1 = datetime(2000, 1, 10, tzinfo=ZoneInfo("UTC"))
+    t2 = datetime(2000, 1, 15, tzinfo=ZoneInfo("UTC"))
+    t3 = datetime(2000, 1, 20, tzinfo=ZoneInfo("UTC"))
+
+    submissions = [
+        _make_submission(4, 1.0, t3),
+        _make_submission(1, 0.0, t0),
+        _make_submission(3, 0.0, t2),
+        _make_submission(2, 1.0, t1),
+    ]
+
+    assert _compute_grade_score(submissions, task_score, group_config, ManytaskDeadlinesType.HARD) == expected_score
+
+
+def test_compute_grade_score_zero_run_penalty_is_plain_max():
+    task_score = 10
+
+    group_config = ManytaskGroupConfig(
+        group="group_0",
+        start=datetime(2000, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end=datetime(2000, 2, 1, tzinfo=ZoneInfo("UTC")),
+        run_penalty=0,
+    )
+    submit_time = datetime(2000, 1, 5, tzinfo=ZoneInfo("UTC"))
+    submissions = [
+        _make_submission(1, 0.5, submit_time),
+        _make_submission(2, 1.0, submit_time),
+        _make_submission(3, 0.8, submit_time),
+    ]
+    assert _compute_grade_score(submissions, task_score, group_config, ManytaskDeadlinesType.HARD) == task_score
+
+
+def test_compute_grade_score_ignores_ignored_submissions():
+    task_score = 100
+
+    group_config = ManytaskGroupConfig(
+        group="group_0",
+        start=datetime(2000, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end=datetime(2000, 2, 1, tzinfo=ZoneInfo("UTC")),
+        run_penalty=10,
+    )
+    submit_time = datetime(2000, 1, 5, tzinfo=ZoneInfo("UTC"))
+    submissions = [
+        _make_submission(1, 0.0, submit_time, ignored=True),
+        _make_submission(2, 1.0, submit_time),
+    ]
+    assert _compute_grade_score(submissions, task_score, group_config, ManytaskDeadlinesType.HARD) == task_score
+
+
+def test_compute_grade_score_no_submissions_returns_zero():
+    group_config = ManytaskGroupConfig(
+        group="group_0",
+        start=datetime(2000, 1, 1, tzinfo=ZoneInfo("UTC")),
+        end=datetime(2000, 2, 1, tzinfo=ZoneInfo("UTC")),
+    )
+    assert _compute_grade_score([], 100, group_config, ManytaskDeadlinesType.HARD) == 0
+
+
 def test_recalculate_all_scores_applies_run_penalty(db_api_with_initialized_first_course, first_course_config, session):
     task_0_0_full_score = 10
     run_penalty = 3
@@ -1334,17 +1410,106 @@ def test_recalculate_all_scores_applies_run_penalty(db_api_with_initialized_firs
     submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
     set_group_0_run_penalty(run_penalty)
 
-    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.0, submit_time, True, None, None, None)
     db_api.recalculate_all_scores(FIRST_COURSE_NAME)
-    assert task_0_0_score() == task_0_0_full_score  # first submission is free
+    assert task_0_0_score() == 0
 
-    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.0, submit_time, True, None, None, None)
     db_api.recalculate_all_scores(FIRST_COURSE_NAME)
-    assert task_0_0_score() == task_0_0_full_score - run_penalty
+    assert task_0_0_score() == 0
 
     db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
     db_api.recalculate_all_scores(FIRST_COURSE_NAME)
     assert task_0_0_score() == task_0_0_full_score - 2 * run_penalty
+
+
+def test_recalculate_all_scores_run_penalty_only_charges_for_failures(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    task_0_0_full_score = 100
+    run_penalty = 10
+    expected_score = 90
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+    deadlines_data["schedule"][0]["run_penalty"] = run_penalty
+    task_index = next(i for i, t in enumerate(deadlines_data["schedule"][0]["tasks"]) if t["task"] == "task_0_0")
+    deadlines_data["schedule"][0]["tasks"][task_index]["score"] = task_0_0_full_score
+    update_course(
+        db_api,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+        ManytaskDeadlinesConfig(**deadlines_data),
+    )
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    for raw_score in (0.0, 1.0, 0.0, 1.0):
+        db_api.store_submission(
+            FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", raw_score, submit_time, True, None, None, None
+        )
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == expected_score
+
+
+def test_recalculate_all_scores_run_penalty_repeated_pass_does_not_reduce_score(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    task_0_0_full_score = 10
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+    deadlines_data["schedule"][0]["run_penalty"] = 3
+    update_course(
+        db_api,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+        ManytaskDeadlinesConfig(**deadlines_data),
+    )
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == task_0_0_full_score
+
+
+def test_recalculate_all_scores_run_penalty_failure_after_success_is_free(
+    db_api_with_initialized_first_course, first_course_config, session
+):
+    task_0_0_full_score = 10
+
+    db_api = db_api_with_initialized_first_course
+    create_user(db_api)
+
+    deadlines_data = _load_yaml(DEADLINES_CONFIG_FILES[0])["deadlines"]
+    deadlines_data["schedule"][0]["run_penalty"] = 3
+    update_course(
+        db_api,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template=first_course_config.task_url_template, links=first_course_config.links),
+        ManytaskDeadlinesConfig(**deadlines_data),
+    )
+
+    submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
+    for raw_score in (1.0, 0.0, 1.0):
+        db_api.store_submission(
+            FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", raw_score, submit_time, True, None, None, None
+        )
+
+    db_api.recalculate_all_scores(FIRST_COURSE_NAME)
+
+    grade = session.query(Grade).join(Task).filter(Task.name == "task_0_0").one()
+    assert grade.score == task_0_0_full_score
 
 
 def test_recalculate_all_scores_clamps_run_penalty_at_zero(
@@ -1364,7 +1529,7 @@ def test_recalculate_all_scores_clamps_run_penalty_at_zero(
 
     submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
     for _ in range(5):
-        db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+        db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.0, submit_time, True, None, None, None)
 
     db_api.recalculate_all_scores(FIRST_COURSE_NAME)
 
@@ -1410,9 +1575,9 @@ def test_recalculate_grade_score_applies_run_penalty_from_history(
     )
 
     submit_time = datetime(2000, 2, 15, 12, 0, tzinfo=ZoneInfo("Europe/Berlin"))
-    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
+    db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 0.0, submit_time, True, None, None, None)
     score = db_api.recalculate_grade_score(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0")
-    assert score == task_0_0_full_score
+    assert score == 0
 
     db_api.store_submission(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0", 1.0, submit_time, True, None, None, None)
     score = db_api.recalculate_grade_score(FIRST_COURSE_NAME, TEST_USERNAME, "task_0_0")


### PR DESCRIPTION
Submissions (raw score, submit time, flags, commit sha) are now persisted per grade; task scores are recomputed from the full history when the course config changes, so deadline/max-score edits apply retroactively; commit_sha is informational (taken from CI_COMMIT_SHA) and enables reviewing the exact submitted commit; groundwork for attempt-count-based scoring.

Внимание! Нельзя переключать во время семестра - старые результаты могут пропасть при наличии новых посылок