### PR TITLE
Draft: Feat/enroll api

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,3 +16,22 @@ However, you can implement your own checker just use the Manytask api. Note that
 | GET    | `/api/<course_name>/ping`                 | validate course-token without side effects        | -                                                                         | -                                                                                                                     | `course`, `ok`                                                       |
 | GET    | `/api/<course_name>/is_admin`             | check whether RMS user is a course admin          | `rms_username` (query string, RMS/GitLab login)                           | -                                                                                                                     | `rms_username`, `is_admin`                                           |
 | GET    | `/api/<course_name>/deadlines`            | machine-readable list of tasks with deadlines     | -                                                                         | -                                                                                                                     | `course`, `tasks` (list of `{task_name, group, deadline, score, is_bonus, is_large}`) |
+| POST   | `/api/<course_name>/enroll`               | enroll a manytask user on the course (create their `users_on_courses` row and RMS project); user must already exist, see `POST /api/users` below | `username` | `course_admin` (bool, default `false`) | `username`, `course`, `is_course_admin`, `project` (`<students_group>/<username>`) |
+
+## Instance-scoped API (external registration)
+
+`POST /api/users` is instance-scoped (not tied to a course), so it lives directly under `/api` and is
+authorized differently: it requires an `Authorization: Bearer <token>` header containing
+`MANYTASK_API_TOKEN` (set as an environment variable for the whole manytask instance). If
+`MANYTASK_API_TOKEN` is not set, the endpoint always returns 403.
+
+`POST /api/<course_name>/enroll` (see the table above) also accepts `MANYTASK_API_TOKEN` in addition to
+the course token, so an external registration flow (e.g. a bot) can enroll a user on a course using only
+the instance token, without knowing any individual course's token.
+
+| method | api endpoint  | description                                                                 | required in body                                          | optional in body                                                                     | return                                              |
+|--------|---------------|------------------------------------------------------------------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------------|------------------------------------------------------|
+| POST   | `/api/users`  | create or update a manytask user from an already-existing RMS (GitLab) user | exactly one of `rms_id`, `username` (to look up the RMS user) | `first_name`, `last_name` (derived from the RMS user's name if omitted), `auth_id` (defaults to `rms_id` when `rms == gitlab`) | `user_id`, `username`, `rms_id`, `created` |
+
+Calling `POST /api/users` before a student's first login makes `/signup_finish` skip the "enter your
+name" form on that first OAuth login, since the user row (matched by `auth_id`) already exists.

--- a/manytask/manytask/abstract.py
+++ b/manytask/manytask/abstract.py
@@ -204,7 +204,7 @@ class StorageApi(ABC):
 
     @abstractmethod
     def update_or_create_user(
-        self, username: str, first_name: str, last_name: str, rms_id: str, auth_id: int
+        self, username: str, first_name: str, last_name: str, rms_id: str, auth_id: int, update_names: bool = False
     ) -> None: ...
 
     @abstractmethod

--- a/manytask/manytask/api.py
+++ b/manytask/manytask/api.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 from http import HTTPStatus
 from typing import Any, Callable, TypeVar
 
+import gitlab
 import yaml
 from flask import Blueprint, abort, current_app, jsonify, request, session
 from flask.typing import ResponseReturnValue
@@ -24,8 +25,10 @@ from .config import (
     CourseResponse,
     CreateCourseRequest,
     CreateNamespaceRequest,
+    CreateUserRequest,
     DeadlineItem,
     DeadlinesResponse,
+    EnrollUserRequest,
     ErrorResponse,
     IsAdminResponse,
     ManytaskGroupConfig,
@@ -39,16 +42,19 @@ from .config import (
     PingResponse,
     UpdateUserRoleRequest,
     UserOnNamespaceResponse,
+    UserResponse,
 )
 from pydantic import BaseModel
 from .course import DEFAULT_TIMEZONE, Course, CourseStatus, get_current_time
 from .main import CustomFlask
 from .utils.database import get_database_table_data
+from .utils.enrollment import enroll_user_on_course
 from .utils.generic import (
     calculate_percent,
     check_course_creation_namespace_permission,
     sanitize_and_validate_comment,
     sanitize_log_data,
+    validate_name,
 )
 
 
@@ -228,6 +234,69 @@ def requires_token(f: Callable[..., Any]) -> Callable[..., Any]:
 
         logger.debug("Token validated for course=%s", course_name)
         return f(*args, **kwargs)
+
+    return decorated
+
+
+def requires_instance_token(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator to check the instance-scoped API token (MANYTASK_API_TOKEN / app.app_config.api_token)."""
+
+    @functools.wraps(f)
+    def decorated(*args: Any, **kwargs: Any) -> Any:
+        app: CustomFlask = current_app  # type: ignore
+
+        instance_token = app.app_config.api_token
+
+        auth_header = request.headers.get("Authorization")
+        if auth_header is None:
+            logger.warning("Missing Authorization header for instance-token-protected endpoint")
+            abort(HTTPStatus.FORBIDDEN, "Missing authorization: provide instance token via 'Authorization' header")
+
+        # Support "Authorization: Bearer <token>" by taking the trailing component.
+        token_parts = auth_header.split()
+        submitted_token = token_parts[-1] if token_parts else ""
+
+        if not submitted_token:
+            logger.warning("Empty authorization token")
+            abort(HTTPStatus.FORBIDDEN, "Empty authorization token")
+
+        if not instance_token:
+            logger.error("Instance API token (MANYTASK_API_TOKEN) is not configured")
+            abort(HTTPStatus.FORBIDDEN, "Instance API token is not configured")
+
+        if not secrets.compare_digest(submitted_token, instance_token):
+            logger.warning("Invalid instance token")
+            abort(HTTPStatus.FORBIDDEN, "Invalid instance token")
+
+        logger.debug("Instance token validated")
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def requires_instance_or_course_token(f: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator for course-scoped routes accepting either the instance token or the course token.
+
+    The instance token is checked first; if it is not configured, missing, or doesn't match, this
+    falls through to the regular course-token check (`requires_token`), so a wrong token still
+    yields 403 and an unknown course still yields 404.
+    """
+
+    @functools.wraps(f)
+    def decorated(*args: Any, **kwargs: Any) -> Any:
+        app: CustomFlask = current_app  # type: ignore
+
+        instance_token = app.app_config.api_token
+        auth_header = request.headers.get("Authorization")
+
+        if instance_token and auth_header:
+            token_parts = auth_header.split()
+            submitted_token = token_parts[-1] if token_parts else ""
+            if submitted_token and secrets.compare_digest(submitted_token, instance_token):
+                logger.debug("Instance token validated for course=%s", kwargs.get("course_name"))
+                return f(*args, **kwargs)
+
+        return requires_token(f)(*args, **kwargs)
 
     return decorated
 
@@ -1693,3 +1762,188 @@ def clear_grade_override(course_name: str) -> ResponseReturnValue:
         return jsonify(
             {"success": False, "message": "Internal error when clearing grade override"}
         ), HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+@namespace_bp.post("/users")
+@requires_instance_token
+@requires_json_validation(CreateUserRequest)
+def create_user_api(validated_data: CreateUserRequest) -> ResponseReturnValue:
+    """Create or update a manytask user from an RMS user, without an OAuth login.
+
+    Used by external registration flows (e.g. a Telegram bot) to pre-create manytask users right
+    after the RMS account is created, so that `/signup_finish` skips the name form on first login.
+
+    Request JSON:
+    {
+        "rms_id": "1234",         // exactly one of rms_id/username is required
+        "username": "hse_ivanov",
+        "first_name": "Иван",     // optional, derived from the RMS user's name if omitted
+        "last_name": "Иванов",    // optional
+        "auth_id": 1234           // optional, defaults to int(rms_id) when rms == "gitlab"
+    }
+
+    Returns:
+        201: user created, body {user_id, username, rms_id, created: true}
+        200: user already existed (names updated), body {..., created: false}
+        400: invalid request (both/neither of rms_id+username, names that can't be derived/validated,
+             auth_id required for non-gitlab RMS)
+        403: missing/invalid instance token
+        404: no such RMS user
+    """
+    app: CustomFlask = current_app  # type: ignore
+    storage_api = app.storage_api
+    rms_api = app.rms_api
+
+    try:
+        if validated_data.rms_id is not None:
+            rms_user = rms_api.get_rms_user_by_id(validated_data.rms_id)
+        else:
+            assert validated_data.username is not None
+            rms_user = rms_api.get_rms_user_by_username(validated_data.username)
+    except (RmsApiException, gitlab.GitlabError) as e:
+        identifier = sanitize_log_data(str(validated_data.rms_id or validated_data.username))
+        logger.warning("RMS user not found for identifier=%s: %s", identifier, str(e))
+        return jsonify(
+            ErrorResponse(error=f"There is no RMS user with rms_id/username={identifier}").model_dump()
+        ), HTTPStatus.NOT_FOUND
+
+    first_name = validated_data.first_name
+    last_name = validated_data.last_name
+    if first_name is None or last_name is None:
+        name_parts = rms_user.name.split(" ", 1)
+        if len(name_parts) < 2:
+            return jsonify(
+                ErrorResponse(
+                    error=f"Cannot derive first_name/last_name from RMS user name "
+                    f"'{sanitize_log_data(rms_user.name)}'; provide first_name and last_name explicitly"
+                ).model_dump()
+            ), HTTPStatus.BAD_REQUEST
+        first_name = first_name if first_name is not None else name_parts[0]
+        last_name = last_name if last_name is not None else name_parts[1]
+
+    validated_first_name = validate_name(first_name)
+    validated_last_name = validate_name(last_name)
+    if validated_first_name is None or validated_last_name is None:
+        return jsonify(
+            ErrorResponse(
+                error="first_name and last_name must be 1-50 characters and contain only letters, "
+                "hyphens, apostrophes or single spaces."
+            ).model_dump()
+        ), HTTPStatus.BAD_REQUEST
+
+    if validated_data.auth_id is not None:
+        auth_id = validated_data.auth_id
+    elif app.app_config.rms == "gitlab":
+        auth_id = int(rms_user.id)
+    else:
+        return jsonify(
+            ErrorResponse(error="auth_id is required when the instance RMS is not gitlab").model_dump()
+        ), HTTPStatus.BAD_REQUEST
+
+    created = storage_api.get_stored_user_by_rms_id(rms_user.id) is None
+
+    storage_api.update_or_create_user(
+        username=rms_user.username,
+        first_name=validated_first_name,
+        last_name=validated_last_name,
+        rms_id=rms_user.id,
+        auth_id=auth_id,
+        update_names=True,
+    )
+
+    stored_user = storage_api.get_stored_user_by_rms_id(rms_user.id)
+    assert stored_user is not None
+
+    logger.info(
+        "User '%s' (rms_id=%s) %s via instance API",
+        stored_user.username,
+        rms_user.id,
+        "created" if created else "updated",
+    )
+
+    response = UserResponse(
+        user_id=stored_user.user_id,
+        username=stored_user.username,
+        rms_id=stored_user.rms_id,
+        created=created,
+    )
+    return jsonify(response.model_dump()), HTTPStatus.CREATED if created else HTTPStatus.OK
+
+
+@bp.post("/enroll")
+@requires_instance_or_course_token
+@requires_json_validation(EnrollUserRequest)
+def enroll_user(course_name: str, validated_data: EnrollUserRequest) -> ResponseReturnValue:
+    """Enroll an already-registered manytask user on a course.
+
+    Records them in users_on_courses and creates/forks their RMS project. Does not create the
+    manytask user itself — call `POST /api/users` first.
+
+    Deliberately not gated behind course readiness (no `@requires_ready`/status check): enrolling
+    students must work while the course is still CREATED/HIDDEN, before it is opened.
+
+    Request JSON:
+    {
+        "username": "hse_ivanov",
+        "course_admin": false
+    }
+
+    Returns:
+        200: {username, course, is_course_admin, project: "<students_group>/<username>"}
+        400: invalid request
+        403: missing/invalid token
+        404: unknown course, or user not registered in manytask (call POST /api/users first)
+        502: RMS (GitLab) error while creating the project
+    """
+    app: CustomFlask = current_app  # type: ignore
+    storage_api = app.storage_api
+    rms_api = app.rms_api
+
+    course = __get_course_or_not_found(storage_api, course_name)
+
+    username = validated_data.username
+    course_admin = validated_data.course_admin
+
+    try:
+        stored_user = storage_api.get_stored_user_by_username(username)
+    except NoResultFound:
+        stored_user = None
+    if stored_user is None:
+        logger.warning(
+            "User '%s' not registered in manytask, cannot enroll on course=%s", sanitize_log_data(username), course_name
+        )
+        return jsonify(
+            ErrorResponse(
+                error=f"User '{sanitize_log_data(username)}' is not registered in manytask. Call POST /api/users first."
+            ).model_dump()
+        ), HTTPStatus.NOT_FOUND
+
+    try:
+        rms_user = rms_api.get_rms_user_by_id(stored_user.rms_id)
+    except (RmsApiException, gitlab.GitlabError) as e:
+        logger.error(
+            "RMS user not found for username=%s rms_id=%s: %s", sanitize_log_data(username), stored_user.rms_id, str(e)
+        )
+        return jsonify(
+            ErrorResponse(error=f"There is no RMS user with id={stored_user.rms_id}").model_dump()
+        ), HTTPStatus.NOT_FOUND
+
+    try:
+        enroll_user_on_course(storage_api, rms_api, rms_user, course, username, course_admin)
+    except (RuntimeError, gitlab.GitlabError) as e:
+        message = getattr(e, "error_message", None) or str(e)
+        logger.error("Failed to enroll user=%s on course=%s: %s", sanitize_log_data(username), course_name, message)
+        return jsonify(ErrorResponse(error=str(message)).model_dump()), HTTPStatus.BAD_GATEWAY
+
+    is_course_admin = storage_api.check_if_course_admin(course.course_name, username)
+
+    logger.info("Enrolled user=%s on course=%s (course_admin=%s)", username, course.course_name, is_course_admin)
+
+    return jsonify(
+        {
+            "username": username,
+            "course": course.course_name,
+            "is_course_admin": is_course_admin,
+            "project": f"{course.gitlab_course_students_group}/{username}",
+        }
+    ), HTTPStatus.OK

--- a/manytask/manytask/config.py
+++ b/manytask/manytask/config.py
@@ -46,6 +46,37 @@ class AddUserToNamespaceRequest(BaseModel):
     role: Literal["namespace_admin", "program_manager"]
 
 
+class CreateUserRequest(BaseModel):
+    """Request to create or update a manytask user from an RMS (GitLab/SourceCraft) user.
+
+    Exactly one of rms_id or username must be provided to identify the RMS user.
+    """
+
+    rms_id: Optional[str] = None
+    username: Optional[str] = None
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    auth_id: Optional[int] = None
+
+    @model_validator(mode="after")
+    def check_identifier(self) -> "CreateUserRequest":
+        if bool(self.rms_id) == bool(self.username):
+            raise ValueError("Exactly one of 'rms_id' or 'username' must be provided")
+        return self
+
+
+class UserResponse(BaseModel):
+    user_id: int
+    username: str
+    rms_id: str
+    created: bool
+
+
+class EnrollUserRequest(BaseModel):
+    username: str
+    course_admin: bool = False
+
+
 ROLE_STUDENT = "student"
 
 

--- a/manytask/manytask/database.py
+++ b/manytask/manytask/database.py
@@ -932,21 +932,31 @@ class DataBaseApi(StorageApi):
                 logger.warning("User '%s' isn't enrolled in course '%s'", username, course_name)
                 return False
 
-    def update_or_create_user(self, username: str, first_name: str, last_name: str, rms_id: str, auth_id: int) -> None:
-        """Update or create user in DB"""
+    def update_or_create_user(
+        self, username: str, first_name: str, last_name: str, rms_id: str, auth_id: int, update_names: bool = False
+    ) -> None:
+        """Update or create user in DB
+
+        :param update_names: if True, also update first_name/last_name on an already existing user
+            (by default they are only set when the user is created)
+        """
 
         with self._session_create() as session:
             logger.debug(
                 f"Creating or updating user '{username}' "
-                f"(first_name={first_name}, last_name={last_name}, rms_id={rms_id}, auth_id={auth_id})"
+                f"(first_name={first_name}, last_name={last_name}, rms_id={rms_id}, "
+                f"auth_id={auth_id}, update_names={update_names})"
             )
+            defaults = dict[str, Any](
+                rms_id=rms_id,
+                auth_id=auth_id,
+            )
+            if update_names:
+                defaults.update(first_name=first_name, last_name=last_name)
             self._update_or_create(
                 session,
                 models.User,
-                defaults=dict[str, Any](
-                    rms_id=rms_id,
-                    auth_id=auth_id,
-                ),
+                defaults=defaults,
                 create_defaults=dict[str, Any](
                     first_name=first_name,
                     last_name=last_name,

--- a/manytask/manytask/local_config.py
+++ b/manytask/manytask/local_config.py
@@ -32,6 +32,9 @@ class LocalConfig:
 
     disable_signup: bool
 
+    # instance-scoped API token (MANYTASK_API_TOKEN), used by requires_instance_token
+    api_token: str
+
     @classmethod
     def from_env(cls) -> LocalConfig:
         gitlab_url = os.environ.get("GITLAB_URL", "https://gitlab.manytask2.org")
@@ -56,6 +59,7 @@ class LocalConfig:
             yandex_id_client_secret=os.environ.get("YANDEX_ID_CLIENT_SECRET", ""),
             yandex_id_oauth_base=os.environ.get("YANDEX_ID_OAUTH_BASE", "https://oauth.yandex.com"),
             disable_signup=os.environ.get("MANYTASK_DISABLE_SIGNUP", "false").lower() in ("true", "1", "yes"),
+            api_token=os.environ.get("MANYTASK_API_TOKEN", ""),
         )
 
 
@@ -85,6 +89,8 @@ class DebugLocalConfig(LocalConfig):
     yandex_id_oauth_base: str = "https://oauth.yandex.com"
 
     disable_signup: bool = False
+
+    api_token: str = ""
 
     show_allscores: bool = True
 

--- a/manytask/manytask/utils/enrollment.py
+++ b/manytask/manytask/utils/enrollment.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from manytask.abstract import RmsApi, RmsUser, StorageApi
+from manytask.course import Course
+
+
+def enroll_user_on_course(
+    storage_api: StorageApi,
+    rms_api: RmsApi,
+    rms_user: RmsUser,
+    course: Course,
+    username: str,
+    course_admin: bool,
+) -> None:
+    """Enroll a user on a course: record them in users_on_courses and create/update their RMS project.
+
+    Shared by the web `create_project` view and the `POST /api/<course_name>/enroll` API endpoint.
+    Idempotent: safe to call again for an already enrolled user.
+    """
+    storage_api.sync_user_on_course(course.course_name, username, course_admin)
+    rms_api.create_project(rms_user, course.gitlab_course_students_group, course.gitlab_course_public_repo)

--- a/manytask/manytask/utils/generic.py
+++ b/manytask/manytask/utils/generic.py
@@ -38,8 +38,15 @@ def lerp(p1: tuple[float, float], p2: tuple[float, float], x: float) -> float:
     return p1[1] * (1 - t) + p2[1] * t
 
 
+MAX_NAME_LENGTH = 50
+
+
 def validate_name(name: str) -> str | None:
-    return name if (re.match(r"^[a-zA-Zа-яА-Я-]{1,50}$", name) is not None) else None
+    # Letters (incl. ё/Ё), hyphen, apostrophe and single spaces inside the string
+    # (not leading/trailing, not doubled) to allow double names/surnames ("Анна Мария").
+    if re.match(r"^[a-zA-Zа-яА-ЯёЁ'-]+( [a-zA-Zа-яА-ЯёЁ'-]+)*$", name) is None:
+        return None
+    return name if len(name) <= MAX_NAME_LENGTH else None
 
 
 def sanitize_and_validate_comment(comment: str | None, max_length: int = 1000) -> tuple[str | None, str | None]:

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -30,6 +30,7 @@ from .auth import (
 )
 from .course import Course, CourseConfig, CourseStatus, get_current_time
 from .main import CustomFlask
+from .utils.enrollment import enroll_user_on_course
 from .utils.flask import check_if_current_user_is_instance_admin, get_courses, has_role
 from .utils.generic import (
     check_course_creation_namespace_permission,
@@ -386,11 +387,10 @@ def create_project(course_name: str) -> ResponseReturnValue:
             base_url=app.rms_api.base_url,
         )
 
-    app.storage_api.sync_user_on_course(course.course_name, session["manytask"]["username"], is_course_admin)
-
-    # Create use if needed
     try:
-        app.rms_api.create_project(rms_user, course.gitlab_course_students_group, course.gitlab_course_public_repo)
+        enroll_user_on_course(
+            app.storage_api, app.rms_api, rms_user, course, session["manytask"]["username"], is_course_admin
+        )
         logger.info("Successfully created project for user %s in course %s", rms_user.username, course.course_name)
     except gitlab.GitlabError as ex:
         logger.error("Project creation failed: %s", ex.error_message)

--- a/manytask/tests/constants.py
+++ b/manytask/tests/constants.py
@@ -37,6 +37,7 @@ TEST_TASK_NAME = "test_task"
 TEST_TASK_GROUP_NAME = "test_task_group"
 TEST_INVALID_USER_ID = 321
 TEST_INVALID_USERNAME = "invalid_user"
+TEST_INSTANCE_TOKEN = "test_instance_token"
 
 
 # test_auth

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -9,15 +9,19 @@ import pytest
 import yaml
 from flask import json, url_for
 from pytest import approx
+from sqlalchemy.exc import NoResultFound
 from werkzeug.exceptions import HTTPException
 
-from manytask.abstract import RmsUser
-from manytask.api import _parse_flags, _process_score, _update_score, _validate_and_extract_params
+from manytask.abstract import RmsUser, StoredUser
+from manytask.api import _parse_flags, _process_score, _update_score, _validate_and_extract_params, namespace_bp
 from manytask.api import bp as api_bp
 from manytask.config import ManytaskConfig, ManytaskDeadlinesType, ManytaskGroupConfig, ManytaskTaskConfig
+from manytask.course import CourseStatus
 from manytask.database import DataBaseApi
+from manytask.local_config import TestConfig
 from manytask.mock_auth import MockAuthApi
 from manytask.mock_rms import MockRmsApi
+from manytask.utils.generic import validate_name
 from manytask.web import course_bp, root_bp
 from tests.constants import (
     GITLAB_BASE_URL,
@@ -26,6 +30,7 @@ from tests.constants import (
     TEST_COURSE_NAME,
     TEST_EMAIL,
     TEST_FIRST_NAME,
+    TEST_INSTANCE_TOKEN,
     TEST_INVALID_USER_ID,
     TEST_INVALID_USERNAME,
     TEST_LAST_NAME,
@@ -51,12 +56,14 @@ from tests.helpers import (
 
 @pytest.fixture
 def app(mock_storage_api):
-    app = make_flask_app(root_bp, course_bp, api_bp)
+    app = make_flask_app(root_bp, course_bp, api_bp, namespace_bp)
     app.storage_api = mock_storage_api
     app.rms_api = MockRmsApi(GITLAB_BASE_URL)
     app.auth_api = MockAuthApi()
     app.manytask_version = "1.0.0"
     app.favicon = "test_favicon"
+    app.app_config = TestConfig()
+    app.app_config.api_token = TEST_INSTANCE_TOKEN
 
     def store_config(course_name, content):
         pass
@@ -100,6 +107,11 @@ def mock_storage_api(mock_course, mock_task, mock_group):  # noqa: C901
             super().__init__()
             self.scores = {}
             self.non_admin_users: set[str] = set()
+            self.users_by_username: dict[str, StoredUser] = {self.stored_user.username: self.stored_user}
+            self.users_by_rms_id: dict[str, StoredUser] = {self.stored_user.rms_id: self.stored_user}
+            self._next_user_id = TEST_USER_ID + 1
+            self.course_admins: dict[tuple[str, str], bool] = {}
+            self.enrolled: set[tuple[str, str]] = set()
 
         def store_score(self, _course_name, username, task_name, update_fn):
             old_score = self.scores.get(f"{username}_{task_name}", 0)
@@ -119,21 +131,55 @@ def mock_storage_api(mock_course, mock_task, mock_group):  # noqa: C901
             return {"test_user": self.get_scores(course_name, "test_user")}
 
         def get_stored_user_by_auth_id(self, auth_id):
-            if auth_id == self.stored_user.auth_id:
-                return self.stored_user
+            for user in self.users_by_username.values():
+                if user.auth_id == auth_id:
+                    return user
             return None
 
         def get_stored_user_by_rms_id(self, rms_id):
-            if rms_id == self.stored_user.rms_id:
-                return self.stored_user
-            return None
+            return self.users_by_rms_id.get(rms_id)
 
         def get_stored_user_by_username(self, username):
-            if username == self.stored_user.username:
-                return self.stored_user
-            return None
+            user = self.users_by_username.get(username)
+            if user is None:
+                raise NoResultFound(f"User not found with username={username}")
+            return user
 
-        def check_if_course_admin(self, _course_name, username):
+        def update_or_create_user(  # noqa: PLR0913
+            self, username, first_name, last_name, rms_id, auth_id, update_names=False
+        ):
+            existing = self.users_by_rms_id.get(rms_id) or self.users_by_username.get(username)
+            if existing is not None:
+                if update_names:
+                    existing.first_name = first_name
+                    existing.last_name = last_name
+                existing.rms_id = rms_id
+                existing.auth_id = auth_id
+                self.users_by_username[existing.username] = existing
+                self.users_by_rms_id[existing.rms_id] = existing
+                return
+
+            new_user = StoredUser(
+                username=username,
+                first_name=first_name,
+                last_name=last_name,
+                rms_id=rms_id,
+                auth_id=auth_id,
+                user_id=self._next_user_id,
+            )
+            self._next_user_id += 1
+            self.users_by_username[username] = new_user
+            self.users_by_rms_id[rms_id] = new_user
+
+        def sync_user_on_course(self, course_name, username, course_admin):
+            key = (course_name, username)
+            self.enrolled.add(key)
+            self.course_admins[key] = self.course_admins.get(key, False) or course_admin
+
+        def check_if_course_admin(self, course_name, username):
+            key = (course_name, username)
+            if key in self.course_admins:
+                return self.course_admins[key]
             if username in self.non_admin_users:
                 return False
             return True
@@ -1485,3 +1531,251 @@ def test_deadlines_invalid_token(app):
     response = client.get(f"/api/{TEST_COURSE_NAME}/deadlines", headers=headers)
 
     assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+# ---- validate_name ----
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "Ivanov",
+        "Anna Maria",
+        "Jean-Pierre",
+        "O'Brien",
+        "Иванов",
+        "Пётр",
+        "Гарсиа Лопес",
+        "ё" * 50,
+    ],
+)
+def test_validate_name_accepts(name):
+    assert validate_name(name) == name
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "",
+        " Ivanov",
+        "Ivanov ",
+        "Anna  Maria",
+        "Ivanov1",
+        "a" * 51,
+        "Иванов_Петров",
+    ],
+)
+def test_validate_name_rejects(name):
+    assert validate_name(name) is None
+
+
+# ---- POST /api/users and POST /api/<course_name>/enroll ----
+
+
+def _instance_token_headers():
+    return {"Authorization": f"Bearer {TEST_INSTANCE_TOKEN}"}
+
+
+def _course_token_headers():
+    return {"Authorization": f"Bearer {os.environ['MANYTASK_COURSE_TOKEN']}"}
+
+
+def _register_rms_user(app, *, rms_id, username, name):
+    user = RmsUser(id=rms_id, username=username, name=name)
+    app.rms_api.users[rms_id] = user
+    app.rms_api.users_by_username[username] = user
+    return user
+
+
+def _create_user(app, payload, *, headers=None):
+    return app.test_client().post(
+        "/api/users", json=payload, headers=headers if headers is not None else _instance_token_headers()
+    )
+
+
+def _enroll(app, course_name, payload, *, headers=None):
+    return app.test_client().post(
+        f"/api/{course_name}/enroll",
+        json=payload,
+        headers=headers if headers is not None else _instance_token_headers(),
+    )
+
+
+def test_create_user_missing_token(app):
+    response = app.test_client().post("/api/users", json={"rms_id": "42"})
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_create_user_invalid_token(app):
+    response = _create_user(app, {"rms_id": "42"}, headers={"Authorization": "Bearer wrong_token"})
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_create_user_token_not_configured(app):
+    app.app_config.api_token = ""
+    response = _create_user(app, {"rms_id": "42"})
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_create_user_new_user_by_rms_id(app):
+    _register_rms_user(app, rms_id="42", username="new_student", name="New Student")
+
+    response = _create_user(app, {"rms_id": "42", "first_name": "New", "last_name": "Student"})
+
+    assert response.status_code == HTTPStatus.CREATED
+    body = json.loads(response.data)
+    assert body == {"user_id": body["user_id"], "username": "new_student", "rms_id": "42", "created": True}
+
+    stored = app.storage_api.get_stored_user_by_rms_id("42")
+    assert stored.first_name == "New"
+    assert stored.last_name == "Student"
+
+
+def test_create_user_new_user_by_username(app):
+    _register_rms_user(app, rms_id="43", username="other_student", name="Other Student")
+
+    response = _create_user(app, {"username": "other_student", "first_name": "Other", "last_name": "Student"})
+
+    assert response.status_code == HTTPStatus.CREATED
+    body = json.loads(response.data)
+    assert body["username"] == "other_student"
+    assert body["rms_id"] == "43"
+    assert body["created"] is True
+
+
+def test_create_user_updates_existing_names(app):
+    _register_rms_user(app, rms_id=TEST_RMS_ID, username=TEST_USERNAME, name="Doesn't Matter")
+
+    response = _create_user(app, {"rms_id": TEST_RMS_ID, "first_name": "Updated", "last_name": "Name"})
+
+    assert response.status_code == HTTPStatus.OK
+    body = json.loads(response.data)
+    assert body["created"] is False
+    assert body["username"] == TEST_USERNAME
+
+    stored = app.storage_api.get_stored_user_by_rms_id(TEST_RMS_ID)
+    assert stored.first_name == "Updated"
+    assert stored.last_name == "Name"
+
+
+def test_create_user_both_rms_id_and_username_rejected(app):
+    response = _create_user(app, {"rms_id": "42", "username": "new_student"})
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_create_user_neither_rms_id_nor_username_rejected(app):
+    response = _create_user(app, {"first_name": "New", "last_name": "Student"})
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_create_user_unknown_rms_user(app):
+    response = _create_user(app, {"rms_id": "9999"})
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_create_user_names_derived_from_rms_name(app):
+    _register_rms_user(app, rms_id="44", username="anna", name="Anna Maria")
+
+    response = _create_user(app, {"rms_id": "44"})
+
+    assert response.status_code == HTTPStatus.CREATED
+    stored = app.storage_api.get_stored_user_by_rms_id("44")
+    assert stored.first_name == "Anna"
+    assert stored.last_name == "Maria"
+
+
+def test_create_user_single_word_rms_name_requires_explicit_names(app):
+    _register_rms_user(app, rms_id="45", username="ivan", name="Ivan")
+
+    response = _create_user(app, {"rms_id": "45"})
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+def test_enroll_no_users_row(app):
+    response = _enroll(app, TEST_COURSE_NAME, {"username": "unregistered_user"})
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert b"POST /api/users" in response.data
+
+
+def test_enroll_success(app):
+    _register_rms_user(app, rms_id="46", username="enroll_student", name="Enroll Student")
+    create_response = _create_user(app, {"rms_id": "46", "first_name": "Enroll", "last_name": "Student"})
+    assert create_response.status_code == HTTPStatus.CREATED
+
+    response = _enroll(app, TEST_COURSE_NAME, {"username": "enroll_student"})
+
+    assert response.status_code == HTTPStatus.OK
+    body = json.loads(response.data)
+    assert body == {
+        "username": "enroll_student",
+        "course": TEST_COURSE_NAME,
+        "is_course_admin": False,
+        "project": "students_2025_spring/enroll_student",
+    }
+    assert app.rms_api.check_project_exists("enroll_student", "students_2025_spring")
+
+
+def test_enroll_idempotent(app):
+    _register_rms_user(app, rms_id="47", username="idempotent_student", name="Idempotent Student")
+    _create_user(app, {"rms_id": "47", "first_name": "Idempotent", "last_name": "Student"})
+
+    first = _enroll(app, TEST_COURSE_NAME, {"username": "idempotent_student"})
+    second = _enroll(app, TEST_COURSE_NAME, {"username": "idempotent_student"})
+
+    assert first.status_code == HTTPStatus.OK
+    assert second.status_code == HTTPStatus.OK
+
+
+def test_enroll_course_admin(app):
+    _register_rms_user(app, rms_id="48", username="admin_student", name="Admin Student")
+    _create_user(app, {"rms_id": "48", "first_name": "Admin", "last_name": "Student"})
+
+    response = _enroll(app, TEST_COURSE_NAME, {"username": "admin_student", "course_admin": True})
+
+    assert response.status_code == HTTPStatus.OK
+    body = json.loads(response.data)
+    assert body["is_course_admin"] is True
+
+
+def test_enroll_via_course_token(app):
+    _register_rms_user(app, rms_id="49", username="course_token_student", name="Course Token Student")
+    _create_user(app, {"rms_id": "49", "first_name": "Course", "last_name": "Token"})
+
+    response = _enroll(app, TEST_COURSE_NAME, {"username": "course_token_student"}, headers=_course_token_headers())
+
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_enroll_wrong_token(app):
+    response = _enroll(app, TEST_COURSE_NAME, {"username": TEST_USERNAME}, headers={"Authorization": "Bearer wrong"})
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_enroll_unknown_course(app):
+    with patch.object(app.storage_api, "get_course", return_value=None):
+        response = _enroll(app, "no-such-course", {"username": TEST_USERNAME})
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_enroll_works_for_created_course(app, mock_course):
+    mock_course.status = CourseStatus.CREATED
+    _register_rms_user(app, rms_id="50", username="created_course_student", name="Created Course Student")
+    _create_user(app, {"rms_id": "50", "first_name": "Created", "last_name": "Course"})
+
+    response = _enroll(app, TEST_COURSE_NAME, {"username": "created_course_student"})
+
+    assert response.status_code == HTTPStatus.OK
+
+
+def test_enroll_rms_error_returns_bad_gateway(app):
+    _register_rms_user(app, rms_id="51", username="failing_student", name="Failing Student")
+    _create_user(app, {"rms_id": "51", "first_name": "Failing", "last_name": "Student"})
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("gitlab is down")
+
+    with patch.object(app.rms_api, "create_project", side_effect=_raise):
+        response = _enroll(app, TEST_COURSE_NAME, {"username": "failing_student"})
+
+    assert response.status_code == HTTPStatus.BAD_GATEWAY


### PR DESCRIPTION
  Lets an external registration flow (e.g. a bot that creates GitLab accounts) register users in manytask and enroll them on a course, so students don't have to type the registration secret or fill in their
  name on first login.
 
  - `MANYTASK_API_TOKEN`: instance-level token; unset = new endpoints return 403, nothing changes for existing deployments.
  - `POST /api/users` (instance token): create/update a manytask user from an RMS user by `rms_id` or `username`; names optional, derived from the RMS name if omitted.
  - `POST /api/<course_name>/enroll` (instance or course token): same as the `create_project` form after the secret check — `users_on_courses` row + student project. Idempotent, works for `CREATED`/`HIDDEN`
  courses.
  - Shared `utils/enrollment.py` used by both the view and the endpoint; `update_or_create_user(update_names=...)`.
  - `validate_name` accepts `ё`, apostrophes and spaces (double names were rejected on `/signup_finish`)