### PR TITLE
feat: show interpolate deadlines as a graph

### DIFF
--- a/manytask/interpolate.example.yml
+++ b/manytask/interpolate.example.yml
@@ -145,6 +145,25 @@ deadlines:
         - task: h_task_3
           score: 20
 
+    # ── 9. Mixed deadline times — exercises the X-axis time rule ──────────────
+    #    A label shows the time only when the deadline is NOT at 23:59, and the
+    #    first point (the group start) never shows one. Here:
+    #      start 09:00  -> "01.09"        (first point, time suppressed)
+    #      step  18:30  -> "15.09 18:30"  (mid-day deadline, time shown)
+    #      step  23:59  -> "25.09"        (end of day, time redundant)
+    #      end   12:00  -> "05.10 12:00"  (mid-day deadline, time shown)
+    - group: "I · Mixed times (09:00 / 18:30 / 23:59 / 12:00)"
+      start: 2026-09-01 09:00
+      steps:
+        0.7: 2026-09-15 18:30
+        0.3: 2026-09-25 23:59
+      end:   2026-10-05 12:00
+      tasks:
+        - task: i_task_1
+          score: 12
+        - task: i_task_2
+          score: 12
+
 grades:
   grades:
     5:

--- a/manytask/interpolate.example.yml
+++ b/manytask/interpolate.example.yml
@@ -1,0 +1,157 @@
+# Demo config for test6 — showcases the interpolated deadline graph
+# Current date: 2026-09-07 (UTC+3), so groups below cover past, active, and future windows.
+
+version: 1
+
+settings:
+  course_name: test6
+  gitlab_base_url: https://gitlab.example.com
+  public_repo: test6/public
+  students_group: test6/students
+
+ui:
+  task_url_template: https://gitlab.example.com/$GROUP_NAME/$USER_NAME/$TASK_NAME
+  links:
+    "Manytask": https://github.com/manytask/manytask
+
+deadlines:
+  timezone: Europe/Moscow
+  deadlines: interpolate          # ← enables the canvas graph on the tasks page
+  max_submissions: 20
+  submission_penalty: 0.0
+  schedule:
+
+    # ── 1. Straight-line decline: no intermediate steps ────────────────────────
+    #    Graph: single diagonal from start (100 %) → end (0 %).
+    #    Status: currently active (now sits in the middle of the window).
+    - group: "A · No Steps (straight decline)"
+      start: 2026-08-01 00:00
+      end:   2026-10-31 23:59
+      tasks:
+        - task: a_task_1
+          score: 10
+        - task: a_task_2
+          score: 10
+        - task: a_task_3
+          score: 10
+
+    # ── 2. Single mid-step: classic "soft deadline" shape ─────────────────────
+    #    100 % until soft deadline (2026-09-01), then linear drop to 50 %
+    #    at the hard deadline (2026-10-15), then 0 % after that.
+    #    Status: past the soft deadline → currently on the descending slope.
+    - group: "B · One Step — past soft deadline"
+      start: 2026-08-15 00:00
+      steps:
+        0.5: 2026-09-01 23:59    # score drops below 100 % from this point
+      end:   2026-10-15 23:59
+      tasks:
+        - task: b_task_1
+          score: 20
+        - task: b_task_2
+          score: 20
+
+    # ── 3. Two steps: plateau → gentle slope → steep drop ────────────────────
+    #    100 % at start → 75 % at step 1 → 25 % at step 2 → 0 % at end.
+    #    Status: between step 1 and step 2 (active, declining).
+    - group: "C · Two Steps — on second slope"
+      start: 2026-08-01 00:00
+      steps:
+        0.75: 2026-09-01 23:59
+        0.25: 2026-09-20 23:59
+      end:   2026-10-31 23:59
+      tasks:
+        - task: c_task_1
+          score: 15
+        - task: c_task_2
+          score: 15
+        - task: c_task_3
+          score: 15
+          is_bonus: true
+
+    # ── 4. Already expired — full window in the past ──────────────────────────
+    #    Graph renders in grey; the "now" marker does not appear.
+    - group: "D · Expired (all grey)"
+      start: 2026-05-01 00:00
+      steps:
+        0.5: 2026-06-01 23:59
+      end:   2026-07-31 23:59
+      tasks:
+        - task: d_task_1
+          score: 10
+        - task: d_task_2
+          score: 10
+
+    # ── 5. Not yet started — "now" marker hidden, no expiry notice ────────────
+    #    Graph shows full green fill; the orange "now" line is off the left edge.
+    - group: "E · Future (not started yet)"
+      start: 2026-10-01 00:00
+      steps:
+        0.6: 2026-11-01 23:59
+      end:   2026-12-15 23:59
+      tasks:
+        - task: e_task_1
+          score: 25
+        - task: e_task_2
+          score: 25
+
+    # ── 6. Three steps — many break-points visible on the X axis ─────────────
+    #    Tests label collision suppression in crowded graphs.
+    - group: "F · Three Steps — label collision test"
+      start: 2026-08-01 00:00
+      steps:
+        0.8: 2026-08-20 23:59
+        0.5: 2026-09-10 23:59
+        0.2: 2026-09-25 23:59
+      end:   2026-10-10 23:59
+      tasks:
+        - task: f_task_1
+          score: 8
+        - task: f_task_2
+          score: 8
+        - task: f_task_3
+          score: 8
+        - task: f_task_4
+          score: 8
+
+    # ── 7. Long window, now near the end ─────────────────────────────────────
+    #    The "now" dot sits close to the end of the curve near 0 %.
+    - group: "G · Near expiry"
+      start: 2026-01-01 00:00
+      steps:
+        0.5: 2026-04-01 23:59
+      end:   2026-09-20 23:59
+      tasks:
+        - task: g_task_1
+          score: 30
+        - task: g_task_2
+          score: 30
+
+    # ── 8. Flat 100 % plateau — "now" is before the first score-drop step ─────
+    #    A step of 1.0 at 2026-09-20 creates a flat segment: the interpolation
+    #    between (start, 1.0) and (step1, 1.0) always yields 100 %.
+    #    The "now" dot therefore sits on the top horizontal line of the graph.
+    - group: "H · Still at 100 % (before first drop)"
+      start: 2026-09-01 00:00
+      steps:
+        1.0: 2026-09-20 23:59    # score stays at 100 % until this date
+        0.5: 2026-10-15 23:59    # then drops toward 50 % by this date
+        0.1: 2026-11-01 23:59    # then toward 10 % by this date
+      end:   2026-12-01 23:59
+      tasks:
+        - task: h_task_1
+          score: 20
+        - task: h_task_2
+          score: 20
+        - task: h_task_3
+          score: 20
+
+grades:
+  grades:
+    5:
+      - percent: 90
+    4:
+      - percent: 70
+    3:
+      - percent: 50
+    2:
+      - {"": 0}

--- a/manytask/manytask/config.py
+++ b/manytask/manytask/config.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from pydantic import AnyUrl, BaseModel, Field, field_validator, model_validator
 
 from manytask.course import CourseStatus, ManytaskDeadlinesType
-from manytask.utils.generic import lerp
+from manytask.utils.generic import SECONDS_PER_DAY, format_remaining, lerp
 
 MAX_COURSE_NAME_LENGTH = 100
 
@@ -244,6 +244,61 @@ class ManytaskGroupConfig(BaseModel):
 
         # None if now is before start, ok if last_point[1] is zero
         return (last_point and last_point[1]) or 0.0
+
+    @staticmethod
+    def _axis_label(dt: datetime, *, date_only: bool = False) -> str:
+        # 23:59 deadlines mean "that date"; showing the time just adds clutter.
+        if date_only or dt.strftime("%H:%M") == "23:59":
+            return dt.strftime("%d.%m")
+        return dt.strftime("%d.%m %H:%M")
+
+    @staticmethod
+    def _graph_point(dt: datetime, pct: float, label: str) -> dict[str, Any]:
+        return {
+            "ts": dt.timestamp(),
+            "pct": pct,
+            "label": label,
+            "date": dt.strftime("%d.%m.%Y"),
+            "time": dt.strftime("%H:%M"),
+            "tz": dt.strftime("%Z"),
+        }
+
+    def get_graph_data(self, now: datetime, deadlines_type: ManytaskDeadlinesType) -> dict[str, Any]:
+        """Build everything the interpolated-deadline graph (tasks.html) needs to render.
+
+        Mirrors get_current_percent_multiplier(): linear interpolation between (start,
+        100%) and each step, a flat plateau after the last step, then a vertical drop
+        to 0% at `end`. The returned "points" are start -> steps... -> (end, last_pct)
+        -> (end, 0), ready to be dumped as JSON for the canvas renderer.
+        """
+        end_dt = self.get_deadline(self.end)
+
+        points = [self._graph_point(self.start, 1.0, self._axis_label(self.start, date_only=True))]
+        critical_dates = [self.start]
+        last_pct = 1.0
+        for percent, date_or_delta in self.steps.items():
+            step_dt = self.get_deadline(date_or_delta)
+            points.append(self._graph_point(step_dt, percent, self._axis_label(step_dt)))
+            critical_dates.append(step_dt)
+            last_pct = percent
+        points.append(self._graph_point(end_dt, last_pct, self._axis_label(end_dt)))
+        points.append(self._graph_point(end_dt, 0.0, ""))
+        critical_dates.append(end_dt)
+
+        next_deadline = next((d for d in critical_dates if d > now), None)
+        is_expired = end_dt < now
+        is_urgent = next_deadline is not None and (next_deadline - now).total_seconds() < SECONDS_PER_DAY
+        status = "expired" if is_expired else ("urgent" if is_urgent else "active")
+
+        percent = 1.0 if now < self.start else self.get_current_percent_multiplier(now, deadlines_type)
+        hint = f"Next deadline in: {format_remaining(next_deadline, now)}" if next_deadline is not None else ""
+
+        return {
+            "points": points,
+            "status": status,
+            "percent": percent,
+            "hint": hint,
+        }
 
     def replace_timezone(self, timezone: ZoneInfo) -> None:
         self.start = self.start.replace(tzinfo=timezone)

--- a/manytask/manytask/main.py
+++ b/manytask/manytask/main.py
@@ -195,9 +195,11 @@ def create_app(*, debug: bool | None = None, test: bool = False) -> CustomFlask:
     app.register_blueprint(web.instance_admin_bp)
 
     from .utils.flask import get_user_roles, has_role
+    from .utils.generic import format_remaining
 
     app.jinja_env.globals["get_user_roles"] = get_user_roles
     app.jinja_env.globals["has_role"] = has_role
+    app.jinja_env.globals["format_remaining"] = format_remaining
 
     @app.context_processor
     def inject_rms_id() -> dict[str, int | None]:

