### PR TITLE
feat: do not show the secret info on course editing page by default

### DIFF
--- a/manytask/manytask/templates/edit_course.html
+++ b/manytask/manytask/templates/edit_course.html
@@ -23,11 +23,25 @@
                 </div>
                 <div class="mb-3">
                     <label class="form-label">Registration Secret</label>
-                    <input type="text" class="form-control" id="registration_secret" name="registration_secret" value="{{ course.registration_secret }}" required>
+                    <div class="position-relative">
+                        <input type="password" class="form-control pe-5" id="registration_secret" name="registration_secret" value="{{ course.registration_secret }}" required autocomplete="off">
+                        <button class="btn btn-link text-secondary position-absolute top-50 end-0 translate-middle-y me-2 p-0 border-0"
+                                type="button" aria-label="Toggle registration secret visibility"
+                                onclick="toggleSecret('registration_secret', this)">
+                            <i class="fas fa-eye"></i>
+                        </button>
+                    </div>
                 </div>
                 <div class="mb-3">
                     <label for="token" class="form-label">Course Token</label>
-                    <input type="text" class="form-control" id="token" name="token" value="{{ course.token }}" readonly disabled>
+                    <div class="position-relative">
+                        <input type="password" class="form-control pe-5" id="token" name="token" value="{{ course.token }}" readonly disabled autocomplete="off">
+                        <button class="btn btn-link text-secondary position-absolute top-50 end-0 translate-middle-y me-2 p-0 border-0"
+                                type="button" aria-label="Toggle token visibility"
+                                onclick="toggleSecret('token', this)">
+                            <i class="fas fa-eye"></i>
+                        </button>
+                    </div>
                     <div class="form-text">Token cannot be changed</div>
                 </div>
                 <div class="mb-3">
@@ -242,6 +256,19 @@
 </div>
 
 <script>
+    function toggleSecret(fieldId, btn) {
+        const input = document.getElementById(fieldId);
+        const icon = btn.querySelector('i');
+        if (input.type === 'password') {
+            input.type = 'text';
+            icon.classList.replace('fa-eye', 'fa-eye-slash');
+            btn.setAttribute('aria-label', btn.getAttribute('aria-label').replace('Toggle', 'Hide'));
+        } else {
+            input.type = 'password';
+            icon.classList.replace('fa-eye-slash', 'fa-eye');
+        }
+    }
+
     function filterUsers(type) {
         const inputId = `${type}SearchInput`;
         const selectId = `userTo${type.charAt(0).toUpperCase() + type.slice(1)}`;


### PR DESCRIPTION
Course secret and token are exposed on the course editing page. This may lead to someone accidently showing these information when demonstrating their screen. This hides the characters by default. A toggle is added to reveal the info when needed.