### PR TITLE
fix(sourcecraft): resolve RMS user by slug when passport lookup fails

### DIFF
--- a/manytask/manytask/sourcecraft.py
+++ b/manytask/manytask/sourcecraft.py
@@ -348,8 +348,12 @@ class SourceCraftApi(RmsApi):
         self,
         username: str,
     ) -> RmsUser:
-        # NOTE: yandex login is expected as username for now
-        return self._get_user_by_yandex_login(username)
+        try:
+            return self._get_user_by_yandex_login(username)
+        except RmsApiException:
+            user_slug = normalize_string(username)
+            logger.info(f"No yandex login {username}, looking up the user in SourceCraft by slug {user_slug}")
+            return self._get_user_profile(user_slug)
 
     def _get_user_by_yandex_login(self, auth_username: str) -> RmsUser:
         cloud_id = self._get_cloud_id_by_yandex_login(auth_username)
@@ -366,7 +370,7 @@ class SourceCraftApi(RmsApi):
     def _get_user_profile(self, identity: str) -> RmsUser:
         response = self._request("GET", f"users/{identity}")
         if response.status_code != HTTPStatus.OK:
-            raise RmsApiException(f"Failed to get cloud id by yandex login: {response.json()}")
+            raise RmsApiException(f"Failed to get user profile by identity {identity}: {response.json()}")
         return self._unmarshal_user_profile(response.json())
 
     def _unmarshal_user_profile(self, data: dict[str, Any]) -> RmsUser:

--- a/manytask/tests/test_sourcecraft.py
+++ b/manytask/tests/test_sourcecraft.py
@@ -23,6 +23,8 @@ TEST_PUBLIC_REPO = "public-2026-fall"
 YANDEX_LOGIN = "Ps5"
 SOURCECRAFT_USERNAME = "ps5-1"
 TEST_RMS_ID = "rms-uuid-1"
+DOMAIN_LOGIN = "anna@example.org"
+DOMAIN_SLUG = "anna-example-org"
 
 
 @pytest.fixture
@@ -140,3 +142,57 @@ def test_get_url_for_repo_uses_passed_username(sourcecraft_api):
     """
     url = sourcecraft_api.get_url_for_repo(username=SOURCECRAFT_USERNAME, course_students_group=TEST_STUDENTS_GROUP)
     assert url.endswith(f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}")
+
+
+def test_get_rms_user_by_username_falls_back_to_sourcecraft_lookup(sourcecraft_api):
+    """Regression: CI reports the repo slug ('anna-example-org'), which Passport does not know.
+
+    Normalization is not invertible, so the lookup must ask SourceCraft for that name
+    instead of giving up, otherwise /report answers 404 for every domain login.
+    """
+    profile = {"id": TEST_RMS_ID, "username": DOMAIN_SLUG, "display_name": "Anna Example"}
+
+    with patch.object(sourcecraft_api, "_get_cloud_id_by_yandex_login", side_effect=RmsApiException("no such login")):
+        with patch.object(
+            sourcecraft_api, "_request", return_value=_make_response(HTTPStatus.OK, profile)
+        ) as mock_request:
+            rms_user = sourcecraft_api.get_rms_user_by_username(DOMAIN_SLUG)
+
+    assert rms_user == RmsUser(id=TEST_RMS_ID, username=DOMAIN_SLUG, name="Anna Example")
+    mock_request.assert_called_once_with("GET", f"users/{DOMAIN_SLUG}")
+
+
+def test_get_rms_user_by_username_normalizes_before_sourcecraft_lookup(sourcecraft_api):
+    """The fallback queries GET /users/{user_slug}, so a raw login must be normalized first."""
+    profile = {"id": TEST_RMS_ID, "username": DOMAIN_SLUG, "display_name": "Anna Example"}
+
+    with patch.object(sourcecraft_api, "_get_cloud_id_by_yandex_login", side_effect=RmsApiException("passport down")):
+        with patch.object(
+            sourcecraft_api, "_request", return_value=_make_response(HTTPStatus.OK, profile)
+        ) as mock_request:
+            sourcecraft_api.get_rms_user_by_username(DOMAIN_LOGIN)
+
+    mock_request.assert_called_once_with("GET", f"users/{DOMAIN_SLUG}")
+
+
+def test_get_rms_user_by_username_raises_when_both_lookups_fail(sourcecraft_api):
+    """Unknown to Passport and to SourceCraft: the caller must still get an RmsApiException."""
+    with patch.object(sourcecraft_api, "_get_cloud_id_by_yandex_login", side_effect=RmsApiException("no such login")):
+        with patch.object(sourcecraft_api, "_request", return_value=_make_response(HTTPStatus.NOT_FOUND)):
+            with pytest.raises(RmsApiException):
+                sourcecraft_api.get_rms_user_by_username(DOMAIN_SLUG)
+
+
+def test_get_rms_user_by_username_prefers_yandex_login(sourcecraft_api):
+    """The yandex login stays the primary path: resolving it must not query by the raw name."""
+    cloud_id = "cloud-id-1"
+    profile = {"id": TEST_RMS_ID, "username": SOURCECRAFT_USERNAME, "display_name": "Test User"}
+
+    with patch.object(sourcecraft_api, "_get_cloud_id_by_yandex_login", return_value=cloud_id):
+        with patch.object(
+            sourcecraft_api, "_request", return_value=_make_response(HTTPStatus.OK, profile)
+        ) as mock_request:
+            rms_user = sourcecraft_api.get_rms_user_by_username(YANDEX_LOGIN)
+
+    assert rms_user.username == SOURCECRAFT_USERNAME
+    mock_request.assert_called_once_with("GET", f"users/cloud-id:{cloud_id}")


### PR DESCRIPTION
Reporting a score fails with 404 for every student whose auth login is not
already a plain slug. CI reports the RMS-native username -- the repo slug --
while get_rms_user_by_username only asks Yandex Passport, which knows logins:

    --> Running "Report score to manytask" stage:
    Manytask returned HTTP 404:
    <p>There is no RMS user with username='anna-example-ru'</p>

A Yandex 360 login on a custom domain, 'anna@example.ru', becomes the repo
slug 'anna-example-ru', because normalize_string collapses '@' and '.' into
'-', and that slug is the only form CI has at hand. Passport has no such
login, the lookup raises RmsApiException and the endpoint aborts with 404.