--- a/manytask/manytask/static/css/tasks.css
+++ b/manytask/manytask/static/css/tasks.css
@@ -329,22 +329,81 @@
     font-weight: 500;
 }
 
+/* ── Interpolated deadline graph ──────────────────────────────────────────── */
+
 .task-deadlines--graph {
     flex-direction: column;
     align-items: flex-end;
-    min-width: 260px;
-    max-width: 400px;
+    min-width: 280px;
+    max-width: 420px;
     width: 100%;
 }
 
+/* The graph lives inside a regular .task-deadline plank, so it inherits the
+   plank's background, border, radius and padding for free. */
+.task-deadline--graph {
+    width: 100%;
+    box-sizing: border-box;
+}
+
+/*
+ * Palette + geometry for the canvas renderer. deadline-graph.js reads these
+ * custom properties, so all graph styling stays here in CSS.
+ */
 .deadline-graph-canvas {
     display: block;
     width: 100%;
-    border-radius: 8px;
-    border: 1px solid var(--bs-border-color-translucent);
-    background: var(--bs-body-bg);
-    padding: 4px 2px 2px 2px;
-    box-sizing: border-box;
+    margin: 4px 0 2px 0;
+
+    /* geometry (px, unitless values are fine — JS parses with parseFloat) */
+    --graph-height: 110;
+    --graph-margin-left: 46;
+    --graph-margin-right: 8;
+    --graph-margin-top: 6;
+    --graph-margin-bottom: 30;
+    --graph-font-size: 10;
+
+    /* palette — mirrors the plank tokens */
+    --graph-text: var(--bs-secondary-color);
+    --graph-axis: color-mix(in srgb, var(--bs-body-color) 18%, transparent);
+    --graph-grid: color-mix(in srgb, var(--bs-body-color) 7%, transparent);
+    --graph-now: #ef6c00;
+
+    /* default (active) curve colours — match .task-deadline__progress-bar */
+    --graph-line: #4caf50;
+    --graph-dot: #388e3c;
+    --graph-fill: color-mix(in srgb, #4caf50 14%, transparent);
+}
+
+/* Urgent — mirrors .task-deadline__progress-bar.urgent gradient endpoints */
+.task-deadline--graph.urgent .deadline-graph-canvas {
+    --graph-line: #fd3e04;
+    --graph-dot: #ff8f00;
+    --graph-fill: color-mix(in srgb, #ff8f00 14%, transparent);
+}
+
+/* Expired — mirrors .task-deadline__progress-bar.expired */
+.task-deadline--graph.expired .deadline-graph-canvas {
+    --graph-line: #9e9e9e;
+    --graph-dot: #9e9e9e;
+    --graph-fill: color-mix(in srgb, #9e9e9e 12%, transparent);
+}
+
+/* Fallback for browsers without color-mix() */
+@supports not (color: color-mix(in srgb, red 50%, transparent)) {
+    .deadline-graph-canvas {
+        --graph-axis: rgba(128, 128, 128, 0.35);
+        --graph-grid: rgba(128, 128, 128, 0.12);
+        --graph-fill: rgba(76, 175, 80, 0.14);
+    }
+
+    .task-deadline--graph.urgent .deadline-graph-canvas {
+        --graph-fill: rgba(255, 143, 0, 0.14);
+    }
+
+    .task-deadline--graph.expired .deadline-graph-canvas {
+        --graph-fill: rgba(158, 158, 158, 0.12);
+    }
 }
 
 @media (max-width: 767px) {

--- a/manytask/manytask/static/css/tasks.css
+++ b/manytask/manytask/static/css/tasks.css
@@ -329,6 +329,32 @@
     font-weight: 500;
 }
 
+.task-deadlines--graph {
+    flex-direction: column;
+    align-items: flex-end;
+    min-width: 260px;
+    max-width: 400px;
+    width: 100%;
+}
+
+.deadline-graph-canvas {
+    display: block;
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--bs-border-color-translucent);
+    background: var(--bs-body-bg);
+    padding: 4px 2px 2px 2px;
+    box-sizing: border-box;
+}
+
+@media (max-width: 767px) {
+    .task-deadlines--graph {
+        min-width: unset;
+        max-width: unset;
+        align-items: stretch;
+    }
+}
+
 .course-status-badge {
     padding: 6px 12px;
     border-radius: 8px;

--- a/manytask/manytask/static/css/tasks.css
+++ b/manytask/manytask/static/css/tasks.css
@@ -347,21 +347,50 @@
 }
 
 /*
+ * The "next deadline in" hint shares the header row with the percent and the
+ * status pill. .deadline-header is `justify-content: space-between`, so the
+ * hint is pushed to fill the gap and right-aligned against the pill; it is
+ * shorter than the pill, so the row height is unchanged.
+ */
+.task-deadline--graph .deadline-header {
+    align-items: baseline;
+    gap: 8px;
+}
+
+.task-deadline--graph .deadline-header .task-deadline__deadline-hint {
+    flex: 1 1 auto;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/*
  * Palette + geometry for the canvas renderer. deadline-graph.js reads these
  * custom properties, so all graph styling stays here in CSS.
  */
 .deadline-graph-canvas {
     display: block;
     width: 100%;
-    margin: 4px 0 2px 0;
+    margin: 2px 0 0 0;
 
-    /* geometry (px, unitless values are fine — JS parses with parseFloat) */
-    --graph-height: 110;
-    --graph-margin-left: 46;
-    --graph-margin-right: 8;
-    --graph-margin-top: 6;
-    --graph-margin-bottom: 30;
-    --graph-font-size: 10;
+    /*
+     * Geometry (px, unitless — JS parses with parseFloat).
+     *
+     * Tuned so .task-deadline--graph is the same height as a regular deadline
+     * plank (~101px). Because the "next deadline in" hint moved up into
+     * .deadline-header, the canvas gets that row's height too: it now spans the
+     * progress-bar, date/time AND hint rows (2 + 50 = 52px vs ~52px replaced).
+     *
+     * --graph-margin-bottom must stay >= 14 so the X-axis date labels
+     * (font-size 9px, ~11px line box + 3px gap) are not clipped.
+     */
+    --graph-height: 50;
+    --graph-margin-left: 30;
+    --graph-margin-right: 6;
+    --graph-margin-top: 4;
+    --graph-margin-bottom: 14;
+    --graph-font-size: 9;
 
     /* palette — mirrors the plank tokens */
     --graph-text: var(--bs-secondary-color);

--- a/manytask/manytask/static/css/tasks.css
+++ b/manytask/manytask/static/css/tasks.css
@@ -382,14 +382,19 @@
      * .deadline-header, the canvas gets that row's height too: it now spans the
      * progress-bar, date/time AND hint rows (2 + 50 = 52px vs ~52px replaced).
      *
-     * --graph-margin-bottom must stay >= 14 so the X-axis date labels
-     * (font-size 9px, ~11px line box + 3px gap) are not clipped.
+     * Margin floors, both enforced by the renderer's label placement:
+     *   --graph-margin-top    >= 5  half of the 100 % label, which is centred
+     *                              on the top gridline (it is clamped into the
+     *                              canvas, so a smaller value only crowds it)
+     *   --graph-margin-bottom >= 10 the X-axis dates: 2px gap + ~7px glyph ink
+     *                              (9 puts the ink exactly on the canvas edge)
+     * Going below those crowds or clips the labels.
      */
-    --graph-height: 50;
+    --graph-height: 51;
     --graph-margin-left: 30;
     --graph-margin-right: 6;
-    --graph-margin-top: 4;
-    --graph-margin-bottom: 14;
+    --graph-margin-top: 5;
+    --graph-margin-bottom: 10;
     --graph-font-size: 9;
 
     /* palette — mirrors the plank tokens */

--- a/manytask/manytask/static/css/tasks.css
+++ b/manytask/manytask/static/css/tasks.css
@@ -366,6 +366,23 @@
 }
 
 /*
+ * Hover tooltip on the graph's breakpoint dots. Mirrors the icon + text layout
+ * of .task-deadline__deadline-time on the non-interpolated planks.
+ */
+.deadline-graph-tip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 0.8rem;
+    white-space: nowrap;
+}
+
+.deadline-graph-tip i {
+    margin-right: 2px;
+    opacity: 0.75;
+}
+
+/*
  * Palette + geometry for the canvas renderer. deadline-graph.js reads these
  * custom properties, so all graph styling stays here in CSS.
  */

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -132,7 +132,6 @@ function drawDeadlineGraph(canvas) {
     ctx.font = labelFont;
     ctx.fillStyle = color.text;
     ctx.textAlign = 'right';
-    ctx.textBaseline = 'middle';
     const fmtPct = function (pct) {
         return Math.round(pct * 100) + '%';
     };
@@ -142,12 +141,17 @@ function drawDeadlineGraph(canvas) {
     const midPcts = [...new Set(points.slice(1, -1).map(function (p) { return p.pct; }))]
         .filter(function (p) { return p !== 1.0 && p !== 0.0; })
         .sort(function (a, b) { return b - a; });
+    ctx.textBaseline = 'middle';
     [1.0, 0.0].concat(midPcts).forEach(function (pct) {
         const y = yOf(pct);
         const clash = drawnY.some(function (dy) { return Math.abs(dy - y) < minYGap; });
         if (clash) return;
         drawnY.push(y);
-        ctx.fillText(fmtPct(pct), mL - 4, y);
+        // Clamp into the canvas so the outermost labels are never cut off by
+        // the top/bottom edge, while staying centred on their gridline.
+        const half = m.fontSize * 0.5;
+        const cy = Math.min(Math.max(y, half), cssHeight - half);
+        ctx.fillText(fmtPct(pct), mL - 4, cy);
     });
 
     // X-axis date labels at each critical point.
@@ -184,7 +188,7 @@ function drawDeadlineGraph(canvas) {
         ctx.textAlign = isFirst ? 'left' : (isLast ? 'right' : 'center');
         const labelX  = isFirst ? mL : (isLast ? mL + pW : x);
         ctx.fillStyle = color.text;
-        ctx.fillText(textOf(pt), labelX, mT + pH + 4);
+        ctx.fillText(textOf(pt), labelX, mT + pH + 2);
 
         // Tick mark
         ctx.strokeStyle = color.axis;

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -51,7 +51,6 @@ function _readGraphMetrics(canvas) {
 function drawDeadlineGraph(canvas) {
     const points = JSON.parse(canvas.dataset.points);
     const nowTs = parseFloat(canvas.dataset.now);
-    const totalScore = parseInt(canvas.dataset.score) || 0;
 
     if (!points || points.length < 2) return;
 
@@ -126,32 +125,52 @@ function drawDeadlineGraph(canvas) {
     ctx.lineTo(mL + pW, mT + pH);
     ctx.stroke();
 
-    // Y-axis labels at each unique percentage breakpoint
+    // Y-axis labels. The plank is short, so only draw the breakpoints that fit;
+    // the 100 % / 0 % endpoints always win over intermediate steps.
+    // Percentages (not absolute points) keep the labels narrow enough for the
+    // left margin — the exact score is already shown in .deadline-percent.
     ctx.font = labelFont;
     ctx.fillStyle = color.text;
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
-    const allPcts    = [1.0, ...points.slice(1, -1).map(function (p) { return p.pct; }), 0.0];
-    const uniquePcts = [...new Set(allPcts)].sort(function (a, b) { return b - a; });
-    let lastLabelY   = -Infinity;
-    uniquePcts.forEach(function (pct) {
+    const fmtPct = function (pct) {
+        return Math.round(pct * 100) + '%';
+    };
+    const minYGap = m.fontSize + 3;
+    const drawnY  = [];
+    // endpoints first, then intermediates in descending order
+    const midPcts = [...new Set(points.slice(1, -1).map(function (p) { return p.pct; }))]
+        .filter(function (p) { return p !== 1.0 && p !== 0.0; })
+        .sort(function (a, b) { return b - a; });
+    [1.0, 0.0].concat(midPcts).forEach(function (pct) {
         const y = yOf(pct);
-        // Always draw endpoints; skip middle ones if too close
-        if (pct !== 1.0 && pct !== 0.0 && y - lastLabelY < m.fontSize + 4) return;
-        lastLabelY = y;
-        const label = totalScore > 0
-            ? (Math.round(pct * totalScore) + 'pt')
-            : (Math.round(pct * 100) + '%');
-        ctx.fillText(label, mL - 4, y);
+        const clash = drawnY.some(function (dy) { return Math.abs(dy - y) < minYGap; });
+        if (clash) return;
+        drawnY.push(y);
+        ctx.fillText(fmtPct(pct), mL - 4, y);
     });
 
-    // X-axis date labels at each critical point
-    ctx.textBaseline = 'top';
-    let lastLabelX = -Infinity;
-    const minGap   = m.fontSize * 5.2;
+    // X-axis date labels at each critical point.
     // The final point is the vertical drop to 0 % and shares its timestamp with
     // the previous one, so it carries no label of its own.
+    ctx.textBaseline = 'top';
     const labelled = points.filter(function (pt) { return pt.label; });
+
+    // Use the full "DD.MM HH:MM" form only if every label would still fit,
+    // otherwise fall back to the compact "DD.MM".
+    const widest = Math.max.apply(null, labelled.map(function (pt) {
+        return ctx.measureText(pt.full || pt.label).width;
+    }));
+    const useFull = labelled.length > 1
+        && widest * labelled.length <= pW
+        && labelled.every(function (pt) { return pt.full; });
+    const textOf = function (pt) { return useFull ? pt.full : pt.label; };
+
+    const minGap = Math.max.apply(null, labelled.map(function (pt) {
+        return ctx.measureText(textOf(pt)).width;
+    })) + 6;
+
+    let lastLabelX = -Infinity;
     labelled.forEach(function (pt, i) {
         const x       = xOf(pt.ts);
         const isFirst = (i === 0);
@@ -165,7 +184,7 @@ function drawDeadlineGraph(canvas) {
         ctx.textAlign = isFirst ? 'left' : (isLast ? 'right' : 'center');
         const labelX  = isFirst ? mL : (isLast ? mL + pW : x);
         ctx.fillStyle = color.text;
-        ctx.fillText(pt.label, labelX, mT + pH + 5);
+        ctx.fillText(textOf(pt), labelX, mT + pH + 4);
 
         // Tick mark
         ctx.strokeStyle = color.axis;

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -1,0 +1,216 @@
+'use strict';
+
+function _formatRemaining(diffSec) {
+    if (diffSec < 3600) {
+        const m = Math.ceil(diffSec / 60);
+        return m + ' min.';
+    }
+    if (diffSec < 86400) {
+        const h = Math.floor(diffSec / 3600);
+        return h + ' h.';
+    }
+    const d = Math.floor(diffSec / 86400);
+    return d + ' d.';
+}
+
+function drawDeadlineGraph(canvas) {
+    const points = JSON.parse(canvas.dataset.points);
+    const nowTs = parseFloat(canvas.dataset.now);
+    const totalScore = parseInt(canvas.dataset.score) || 0;
+    const isExpired = canvas.dataset.expired === 'true';
+
+    if (!points || points.length < 2) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const cssWidth = canvas.getBoundingClientRect().width || canvas.parentElement.clientWidth || 300;
+    const cssHeight = 130;
+
+    canvas.style.height = cssHeight + 'px';
+    canvas.width = Math.round(cssWidth * dpr);
+    canvas.height = Math.round(cssHeight * dpr);
+
+    const ctx = canvas.getContext('2d');
+    ctx.scale(dpr, dpr);
+
+    const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'
+                || window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+    const textColor = isDark ? '#adb5bd' : '#555';
+    const axisColor = isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.18)';
+    const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)';
+    const lineColor = isExpired ? '#9e9e9e'
+                    : (isDark   ? '#66cda3' : '#2e7d32');
+    const fillColor = isExpired ? 'rgba(158,158,158,0.12)'
+                    : (isDark   ? 'rgba(102,205,163,0.15)' : 'rgba(46,125,50,0.12)');
+    const nowColor  = '#ef6c00';
+    const dotColor  = isExpired ? '#9e9e9e' : (isDark ? '#66cda3' : '#388e3c');
+
+    const mL = 46, mR = 8, mT = 10, mB = 34;
+    const pW = cssWidth - mL - mR;
+    const pH = cssHeight - mT - mB;
+
+    const minTs   = points[0].ts;
+    const maxTs   = points[points.length - 1].ts;
+    const tsRange = maxTs - minTs || 1;
+
+    function xOf(ts)  { return mL + (ts - minTs) / tsRange * pW; }
+    function yOf(pct) { return mT + (1 - pct) * pH; }
+
+    ctx.clearRect(0, 0, cssWidth, cssHeight);
+
+    // Horizontal grid lines at 0%, 50%, 100%
+    ctx.strokeStyle = gridColor;
+    ctx.lineWidth = 1;
+    [0, 0.5, 1.0].forEach(function (p) {
+        const y = yOf(p);
+        ctx.beginPath();
+        ctx.moveTo(mL, y);
+        ctx.lineTo(mL + pW, y);
+        ctx.stroke();
+    });
+
+    // Filled area under the piecewise line
+    ctx.beginPath();
+    ctx.moveTo(xOf(points[0].ts), yOf(points[0].pct));
+    for (let i = 1; i < points.length; i++) {
+        ctx.lineTo(xOf(points[i].ts), yOf(points[i].pct));
+    }
+    ctx.lineTo(xOf(points[points.length - 1].ts), yOf(0));
+    ctx.lineTo(xOf(points[0].ts), yOf(0));
+    ctx.closePath();
+    ctx.fillStyle = fillColor;
+    ctx.fill();
+
+    // Piecewise line
+    ctx.beginPath();
+    ctx.moveTo(xOf(points[0].ts), yOf(points[0].pct));
+    for (let i = 1; i < points.length; i++) {
+        ctx.lineTo(xOf(points[i].ts), yOf(points[i].pct));
+    }
+    ctx.strokeStyle = lineColor;
+    ctx.lineWidth = 2;
+    ctx.lineJoin = 'round';
+    ctx.stroke();
+
+    // Axes
+    ctx.strokeStyle = axisColor;
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(mL, mT);
+    ctx.lineTo(mL, mT + pH);
+    ctx.lineTo(mL + pW, mT + pH);
+    ctx.stroke();
+
+    // Y-axis labels at each unique percentage breakpoint
+    ctx.font = '10px system-ui, -apple-system, sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    const allPcts    = [1.0, ...points.slice(1, -1).map(function (p) { return p.pct; }), 0.0];
+    const uniquePcts = [...new Set(allPcts)].sort(function (a, b) { return b - a; });
+    let lastLabelY   = -Infinity;
+    uniquePcts.forEach(function (pct) {
+        const y = yOf(pct);
+        // Always draw endpoints; skip middle ones if too close
+        if (pct !== 1.0 && pct !== 0.0 && y - lastLabelY < 14) return;
+        lastLabelY = y;
+        ctx.fillStyle = textColor;
+        const label = totalScore > 0
+            ? (Math.round(pct * totalScore) + 'pt')
+            : (Math.round(pct * 100) + '%');
+        ctx.fillText(label, mL - 4, y);
+    });
+
+    // X-axis date labels at each critical point
+    ctx.textBaseline = 'top';
+    let lastLabelX = -Infinity;
+    const minGap   = 52;
+    points.forEach(function (pt, i) {
+        const x       = xOf(pt.ts);
+        const isFirst = (i === 0);
+        const isLast  = (i === points.length - 1);
+
+        // Enforce spacing; always show first and last
+        if (!isFirst && !isLast && x - lastLabelX < minGap) return;
+        // Skip intermediate labels that would crowd the final label
+        if (!isLast && (xOf(points[points.length - 1].ts) - x) < minGap && !isFirst) return;
+
+        ctx.textAlign = isFirst ? 'left' : (isLast ? 'right' : 'center');
+        const labelX  = isFirst ? mL : (isLast ? mL + pW : x);
+        ctx.fillStyle = textColor;
+        ctx.fillText(pt.label, labelX, mT + pH + 5);
+
+        // Tick mark
+        ctx.strokeStyle = axisColor;
+        ctx.lineWidth = 1;
+        ctx.beginPath();
+        ctx.moveTo(x, mT + pH);
+        ctx.lineTo(x, mT + pH + 3);
+        ctx.stroke();
+
+        lastLabelX = x;
+    });
+
+    // "Now" dashed marker — only shown while the deadline window is open
+    if (nowTs > minTs && nowTs < maxTs) {
+        const nx = xOf(nowTs);
+
+        // Interpolate the currently achievable percentage
+        let curPct = 0;
+        for (let i = 0; i < points.length - 1; i++) {
+            if (nowTs >= points[i].ts && nowTs <= points[i + 1].ts) {
+                const t = (nowTs - points[i].ts) / (points[i + 1].ts - points[i].ts);
+                curPct = points[i].pct + t * (points[i + 1].pct - points[i].pct);
+                break;
+            }
+        }
+
+        ctx.strokeStyle = nowColor;
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([4, 3]);
+        ctx.beginPath();
+        ctx.moveTo(nx, mT);
+        ctx.lineTo(nx, mT + pH);
+        ctx.stroke();
+        ctx.setLineDash([]);
+
+        // Dot at current achievable score on the curve
+        ctx.fillStyle = nowColor;
+        ctx.beginPath();
+        ctx.arc(nx, yOf(curPct), 4, 0, Math.PI * 2);
+        ctx.fill();
+    }
+
+    // Dots at key breakpoints
+    ctx.fillStyle = dotColor;
+    points.forEach(function (pt) {
+        ctx.beginPath();
+        ctx.arc(xOf(pt.ts), yOf(pt.pct), 3, 0, Math.PI * 2);
+        ctx.fill();
+    });
+
+    // "Next deadline in" hint — drawn inside the bottom-right of the plot area
+    const next = points.find(function (pt) { return pt.ts > nowTs; });
+    if (next) {
+        const diffSec = next.ts - nowTs;
+        const isUrgent = diffSec < 86400;
+        const hintText = 'Next deadline in: ' + _formatRemaining(diffSec);
+        ctx.font = 'italic 10px system-ui, -apple-system, sans-serif';
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'top';
+        ctx.fillStyle = isUrgent ? nowColor : textColor;
+        ctx.fillText(hintText, mL + pW, mT + 4);
+    }
+}
+
+function initDeadlineGraphs() {
+    document.querySelectorAll('.deadline-graph-canvas').forEach(drawDeadlineGraph);
+}
+
+initDeadlineGraphs();
+
+// Redraw on resize so the canvas stays sharp and correctly sized
+let _deadlineGraphResizeTimer;
+window.addEventListener('resize', function () {
+    clearTimeout(_deadlineGraphResizeTimer);
+    _deadlineGraphResizeTimer = setTimeout(initDeadlineGraphs, 120);
+});

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -1,29 +1,66 @@
 'use strict';
 
-function _formatRemaining(diffSec) {
-    if (diffSec < 3600) {
-        const m = Math.ceil(diffSec / 60);
-        return m + ' min.';
-    }
-    if (diffSec < 86400) {
-        const h = Math.floor(diffSec / 3600);
-        return h + ' h.';
-    }
-    const d = Math.floor(diffSec / 86400);
-    return d + ' d.';
+/**
+ * Renders the interpolated-deadline score curve onto a <canvas>.
+ *
+ * All colours come from CSS custom properties declared on the canvas element
+ * (see .deadline-graph-canvas in tasks.css), so the graph automatically follows
+ * the light/dark theme and any restyling of the deadline planks. Nothing about
+ * the palette is hard-coded here.
+ */
+
+// CSS custom property -> internal name. Values are resolved per canvas so that
+// the `.expired` / `.urgent` / `.active` modifier on the parent plank can change
+// them via normal CSS cascade.
+const GRAPH_COLOR_VARS = {
+    text: '--graph-text',
+    axis: '--graph-axis',
+    grid: '--graph-grid',
+    line: '--graph-line',
+    fill: '--graph-fill',
+    dot:  '--graph-dot',
+    now:  '--graph-now'
+};
+
+function _readGraphColors(canvas) {
+    const cs = getComputedStyle(canvas);
+    const colors = {};
+    Object.keys(GRAPH_COLOR_VARS).forEach(function (key) {
+        colors[key] = cs.getPropertyValue(GRAPH_COLOR_VARS[key]).trim();
+    });
+    return colors;
+}
+
+function _readGraphMetrics(canvas) {
+    const cs = getComputedStyle(canvas);
+    const num = function (prop, fallback) {
+        const v = parseFloat(cs.getPropertyValue(prop));
+        return isNaN(v) ? fallback : v;
+    };
+    return {
+        height:   num('--graph-height', 110),
+        marginL:  num('--graph-margin-left', 46),
+        marginR:  num('--graph-margin-right', 8),
+        marginT:  num('--graph-margin-top', 6),
+        marginB:  num('--graph-margin-bottom', 30),
+        fontSize: num('--graph-font-size', 10),
+        fontFamily: cs.fontFamily || 'system-ui, sans-serif'
+    };
 }
 
 function drawDeadlineGraph(canvas) {
     const points = JSON.parse(canvas.dataset.points);
     const nowTs = parseFloat(canvas.dataset.now);
     const totalScore = parseInt(canvas.dataset.score) || 0;
-    const isExpired = canvas.dataset.expired === 'true';
 
     if (!points || points.length < 2) return;
 
+    const color = _readGraphColors(canvas);
+    const m = _readGraphMetrics(canvas);
+
     const dpr = window.devicePixelRatio || 1;
     const cssWidth = canvas.getBoundingClientRect().width || canvas.parentElement.clientWidth || 300;
-    const cssHeight = 130;
+    const cssHeight = m.height;
 
     canvas.style.height = cssHeight + 'px';
     canvas.width = Math.round(cssWidth * dpr);
@@ -32,41 +69,10 @@ function drawDeadlineGraph(canvas) {
     const ctx = canvas.getContext('2d');
     ctx.scale(dpr, dpr);
 
-    // Detect dark mode from the page theme attribute first; fall back to the
-    // canvas's actual background luminance so OS preference never overrides the
-    // explicit Bootstrap theme setting.
-    const bsTheme = document.documentElement.getAttribute('data-bs-theme');
-    let isDark;
-    if (bsTheme === 'dark') {
-        isDark = true;
-    } else if (bsTheme === 'light') {
-        isDark = false;
-    } else {
-        // No explicit theme — read the canvas background colour to decide.
-        const bg = getComputedStyle(canvas).backgroundColor;
-        const m  = bg.match(/\d+/g);
-        if (m && m.length >= 3) {
-            // Perceived luminance (rec. 709)
-            const lum = 0.2126 * parseInt(m[0]) + 0.7152 * parseInt(m[1]) + 0.0722 * parseInt(m[2]);
-            isDark = lum < 128;
-        } else {
-            isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        }
-    }
-
-    const textColor = isDark ? '#adb5bd' : '#555';
-    const axisColor = isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.18)';
-    const gridColor = isDark ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.05)';
-    const lineColor = isExpired ? '#9e9e9e'
-                    : (isDark   ? '#66cda3' : '#2e7d32');
-    const fillColor = isExpired ? 'rgba(158,158,158,0.12)'
-                    : (isDark   ? 'rgba(102,205,163,0.15)' : 'rgba(46,125,50,0.12)');
-    const nowColor  = '#ef6c00';
-    const dotColor  = isExpired ? '#9e9e9e' : (isDark ? '#66cda3' : '#388e3c');
-
-    const mL = 46, mR = 8, mT = 10, mB = 34;
+    const mL = m.marginL, mR = m.marginR, mT = m.marginT, mB = m.marginB;
     const pW = cssWidth - mL - mR;
     const pH = cssHeight - mT - mB;
+    const labelFont = m.fontSize + 'px ' + m.fontFamily;
 
     const minTs   = points[0].ts;
     const maxTs   = points[points.length - 1].ts;
@@ -77,8 +83,8 @@ function drawDeadlineGraph(canvas) {
 
     ctx.clearRect(0, 0, cssWidth, cssHeight);
 
-    // Horizontal grid lines at 0%, 50%, 100%
-    ctx.strokeStyle = gridColor;
+    // Horizontal grid lines at 0 %, 50 %, 100 %
+    ctx.strokeStyle = color.grid;
     ctx.lineWidth = 1;
     [0, 0.5, 1.0].forEach(function (p) {
         const y = yOf(p);
@@ -97,7 +103,7 @@ function drawDeadlineGraph(canvas) {
     ctx.lineTo(xOf(points[points.length - 1].ts), yOf(0));
     ctx.lineTo(xOf(points[0].ts), yOf(0));
     ctx.closePath();
-    ctx.fillStyle = fillColor;
+    ctx.fillStyle = color.fill;
     ctx.fill();
 
     // Piecewise line
@@ -106,13 +112,13 @@ function drawDeadlineGraph(canvas) {
     for (let i = 1; i < points.length; i++) {
         ctx.lineTo(xOf(points[i].ts), yOf(points[i].pct));
     }
-    ctx.strokeStyle = lineColor;
+    ctx.strokeStyle = color.line;
     ctx.lineWidth = 2;
     ctx.lineJoin = 'round';
     ctx.stroke();
 
     // Axes
-    ctx.strokeStyle = axisColor;
+    ctx.strokeStyle = color.axis;
     ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.moveTo(mL, mT);
@@ -121,7 +127,8 @@ function drawDeadlineGraph(canvas) {
     ctx.stroke();
 
     // Y-axis labels at each unique percentage breakpoint
-    ctx.font = '10px system-ui, -apple-system, sans-serif';
+    ctx.font = labelFont;
+    ctx.fillStyle = color.text;
     ctx.textAlign = 'right';
     ctx.textBaseline = 'middle';
     const allPcts    = [1.0, ...points.slice(1, -1).map(function (p) { return p.pct; }), 0.0];
@@ -130,9 +137,8 @@ function drawDeadlineGraph(canvas) {
     uniquePcts.forEach(function (pct) {
         const y = yOf(pct);
         // Always draw endpoints; skip middle ones if too close
-        if (pct !== 1.0 && pct !== 0.0 && y - lastLabelY < 14) return;
+        if (pct !== 1.0 && pct !== 0.0 && y - lastLabelY < m.fontSize + 4) return;
         lastLabelY = y;
-        ctx.fillStyle = textColor;
         const label = totalScore > 0
             ? (Math.round(pct * totalScore) + 'pt')
             : (Math.round(pct * 100) + '%');
@@ -142,24 +148,27 @@ function drawDeadlineGraph(canvas) {
     // X-axis date labels at each critical point
     ctx.textBaseline = 'top';
     let lastLabelX = -Infinity;
-    const minGap   = 52;
-    points.forEach(function (pt, i) {
+    const minGap   = m.fontSize * 5.2;
+    // The final point is the vertical drop to 0 % and shares its timestamp with
+    // the previous one, so it carries no label of its own.
+    const labelled = points.filter(function (pt) { return pt.label; });
+    labelled.forEach(function (pt, i) {
         const x       = xOf(pt.ts);
         const isFirst = (i === 0);
-        const isLast  = (i === points.length - 1);
+        const isLast  = (i === labelled.length - 1);
 
         // Enforce spacing; always show first and last
         if (!isFirst && !isLast && x - lastLabelX < minGap) return;
         // Skip intermediate labels that would crowd the final label
-        if (!isLast && (xOf(points[points.length - 1].ts) - x) < minGap && !isFirst) return;
+        if (!isLast && (xOf(labelled[labelled.length - 1].ts) - x) < minGap && !isFirst) return;
 
         ctx.textAlign = isFirst ? 'left' : (isLast ? 'right' : 'center');
         const labelX  = isFirst ? mL : (isLast ? mL + pW : x);
-        ctx.fillStyle = textColor;
+        ctx.fillStyle = color.text;
         ctx.fillText(pt.label, labelX, mT + pH + 5);
 
         // Tick mark
-        ctx.strokeStyle = axisColor;
+        ctx.strokeStyle = color.axis;
         ctx.lineWidth = 1;
         ctx.beginPath();
         ctx.moveTo(x, mT + pH);
@@ -169,21 +178,26 @@ function drawDeadlineGraph(canvas) {
         lastLabelX = x;
     });
 
-    // "Now" dashed marker — only shown while the deadline window is open
+    // "Now" dashed marker — only while the deadline window is open
     if (nowTs > minTs && nowTs < maxTs) {
         const nx = xOf(nowTs);
 
-        // Interpolate the currently achievable percentage
+        // Interpolate the currently achievable percentage. The last segment is
+        // the vertical cliff at `end` (zero width), so skip it to avoid /0.
+        // Uses a half-open interval [ts, nextTs) so that at the exact `end`
+        // instant the value is 0 %, matching get_current_percent_multiplier().
         let curPct = 0;
         for (let i = 0; i < points.length - 1; i++) {
-            if (nowTs >= points[i].ts && nowTs <= points[i + 1].ts) {
-                const t = (nowTs - points[i].ts) / (points[i + 1].ts - points[i].ts);
+            const span = points[i + 1].ts - points[i].ts;
+            if (span <= 0) continue;
+            if (nowTs >= points[i].ts && nowTs < points[i + 1].ts) {
+                const t = (nowTs - points[i].ts) / span;
                 curPct = points[i].pct + t * (points[i + 1].pct - points[i].pct);
                 break;
             }
         }
 
-        ctx.strokeStyle = nowColor;
+        ctx.strokeStyle = color.now;
         ctx.lineWidth = 1.5;
         ctx.setLineDash([4, 3]);
         ctx.beginPath();
@@ -193,56 +207,19 @@ function drawDeadlineGraph(canvas) {
         ctx.setLineDash([]);
 
         // Dot at current achievable score on the curve
-        ctx.fillStyle = nowColor;
+        ctx.fillStyle = color.now;
         ctx.beginPath();
         ctx.arc(nx, yOf(curPct), 4, 0, Math.PI * 2);
         ctx.fill();
     }
 
     // Dots at key breakpoints
-    ctx.fillStyle = dotColor;
+    ctx.fillStyle = color.dot;
     points.forEach(function (pt) {
         ctx.beginPath();
         ctx.arc(xOf(pt.ts), yOf(pt.pct), 3, 0, Math.PI * 2);
         ctx.fill();
     });
-
-    // Current percentage + "Next deadline in" — top-right corner of the plot area
-    if (nowTs >= minTs && nowTs <= maxTs) {
-        // Compute currently achievable percentage
-        let curPctLabel = 0;
-        for (let i = 0; i < points.length - 1; i++) {
-            if (nowTs >= points[i].ts && nowTs <= points[i + 1].ts) {
-                const t = (nowTs - points[i].ts) / (points[i + 1].ts - points[i].ts);
-                curPctLabel = points[i].pct + t * (points[i + 1].pct - points[i].pct);
-                break;
-            }
-        }
-
-        const pctDisplay = Math.round(curPctLabel * 100) + '%';
-
-        ctx.textAlign = 'right';
-        ctx.textBaseline = 'top';
-
-        // Percent label — mirrors .deadline-percent: font-weight:700, font-size:1rem
-        // color: var(--bs-body) = #212529 light / #dee2e6 dark
-        const bodyColor = isDark ? '#dee2e6' : '#212529';
-        ctx.font = 'bold 16px system-ui, -apple-system, sans-serif';
-        ctx.fillStyle = bodyColor;
-        ctx.fillText(pctDisplay, mL + pW, mT + 4);
-
-        // "Next deadline in" hint — mirrors .task-deadline__deadline-hint:
-        // font-size:0.75rem, font-style:italic, color:var(--bs-secondary-color)
-        // urgent overrides to .task-deadline__status.urgent color: #ef6c00
-        const next = points.find(function (pt) { return pt.ts > nowTs; });
-        if (next) {
-            const diffSec = next.ts - nowTs;
-            const isUrgent = diffSec < 86400;
-            ctx.font = 'italic 12px system-ui, -apple-system, sans-serif';
-            ctx.fillStyle = isUrgent ? '#ef6c00' : textColor;  // textColor = var(--bs-secondary-color)
-            ctx.fillText('Next deadline in: ' + _formatRemaining(diffSec), mL + pW, mT + 22);
-        }
-    }
 }
 
 function initDeadlineGraphs() {

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -93,12 +93,18 @@ function drawDeadlineGraph(canvas) {
         ctx.stroke();
     });
 
+    // Helper: traces the piecewise line through all points (shared by the fill
+    // and the stroke below, since both draw the same path).
+    function tracePiecewiseLine() {
+        ctx.moveTo(xOf(points[0].ts), yOf(points[0].pct));
+        for (let i = 1; i < points.length; i++) {
+            ctx.lineTo(xOf(points[i].ts), yOf(points[i].pct));
+        }
+    }
+
     // Filled area under the piecewise line
     ctx.beginPath();
-    ctx.moveTo(xOf(points[0].ts), yOf(points[0].pct));
-    for (let i = 1; i < points.length; i++) {
-        ctx.lineTo(xOf(points[i].ts), yOf(points[i].pct));
-    }
+    tracePiecewiseLine();
     ctx.lineTo(xOf(points[points.length - 1].ts), yOf(0));
     ctx.lineTo(xOf(points[0].ts), yOf(0));
     ctx.closePath();
@@ -107,10 +113,7 @@ function drawDeadlineGraph(canvas) {
 
     // Piecewise line
     ctx.beginPath();
-    ctx.moveTo(xOf(points[0].ts), yOf(points[0].pct));
-    for (let i = 1; i < points.length; i++) {
-        ctx.lineTo(xOf(points[i].ts), yOf(points[i].pct));
-    }
+    tracePiecewiseLine();
     ctx.strokeStyle = color.line;
     ctx.lineWidth = 2;
     ctx.lineJoin = 'round';

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -337,3 +337,20 @@ window.addEventListener('resize', function () {
     clearTimeout(_deadlineGraphResizeTimer);
     _deadlineGraphResizeTimer = setTimeout(initDeadlineGraphs, 120);
 });
+
+/*
+ * Canvas pixels are static once painted: they don't follow CSS variable
+ * changes the way normal DOM elements do. Colours are read once via
+ * getComputedStyle() in drawDeadlineGraph(), so switching the light/dark
+ * theme (base.html toggles `data-bs-theme` on <html>, possibly after this
+ * script's initial run) leaves stale colours baked into the canvas — most
+ * noticeably dark axis/grid text left over from the light theme. Watch the
+ * attribute and repaint whenever it changes so the graph always matches the
+ * active theme.
+ */
+new MutationObserver(function () {
+    initDeadlineGraphs();
+}).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-bs-theme']
+});

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -154,51 +154,50 @@ function drawDeadlineGraph(canvas) {
         ctx.fillText(fmtPct(pct), mL - 4, cy);
     });
 
-    // X-axis date labels at each critical point.
+    // X-axis labels. Each carries a time only when the deadline is not at the
+    // end of the day (see the template), so widths are mixed and collisions are
+    // resolved from the measured extents rather than one global gap.
     // The final point is the vertical drop to 0 % and shares its timestamp with
     // the previous one, so it carries no label of its own.
     ctx.textBaseline = 'top';
     const labelled = points.filter(function (pt) { return pt.label; });
+    const PAD = 4;
 
-    // Use the full "DD.MM HH:MM" form only if every label would still fit,
-    // otherwise fall back to the compact "DD.MM".
-    const widest = Math.max.apply(null, labelled.map(function (pt) {
-        return ctx.measureText(pt.full || pt.label).width;
-    }));
-    const useFull = labelled.length > 1
-        && widest * labelled.length <= pW
-        && labelled.every(function (pt) { return pt.full; });
-    const textOf = function (pt) { return useFull ? pt.full : pt.label; };
+    // Resolve each label's drawing position and horizontal extent up front.
+    const boxes = labelled.map(function (pt, i) {
+        const x     = xOf(pt.ts);
+        const w     = ctx.measureText(pt.label).width;
+        const first = (i === 0);
+        const last  = (i === labelled.length - 1);
+        const align = first ? 'left' : (last ? 'right' : 'center');
+        const drawX = first ? mL : (last ? mL + pW : x);
+        const left  = align === 'left' ? drawX : (align === 'right' ? drawX - w : drawX - w / 2);
+        return { pt: pt, x: x, align: align, drawX: drawX, left: left, right: left + w, first: first, last: last };
+    });
 
-    const minGap = Math.max.apply(null, labelled.map(function (pt) {
-        return ctx.measureText(textOf(pt)).width;
-    })) + 6;
+    // The first and last labels anchor the axis and are always drawn; drop any
+    // intermediate label that would overlap an already-placed neighbour.
+    const placed = boxes.filter(function (b) { return b.first || b.last; });
+    boxes.forEach(function (b) {
+        if (b.first || b.last) return;
+        const clash = placed.some(function (p) {
+            return b.left - PAD < p.right && b.right + PAD > p.left;
+        });
+        if (!clash) placed.push(b);
+    });
 
-    let lastLabelX = -Infinity;
-    labelled.forEach(function (pt, i) {
-        const x       = xOf(pt.ts);
-        const isFirst = (i === 0);
-        const isLast  = (i === labelled.length - 1);
-
-        // Enforce spacing; always show first and last
-        if (!isFirst && !isLast && x - lastLabelX < minGap) return;
-        // Skip intermediate labels that would crowd the final label
-        if (!isLast && (xOf(labelled[labelled.length - 1].ts) - x) < minGap && !isFirst) return;
-
-        ctx.textAlign = isFirst ? 'left' : (isLast ? 'right' : 'center');
-        const labelX  = isFirst ? mL : (isLast ? mL + pW : x);
+    placed.forEach(function (b) {
+        ctx.textAlign = b.align;
         ctx.fillStyle = color.text;
-        ctx.fillText(textOf(pt), labelX, mT + pH + 2);
+        ctx.fillText(b.pt.label, b.drawX, mT + pH + 2);
 
         // Tick mark
         ctx.strokeStyle = color.axis;
         ctx.lineWidth = 1;
         ctx.beginPath();
-        ctx.moveTo(x, mT + pH);
-        ctx.lineTo(x, mT + pH + 3);
+        ctx.moveTo(b.x, mT + pH);
+        ctx.lineTo(b.x, mT + pH + 3);
         ctx.stroke();
-
-        lastLabelX = x;
     });
 
     // "Now" dashed marker — only while the deadline window is open
@@ -236,13 +235,94 @@ function drawDeadlineGraph(canvas) {
         ctx.fill();
     }
 
-    // Dots at key breakpoints
+    // Dots at key breakpoints. Their positions are cached on the element so the
+    // hover handler can map a cursor position back to a deadline.
     ctx.fillStyle = color.dot;
+    const hotspots = [];
     points.forEach(function (pt) {
+        const cx = xOf(pt.ts), cy = yOf(pt.pct);
         ctx.beginPath();
-        ctx.arc(xOf(pt.ts), yOf(pt.pct), 3, 0, Math.PI * 2);
+        ctx.arc(cx, cy, 3, 0, Math.PI * 2);
         ctx.fill();
+        if (pt.date) hotspots.push({ x: cx, y: cy, pt: pt });
     });
+    canvas._deadlineHotspots = hotspots;
+
+    attachDeadlineTooltip(canvas);
+}
+
+/**
+ * Shows a tippy tooltip with the full date/time when the cursor is over one of
+ * the breakpoint dots. Mirrors the calendar/clock icon markup used by
+ * .task-deadline__deadline-time on the non-interpolated planks.
+ */
+function attachDeadlineTooltip(canvas) {
+    if (typeof tippy !== 'function') return;
+
+    // Create the singleton instance once per canvas; later redraws (resize)
+    // only refresh the cached hotspot coordinates.
+    if (!canvas._deadlineTippy) {
+        canvas._deadlineTippy = tippy(canvas, {
+            trigger: 'manual',
+            arrow: false,
+            allowHTML: true,
+            placement: 'top',
+            offset: [0, 8],
+            content: ''
+        });
+
+        const HIT_RADIUS = 7;
+
+        canvas.addEventListener('mousemove', function (event) {
+            const spots = canvas._deadlineHotspots || [];
+            const rect  = canvas.getBoundingClientRect();
+            const mx    = event.clientX - rect.left;
+            const my    = event.clientY - rect.top;
+
+            let hit = null;
+            let bestDist = Infinity;
+            spots.forEach(function (s) {
+                const d = Math.hypot(s.x - mx, s.y - my);
+                if (d <= HIT_RADIUS && d < bestDist) {
+                    bestDist = d;
+                    hit = s;
+                }
+            });
+
+            const tip = canvas._deadlineTippy;
+            if (!hit) {
+                tip.hide();
+                canvas.style.cursor = '';
+                return;
+            }
+
+            canvas.style.cursor = 'pointer';
+            tip.setContent(
+                '<span class="deadline-graph-tip">' +
+                    '<span><i class="far fa-calendar"></i> ' + hit.pt.date + '</span>' +
+                    '<span><i class="far fa-clock"></i> ' + hit.pt.time +
+                        (hit.pt.tz ? ' ' + hit.pt.tz : '') + '</span>' +
+                '</span>'
+            );
+            // Anchor the tooltip to the dot rather than the cursor.
+            tip.setProps({
+                getReferenceClientRect: function () {
+                    const r = canvas.getBoundingClientRect();
+                    return {
+                        width: 0, height: 0,
+                        top: r.top + hit.y, bottom: r.top + hit.y,
+                        left: r.left + hit.x, right: r.left + hit.x
+                    };
+                }
+            });
+            tip.show();
+        });
+
+        canvas.addEventListener('mouseleave', function () {
+            canvas._deadlineTippy.hide();
+            canvas.style.cursor = '';
+        });
+    }
 }
 
 function initDeadlineGraphs() {

--- a/manytask/manytask/static/js/deadline-graph.js
+++ b/manytask/manytask/static/js/deadline-graph.js
@@ -32,8 +32,27 @@ function drawDeadlineGraph(canvas) {
     const ctx = canvas.getContext('2d');
     ctx.scale(dpr, dpr);
 
-    const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'
-                || window.matchMedia('(prefers-color-scheme: dark)').matches;
+    // Detect dark mode from the page theme attribute first; fall back to the
+    // canvas's actual background luminance so OS preference never overrides the
+    // explicit Bootstrap theme setting.
+    const bsTheme = document.documentElement.getAttribute('data-bs-theme');
+    let isDark;
+    if (bsTheme === 'dark') {
+        isDark = true;
+    } else if (bsTheme === 'light') {
+        isDark = false;
+    } else {
+        // No explicit theme — read the canvas background colour to decide.
+        const bg = getComputedStyle(canvas).backgroundColor;
+        const m  = bg.match(/\d+/g);
+        if (m && m.length >= 3) {
+            // Perceived luminance (rec. 709)
+            const lum = 0.2126 * parseInt(m[0]) + 0.7152 * parseInt(m[1]) + 0.0722 * parseInt(m[2]);
+            isDark = lum < 128;
+        } else {
+            isDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        }
+    }
 
     const textColor = isDark ? '#adb5bd' : '#555';
     const axisColor = isDark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.18)';
@@ -188,17 +207,41 @@ function drawDeadlineGraph(canvas) {
         ctx.fill();
     });
 
-    // "Next deadline in" hint — drawn inside the bottom-right of the plot area
-    const next = points.find(function (pt) { return pt.ts > nowTs; });
-    if (next) {
-        const diffSec = next.ts - nowTs;
-        const isUrgent = diffSec < 86400;
-        const hintText = 'Next deadline in: ' + _formatRemaining(diffSec);
-        ctx.font = 'italic 10px system-ui, -apple-system, sans-serif';
+    // Current percentage + "Next deadline in" — top-right corner of the plot area
+    if (nowTs >= minTs && nowTs <= maxTs) {
+        // Compute currently achievable percentage
+        let curPctLabel = 0;
+        for (let i = 0; i < points.length - 1; i++) {
+            if (nowTs >= points[i].ts && nowTs <= points[i + 1].ts) {
+                const t = (nowTs - points[i].ts) / (points[i + 1].ts - points[i].ts);
+                curPctLabel = points[i].pct + t * (points[i + 1].pct - points[i].pct);
+                break;
+            }
+        }
+
+        const pctDisplay = Math.round(curPctLabel * 100) + '%';
+
         ctx.textAlign = 'right';
         ctx.textBaseline = 'top';
-        ctx.fillStyle = isUrgent ? nowColor : textColor;
-        ctx.fillText(hintText, mL + pW, mT + 4);
+
+        // Percent label — mirrors .deadline-percent: font-weight:700, font-size:1rem
+        // color: var(--bs-body) = #212529 light / #dee2e6 dark
+        const bodyColor = isDark ? '#dee2e6' : '#212529';
+        ctx.font = 'bold 16px system-ui, -apple-system, sans-serif';
+        ctx.fillStyle = bodyColor;
+        ctx.fillText(pctDisplay, mL + pW, mT + 4);
+
+        // "Next deadline in" hint — mirrors .task-deadline__deadline-hint:
+        // font-size:0.75rem, font-style:italic, color:var(--bs-secondary-color)
+        // urgent overrides to .task-deadline__status.urgent color: #ef6c00
+        const next = points.find(function (pt) { return pt.ts > nowTs; });
+        if (next) {
+            const diffSec = next.ts - nowTs;
+            const isUrgent = diffSec < 86400;
+            ctx.font = 'italic 12px system-ui, -apple-system, sans-serif';
+            ctx.fillStyle = isUrgent ? '#ef6c00' : textColor;  // textColor = var(--bs-secondary-color)
+            ctx.fillText('Next deadline in: ' + _formatRemaining(diffSec), mL + pW, mT + 22);
+        }
     }
 }
 

--- a/manytask/manytask/templates/tasks.html
+++ b/manytask/manytask/templates/tasks.html
@@ -49,7 +49,7 @@
                     <span class="score fs-6 d-none d-sm-block">Score: {{ solved_group_score }}/{{ total_group_score }}</span>
                 </div>
 
-                <div class="task-deadlines">
+                <div class="task-deadlines {% if deadlines_type.value == 'interpolate' %}task-deadlines--graph{% endif %}">
                     {% if group.end < now %}
                         <div class="task-deadline task-group__expired-notice expired-tooltip"
                              data-tippy-content="{{ group.end.strftime('%Z') }}" id="expiredNotice-{{ loop.index }}">
@@ -57,41 +57,59 @@
                             <span>Expired: {{ group.end.strftime('%d.%m.%Y %H:%M') }}</span>
                         </div>
                     {% endif %}
-                    {% set last = namespace(start=group.start) %}
-                    {% for deadline, percent in group.get_displayed_deadlines(deadlines_type) %}
-                        {% set is_less_than_day = deadline.timestamp() - now.timestamp() < 86400 %}
-                        {% set is_expired = deadline < now %}
-                        <div class="task-deadline {% if deadline < now %}passed-deadline{% endif %}"
-                             {% if deadline < now %}style="display: none;"{% endif %}>
-                            <div class="deadline-header">
-                                <span class="deadline-percent">{{ (percent*100)|round|int }}%</span>
-                                <span class="task-deadline__status {{ 'expired' if is_expired else ('urgent' if is_less_than_day else 'active') }}">
-                                    {{ 'Expired' if is_expired else ('Urgent' if is_less_than_day else 'Active') }}
-                                </span>
-                            </div>
-                            <div class="task-deadline__progress">
-                                <div class="task-deadline__progress-bar {{ 'expired' if is_expired else ('urgent' if is_less_than_day else '') }}"
-                                     style="width: {{ 100 if deadline < now else (0 if last.start > now else ((now.timestamp() - last.start.timestamp()) / (deadline.timestamp() - last.start.timestamp()) * 100) | abs | int) }}%">
+
+                    {% if deadlines_type.value == 'interpolate' %}
+                        {# Build graph points: start(100%) → each step → end(0%) #}
+                        {% set graph_pts = [] %}
+                        {% set end_dt = group.get_deadline(group.end) %}
+                        {% set _ = graph_pts.append({'ts': group.start.timestamp(), 'pct': 1.0, 'label': group.start.strftime('%d.%m %H:%M')}) %}
+                        {% for percent, date_or_delta in group.steps.items() %}
+                            {% set step_dt = group.get_deadline(date_or_delta) %}
+                            {% set _ = graph_pts.append({'ts': step_dt.timestamp(), 'pct': percent, 'label': step_dt.strftime('%d.%m %H:%M')}) %}
+                        {% endfor %}
+                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': 0.0, 'label': end_dt.strftime('%d.%m %H:%M')}) %}
+                        <canvas class="deadline-graph-canvas"
+                                data-points='{{ graph_pts | tojson }}'
+                                data-now="{{ now.timestamp() }}"
+                                data-score="{{ total_group_score }}"
+                                data-expired="{{ 'true' if end_dt < now else 'false' }}"></canvas>
+                    {% else %}
+                        {% set last = namespace(start=group.start) %}
+                        {% for deadline, percent in group.get_displayed_deadlines(deadlines_type) %}
+                            {% set is_less_than_day = deadline.timestamp() - now.timestamp() < 86400 %}
+                            {% set is_expired = deadline < now %}
+                            <div class="task-deadline {% if deadline < now %}passed-deadline{% endif %}"
+                                 {% if deadline < now %}style="display: none;"{% endif %}>
+                                <div class="deadline-header">
+                                    <span class="deadline-percent">{{ (percent*100)|round|int }}%</span>
+                                    <span class="task-deadline__status {{ 'expired' if is_expired else ('urgent' if is_less_than_day else 'active') }}">
+                                        {{ 'Expired' if is_expired else ('Urgent' if is_less_than_day else 'Active') }}
+                                    </span>
+                                </div>
+                                <div class="task-deadline__progress">
+                                    <div class="task-deadline__progress-bar {{ 'expired' if is_expired else ('urgent' if is_less_than_day else '') }}"
+                                         style="width: {{ 100 if deadline < now else (0 if last.start > now else ((now.timestamp() - last.start.timestamp()) / (deadline.timestamp() - last.start.timestamp()) * 100) | abs | int) }}%">
+                                    </div>
+                                </div>
+
+                                <div class="task-deadline__deadline-time card-tooltip"
+                                     data-tippy-content="{{ deadline.strftime('%Z') }}">
+                                    <span><i class="far fa-calendar"></i>
+                                    <span>{{ deadline.strftime('%d.%m.%Y') }}</span></span>
+                                    <span>
+                                    <i class="far fa-clock"></i>
+                                    <span>{{ deadline.strftime('%H:%M') }}</span>
+                                    </span>
+                                </div>
+
+                                <div class="task-deadline__deadline-hint">
+                                    {% set remained = (((deadline - now).seconds / 3600)|int|string + ' h.') if is_less_than_day else ((deadline - now).days|string + ' d.') %}
+                                    {{ '' if deadline < now else 'Deadline expires in: ' + remained }}
                                 </div>
                             </div>
-
-                            <div class="task-deadline__deadline-time card-tooltip"
-                                 data-tippy-content="{{ deadline.strftime('%Z') }}">
-                                <span><i class="far fa-calendar"></i>
-                                <span>{{ deadline.strftime('%d.%m.%Y') }}</span></span>
-                                <span>
-                                <i class="far fa-clock"></i>
-                                <span>{{ deadline.strftime('%H:%M') }}</span>
-                                </span>
-                            </div>
-
-                            <div class="task-deadline__deadline-hint">
-                                {% set remained = (((deadline - now).seconds / 3600)|int|string + ' h.') if is_less_than_day else ((deadline - now).days|string + ' d.') %}
-                                {{ '' if deadline < now else 'Deadline expires in: ' + remained }}
-                            </div>
-                        </div>
-                        {% set last.start = deadline %}
-                    {% endfor %}
+                            {% set last.start = deadline %}
+                        {% endfor %}
+                    {% endif %}
                 </div>
             </div>
             <hr class="dashed mt-1">
@@ -147,6 +165,7 @@
 
     <script src="https://unpkg.com/@popperjs/core@2"></script>
     <script src="https://unpkg.com/tippy.js@6"></script>
+    <script src="{{ url_for('static', filename='js/deadline-graph.js') }}"></script>
     <script>
         tippy('.card-tooltip', {
             arrow: false,

--- a/manytask/manytask/templates/tasks.html
+++ b/manytask/manytask/templates/tasks.html
@@ -69,18 +69,29 @@
                         {% set end_dt = group.get_deadline(group.end) %}
                         {% set graph_pts = [] %}
                         {% set crit_dates = [] %}
-                        {% set _ = graph_pts.append({'ts': group.start.timestamp(), 'pct': 1.0, 'label': group.start.strftime('%d.%m'), 'full': group.start.strftime('%d.%m %H:%M')}) %}
+                        {#
+                          `label` is the axis text, `date` / `time` / `tz` feed the
+                          hover tooltip on each dot.
+
+                          The axis label carries the time only when it is not the
+                          end of the day — a 23:59 deadline means "that date", so
+                          printing the time just adds clutter. The first point (the
+                          group start) never shows a time: it is not a deadline.
+                        #}
+                        {% set _ = graph_pts.append({'ts': group.start.timestamp(), 'pct': 1.0, 'label': group.start.strftime('%d.%m'), 'date': group.start.strftime('%d.%m.%Y'), 'time': group.start.strftime('%H:%M'), 'tz': group.start.strftime('%Z')}) %}
                         {% set _ = crit_dates.append(group.start) %}
                         {% set lastpct = namespace(v=1.0) %}
                         {% for percent, date_or_delta in group.steps.items() %}
                             {% set step_dt = group.get_deadline(date_or_delta) %}
-                            {% set _ = graph_pts.append({'ts': step_dt.timestamp(), 'pct': percent, 'label': step_dt.strftime('%d.%m'), 'full': step_dt.strftime('%d.%m %H:%M')}) %}
+                            {% set step_label = step_dt.strftime('%d.%m') if step_dt.strftime('%H:%M') == '23:59' else step_dt.strftime('%d.%m %H:%M') %}
+                            {% set _ = graph_pts.append({'ts': step_dt.timestamp(), 'pct': percent, 'label': step_label, 'date': step_dt.strftime('%d.%m.%Y'), 'time': step_dt.strftime('%H:%M'), 'tz': step_dt.strftime('%Z')}) %}
                             {% set _ = crit_dates.append(step_dt) %}
                             {% set lastpct.v = percent %}
                         {% endfor %}
                         {# flat plateau up to `end`, then the vertical drop to zero #}
-                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': lastpct.v, 'label': end_dt.strftime('%d.%m'), 'full': end_dt.strftime('%d.%m %H:%M')}) %}
-                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': 0.0, 'label': ''}) %}
+                        {% set end_label = end_dt.strftime('%d.%m') if end_dt.strftime('%H:%M') == '23:59' else end_dt.strftime('%d.%m %H:%M') %}
+                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': lastpct.v, 'label': end_label, 'date': end_dt.strftime('%d.%m.%Y'), 'time': end_dt.strftime('%H:%M'), 'tz': end_dt.strftime('%Z')}) %}
+                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': 0.0, 'label': '', 'date': end_dt.strftime('%d.%m.%Y'), 'time': end_dt.strftime('%H:%M'), 'tz': end_dt.strftime('%Z')}) %}
                         {% set _ = crit_dates.append(end_dt) %}
 
                         {# Next upcoming critical date, and derived status — same semantics as the cards #}

--- a/manytask/manytask/templates/tasks.html
+++ b/manytask/manytask/templates/tasks.html
@@ -69,17 +69,17 @@
                         {% set end_dt = group.get_deadline(group.end) %}
                         {% set graph_pts = [] %}
                         {% set crit_dates = [] %}
-                        {% set _ = graph_pts.append({'ts': group.start.timestamp(), 'pct': 1.0, 'label': group.start.strftime('%d.%m %H:%M')}) %}
+                        {% set _ = graph_pts.append({'ts': group.start.timestamp(), 'pct': 1.0, 'label': group.start.strftime('%d.%m'), 'full': group.start.strftime('%d.%m %H:%M')}) %}
                         {% set _ = crit_dates.append(group.start) %}
                         {% set lastpct = namespace(v=1.0) %}
                         {% for percent, date_or_delta in group.steps.items() %}
                             {% set step_dt = group.get_deadline(date_or_delta) %}
-                            {% set _ = graph_pts.append({'ts': step_dt.timestamp(), 'pct': percent, 'label': step_dt.strftime('%d.%m %H:%M')}) %}
+                            {% set _ = graph_pts.append({'ts': step_dt.timestamp(), 'pct': percent, 'label': step_dt.strftime('%d.%m'), 'full': step_dt.strftime('%d.%m %H:%M')}) %}
                             {% set _ = crit_dates.append(step_dt) %}
                             {% set lastpct.v = percent %}
                         {% endfor %}
                         {# flat plateau up to `end`, then the vertical drop to zero #}
-                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': lastpct.v, 'label': end_dt.strftime('%d.%m %H:%M')}) %}
+                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': lastpct.v, 'label': end_dt.strftime('%d.%m'), 'full': end_dt.strftime('%d.%m %H:%M')}) %}
                         {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': 0.0, 'label': ''}) %}
                         {% set _ = crit_dates.append(end_dt) %}
 
@@ -94,8 +94,17 @@
                         {% set cur_pct = 1.0 if now < group.start else group.get_current_percent_multiplier(now, deadlines_type) %}
 
                         <div class="task-deadline task-deadline--graph {{ graph_status }}">
+                            {# The hint sits in the header row: it is shorter than the status
+                               pill that already sets the row height, so it costs no vertical
+                               space and frees a whole row for the graph. #}
                             <div class="deadline-header">
                                 <span class="deadline-percent">{{ (cur_pct*100)|round|int }}%</span>
+                                <span class="task-deadline__deadline-hint">
+                                    {% if nx.dt is not none %}
+                                        {% set remained = (((nx.dt - now).seconds / 3600)|int|string + ' h.') if is_less_than_day else ((nx.dt - now).days|string + ' d.') %}
+                                        Next deadline in: {{ remained }}
+                                    {% endif %}
+                                </span>
                                 <span class="task-deadline__status {{ graph_status }}">
                                     {{ graph_status|title }}
                                 </span>
@@ -103,15 +112,7 @@
 
                             <canvas class="deadline-graph-canvas"
                                     data-points='{{ graph_pts | tojson }}'
-                                    data-now="{{ now.timestamp() }}"
-                                    data-score="{{ total_group_score }}"></canvas>
-
-                            <div class="task-deadline__deadline-hint">
-                                {% if nx.dt is not none %}
-                                    {% set remained = (((nx.dt - now).seconds / 3600)|int|string + ' h.') if is_less_than_day else ((nx.dt - now).days|string + ' d.') %}
-                                    Next deadline in: {{ remained }}
-                                {% endif %}
-                            </div>
+                                    data-now="{{ now.timestamp() }}"></canvas>
                         </div>
                     {% else %}
                         {% set last = namespace(start=group.start) %}

--- a/manytask/manytask/templates/tasks.html
+++ b/manytask/manytask/templates/tasks.html
@@ -59,20 +59,60 @@
                     {% endif %}
 
                     {% if deadlines_type.value == 'interpolate' %}
-                        {# Build graph points: start(100%) → each step → end(0%) #}
-                        {% set graph_pts = [] %}
+                        {#
+                          Build the graph points to match get_current_percent_multiplier():
+                            • linear interpolation between (start, 100%) and each step
+                            • after the LAST step the score stays FLAT at that percentage
+                            • at `end` it drops vertically to 0%
+                          So the point list is: start → steps… → (end, last_pct) → (end, 0)
+                        #}
                         {% set end_dt = group.get_deadline(group.end) %}
+                        {% set graph_pts = [] %}
+                        {% set crit_dates = [] %}
                         {% set _ = graph_pts.append({'ts': group.start.timestamp(), 'pct': 1.0, 'label': group.start.strftime('%d.%m %H:%M')}) %}
+                        {% set _ = crit_dates.append(group.start) %}
+                        {% set lastpct = namespace(v=1.0) %}
                         {% for percent, date_or_delta in group.steps.items() %}
                             {% set step_dt = group.get_deadline(date_or_delta) %}
                             {% set _ = graph_pts.append({'ts': step_dt.timestamp(), 'pct': percent, 'label': step_dt.strftime('%d.%m %H:%M')}) %}
+                            {% set _ = crit_dates.append(step_dt) %}
+                            {% set lastpct.v = percent %}
                         {% endfor %}
-                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': 0.0, 'label': end_dt.strftime('%d.%m %H:%M')}) %}
-                        <canvas class="deadline-graph-canvas"
-                                data-points='{{ graph_pts | tojson }}'
-                                data-now="{{ now.timestamp() }}"
-                                data-score="{{ total_group_score }}"
-                                data-expired="{{ 'true' if end_dt < now else 'false' }}"></canvas>
+                        {# flat plateau up to `end`, then the vertical drop to zero #}
+                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': lastpct.v, 'label': end_dt.strftime('%d.%m %H:%M')}) %}
+                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': 0.0, 'label': ''}) %}
+                        {% set _ = crit_dates.append(end_dt) %}
+
+                        {# Next upcoming critical date, and derived status — same semantics as the cards #}
+                        {% set nx = namespace(dt=none) %}
+                        {% for d in crit_dates %}
+                            {% if nx.dt is none and d > now %}{% set nx.dt = d %}{% endif %}
+                        {% endfor %}
+                        {% set is_expired = end_dt < now %}
+                        {% set is_less_than_day = nx.dt is not none and (nx.dt.timestamp() - now.timestamp()) < 86400 %}
+                        {% set graph_status = 'expired' if is_expired else ('urgent' if is_less_than_day else 'active') %}
+                        {% set cur_pct = 1.0 if now < group.start else group.get_current_percent_multiplier(now, deadlines_type) %}
+
+                        <div class="task-deadline task-deadline--graph {{ graph_status }}">
+                            <div class="deadline-header">
+                                <span class="deadline-percent">{{ (cur_pct*100)|round|int }}%</span>
+                                <span class="task-deadline__status {{ graph_status }}">
+                                    {{ graph_status|title }}
+                                </span>
+                            </div>
+
+                            <canvas class="deadline-graph-canvas"
+                                    data-points='{{ graph_pts | tojson }}'
+                                    data-now="{{ now.timestamp() }}"
+                                    data-score="{{ total_group_score }}"></canvas>
+
+                            <div class="task-deadline__deadline-hint">
+                                {% if nx.dt is not none %}
+                                    {% set remained = (((nx.dt - now).seconds / 3600)|int|string + ' h.') if is_less_than_day else ((nx.dt - now).days|string + ' d.') %}
+                                    Next deadline in: {{ remained }}
+                                {% endif %}
+                            </div>
+                        </div>
                     {% else %}
                         {% set last = namespace(start=group.start) %}
                         {% for deadline, percent in group.get_displayed_deadlines(deadlines_type) %}

--- a/manytask/manytask/templates/tasks.html
+++ b/manytask/manytask/templates/tasks.html
@@ -59,70 +59,21 @@
                     {% endif %}
 
                     {% if deadlines_type.value == 'interpolate' %}
-                        {#
-                          Build the graph points to match get_current_percent_multiplier():
-                            • linear interpolation between (start, 100%) and each step
-                            • after the LAST step the score stays FLAT at that percentage
-                            • at `end` it drops vertically to 0%
-                          So the point list is: start → steps… → (end, last_pct) → (end, 0)
-                        #}
-                        {% set end_dt = group.get_deadline(group.end) %}
-                        {% set graph_pts = [] %}
-                        {% set crit_dates = [] %}
-                        {#
-                          `label` is the axis text, `date` / `time` / `tz` feed the
-                          hover tooltip on each dot.
-
-                          The axis label carries the time only when it is not the
-                          end of the day — a 23:59 deadline means "that date", so
-                          printing the time just adds clutter. The first point (the
-                          group start) never shows a time: it is not a deadline.
-                        #}
-                        {% set _ = graph_pts.append({'ts': group.start.timestamp(), 'pct': 1.0, 'label': group.start.strftime('%d.%m'), 'date': group.start.strftime('%d.%m.%Y'), 'time': group.start.strftime('%H:%M'), 'tz': group.start.strftime('%Z')}) %}
-                        {% set _ = crit_dates.append(group.start) %}
-                        {% set lastpct = namespace(v=1.0) %}
-                        {% for percent, date_or_delta in group.steps.items() %}
-                            {% set step_dt = group.get_deadline(date_or_delta) %}
-                            {% set step_label = step_dt.strftime('%d.%m') if step_dt.strftime('%H:%M') == '23:59' else step_dt.strftime('%d.%m %H:%M') %}
-                            {% set _ = graph_pts.append({'ts': step_dt.timestamp(), 'pct': percent, 'label': step_label, 'date': step_dt.strftime('%d.%m.%Y'), 'time': step_dt.strftime('%H:%M'), 'tz': step_dt.strftime('%Z')}) %}
-                            {% set _ = crit_dates.append(step_dt) %}
-                            {% set lastpct.v = percent %}
-                        {% endfor %}
-                        {# flat plateau up to `end`, then the vertical drop to zero #}
-                        {% set end_label = end_dt.strftime('%d.%m') if end_dt.strftime('%H:%M') == '23:59' else end_dt.strftime('%d.%m %H:%M') %}
-                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': lastpct.v, 'label': end_label, 'date': end_dt.strftime('%d.%m.%Y'), 'time': end_dt.strftime('%H:%M'), 'tz': end_dt.strftime('%Z')}) %}
-                        {% set _ = graph_pts.append({'ts': end_dt.timestamp(), 'pct': 0.0, 'label': '', 'date': end_dt.strftime('%d.%m.%Y'), 'time': end_dt.strftime('%H:%M'), 'tz': end_dt.strftime('%Z')}) %}
-                        {% set _ = crit_dates.append(end_dt) %}
-
-                        {# Next upcoming critical date, and derived status — same semantics as the cards #}
-                        {% set nx = namespace(dt=none) %}
-                        {% for d in crit_dates %}
-                            {% if nx.dt is none and d > now %}{% set nx.dt = d %}{% endif %}
-                        {% endfor %}
-                        {% set is_expired = end_dt < now %}
-                        {% set is_less_than_day = nx.dt is not none and (nx.dt.timestamp() - now.timestamp()) < 86400 %}
-                        {% set graph_status = 'expired' if is_expired else ('urgent' if is_less_than_day else 'active') %}
-                        {% set cur_pct = 1.0 if now < group.start else group.get_current_percent_multiplier(now, deadlines_type) %}
-
-                        <div class="task-deadline task-deadline--graph {{ graph_status }}">
+                        {% set graph = group.get_graph_data(now, deadlines_type) %}
+                        <div class="task-deadline task-deadline--graph {{ graph.status }}">
                             {# The hint sits in the header row: it is shorter than the status
                                pill that already sets the row height, so it costs no vertical
                                space and frees a whole row for the graph. #}
                             <div class="deadline-header">
-                                <span class="deadline-percent">{{ (cur_pct*100)|round|int }}%</span>
-                                <span class="task-deadline__deadline-hint">
-                                    {% if nx.dt is not none %}
-                                        {% set remained = (((nx.dt - now).seconds / 3600)|int|string + ' h.') if is_less_than_day else ((nx.dt - now).days|string + ' d.') %}
-                                        Next deadline in: {{ remained }}
-                                    {% endif %}
-                                </span>
-                                <span class="task-deadline__status {{ graph_status }}">
-                                    {{ graph_status|title }}
+                                <span class="deadline-percent">{{ (graph.percent*100)|round|int }}%</span>
+                                <span class="task-deadline__deadline-hint">{{ graph.hint }}</span>
+                                <span class="task-deadline__status {{ graph.status }}">
+                                    {{ graph.status|title }}
                                 </span>
                             </div>
 
                             <canvas class="deadline-graph-canvas"
-                                    data-points='{{ graph_pts | tojson }}'
+                                    data-points='{{ graph.points | tojson }}'
                                     data-now="{{ now.timestamp() }}"></canvas>
                         </div>
                     {% else %}
@@ -155,8 +106,7 @@
                                 </div>
 
                                 <div class="task-deadline__deadline-hint">
-                                    {% set remained = (((deadline - now).seconds / 3600)|int|string + ' h.') if is_less_than_day else ((deadline - now).days|string + ' d.') %}
-                                    {{ '' if deadline < now else 'Deadline expires in: ' + remained }}
+                                    {{ '' if deadline < now else 'Deadline expires in: ' + format_remaining(deadline, now) }}
                                 </div>
                             </div>
                             {% set last.start = deadline %}

--- a/manytask/manytask/utils/generic.py
+++ b/manytask/manytask/utils/generic.py
@@ -2,6 +2,7 @@ import html
 import logging
 import re
 import secrets
+from datetime import datetime
 from http import HTTPStatus
 from typing import Any, Callable
 
@@ -19,6 +20,17 @@ def calculate_percent(total_score: float, max_score: float) -> float:
     if max_score <= 0:
         return 0.0
     return round(total_score * 100.0 / max_score, 1)
+
+
+SECONDS_PER_DAY = 86400
+
+
+def format_remaining(deadline: datetime, now: datetime) -> str:
+    """Format the time left until `deadline` as e.g. '5 h.' or '3 d.' (used by tasks.html)."""
+    delta = deadline - now
+    if delta.total_seconds() < SECONDS_PER_DAY:
+        return f"{int(delta.seconds / 3600)} h."
+    return f"{delta.days} d."
 
 
 def sanitize_log_data(data: str | None) -> str | None:


### PR DESCRIPTION
Interpolate deadlines allow the available points to decay slowly with time. Although it is liked by the students it is often hard to understand how much points one can get at a given time. This change makes the representation of the interpolate deadlines into a graph, that should be easier to understand.

Closes #1073