### PR TITLE
feat: manage student repo CI config path and protected branches

### DIFF
--- a/docs/manytask_yml_reference.md
+++ b/docs/manytask_yml_reference.md
@@ -17,6 +17,9 @@ deadlines:
 grades:               # optional
   ...
 
+rms:                  # optional
+  ...
+
 mr_review:            # optional
   ...
 ```
@@ -28,6 +31,7 @@ mr_review:            # optional
 | `ui` | object | yes | UI display settings. See [`ui`](#ui). |
 | `deadlines` | object | yes | Deadline schedule and submission rules. See [`deadlines`](#deadlines). |
 | `grades` | object | no | Final grade computation rules. See [`grades`](#grades). |
+| `rms` | object | no | GitLab CI config path and protected-branch settings applied to every student repository. See [`rms`](#rms). |
 | `mr_review` | object | no | Merge-request review bot settings. See [`mr_review`](#mr_review). |
 
 
@@ -237,6 +241,51 @@ Use an empty key `""` with value `0` to create a condition that always matches �
 2:
   - { "": 0 }
 ```
+
+## `rms`
+
+Optional section controlling two GitLab settings applied to every student repository of the course: the CI config path (which pipeline definition the student's fork runs) and protected-branch rules.
+
+```yaml
+rms:
+  ci_config_path: .gitlab-ci.yml@caos-ami/public-2026   # optional
+  protected_branches:                                    # optional
+    - name: main
+      push_access_level: developer      # no_access | developer | maintainer
+      merge_access_level: developer     # no_access | developer | maintainer
+      allow_force_push: true
+```
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `ci_config_path` | string | no | `.gitlab-ci.yml@<gitlab_course_public_repo>` | External CI config path (GitLab's `ci_config_path` project setting), e.g. `.gitlab-ci.yml@group/public-repo`. |
+| `protected_branches` | list | no | a single entry for the course's default branch, `developer`/`developer`, `allow_force_push: true` | Branches to protect on every student repository. See [`rms` protected branch](#rms-protected-branch). |
+
+### `rms` protected branch
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `name` | string | yes | — | Branch name. Must be non-empty and unique within `protected_branches`. GitLab allows protecting a branch that does not exist yet, so this does not have to be created in advance. |
+| `push_access_level` | string | no | `developer` | Minimum role allowed to push directly to the branch: `no_access`, `developer`, or `maintainer`. |
+| `merge_access_level` | string | no | `developer` | Minimum role allowed to accept merge requests into the branch: `no_access`, `developer`, or `maintainer`. |
+| `allow_force_push` | boolean | no | `true` | Whether force-pushes are allowed on the branch. |
+
+### Applying `rms` settings
+
+`rms` settings are applied to a student's GitLab repository:
+
+- when their repository is first created (enrollment / `create_project`);
+- when they are re-enrolled on an already-created repository;
+- to **every** existing student repository of the course, in the background, whenever the `rms` section's effective (defaults-resolved) value changes on a config push (`update_config`). The HTTP response does not wait for this pass; it runs in a background thread and is idempotent (it only writes settings that differ from the desired state).
+
+If the background pass fails for some repositories (e.g. a transient GitLab error), it is retried on the next `update_config` call for the course — even if the `rms` section itself did not change — or by running the manual script:
+
+```bash
+python -m manytask.scripts.reconcile_student_repos <course_name>
+```
+
+This script applies the course's current `rms` settings to every student repository synchronously, prints a per-repository summary, and exits non-zero if any repository failed.
+
 
 ## `mr_review`
 

--- a/manytask/manytask/abstract.py
+++ b/manytask/manytask/abstract.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, Iterable
 from authlib.integrations.flask_client import OAuth
 
 from .config import ManytaskConfig, ManytaskFinalGradeConfig, ManytaskGroupConfig, ManytaskTaskConfig
-from .course import Course, CourseConfig, CourseStatus
+from .course import Course, CourseConfig, CourseStatus, ProtectedBranchSettings
 
 
 @dataclass
@@ -168,6 +168,12 @@ class StorageApi(ABC):
         course_name: str,
         config: ManytaskConfig,
     ) -> None: ...
+
+    @abstractmethod
+    def rms_settings_reconcile_needed(self, course_name: str) -> bool: ...
+
+    @abstractmethod
+    def clear_rms_settings_pending(self, course_name: str) -> None: ...
 
     @abstractmethod
     def get_course(
@@ -413,7 +419,26 @@ class RmsApi(ABC):
         rms_user: RmsUser,
         course_students_group: str,
         course_public_repo: str,
+        ci_config_path: str,
+        protected_branches: list[ProtectedBranchSettings],
     ) -> None: ...
+
+    @abstractmethod
+    def list_group_projects(self, group_path: str) -> list[str]: ...
+
+    @abstractmethod
+    def ensure_project_settings(
+        self,
+        project: Any,
+        ci_config_path: str,
+        protected_branches: list[ProtectedBranchSettings],
+    ) -> bool:
+        """Apply ci_config_path/protected_branches to a project, writing only what differs.
+
+        :param project: project path (str) or an already-fetched RMS project object
+        :returns: whether anything was changed
+        """
+        ...
 
     @abstractmethod
     def get_url_for_task_base(self, course_public_repo: str, default_branch: str) -> str: ...

--- a/manytask/manytask/config.py
+++ b/manytask/manytask/config.py
@@ -480,6 +480,36 @@ class ManytaskFinalGradeConfig(BaseModel):
         return False
 
 
+class ProtectedBranchConfig(BaseModel):
+    name: str
+    push_access_level: Literal["no_access", "developer", "maintainer"] = "developer"
+    merge_access_level: Literal["no_access", "developer", "maintainer"] = "developer"
+    allow_force_push: bool = True
+
+    @field_validator("name")
+    @classmethod
+    def check_name(cls, data: str) -> str:
+        if not data.strip():
+            raise ValueError("protected branch name cannot be empty")
+        return data
+
+
+class ManytaskRmsConfig(BaseModel):
+    ci_config_path: Optional[str] = None
+    protected_branches: Optional[list[ProtectedBranchConfig]] = None
+
+    @field_validator("protected_branches")
+    @classmethod
+    def check_branch_names_unique(cls, data: list[ProtectedBranchConfig] | None) -> list[ProtectedBranchConfig] | None:
+        if data is None:
+            return data
+        names = [branch.name for branch in data]
+        duplicates = [name for name in names if names.count(name) > 1]
+        if duplicates:
+            raise ValueError(f"Protected branch names should be unique, duplicates: {duplicates}")
+        return data
+
+
 class ManytaskConfig(BaseModel):
     """Manytask configuration."""
 
@@ -489,6 +519,7 @@ class ManytaskConfig(BaseModel):
     ui: ManytaskUiConfig
     deadlines: ManytaskDeadlinesConfig
     grades: Optional[ManytaskFinalGradeConfig] = None
+    rms: Optional[ManytaskRmsConfig] = None
 
     @field_validator("version")
     @classmethod

--- a/manytask/manytask/course.py
+++ b/manytask/manytask/course.py
@@ -49,6 +49,35 @@ class ManytaskDeadlinesType(Enum):
 
 
 @dataclass
+class ProtectedBranchSettings:
+    """Desired GitLab protected-branch state for a single branch."""
+
+    name: str
+    push_access_level: str  # "no_access" | "developer" | "maintainer"
+    merge_access_level: str  # "no_access" | "developer" | "maintainer"
+    allow_force_push: bool
+
+
+def resolve_effective_ci_config_path(configured: Optional[str], course_public_repo: str) -> str:
+    return configured if configured else f".gitlab-ci.yml@{course_public_repo}"
+
+
+def resolve_effective_protected_branches(
+    configured: Optional[list[ProtectedBranchSettings]], default_branch: str
+) -> list[ProtectedBranchSettings]:
+    if configured:
+        return configured
+    return [
+        ProtectedBranchSettings(
+            name=default_branch,
+            push_access_level="developer",
+            merge_access_level="developer",
+            allow_force_push=True,
+        )
+    ]
+
+
+@dataclass
 class CourseConfig:
     """Configuration for Course settings."""
 
@@ -69,6 +98,9 @@ class CourseConfig:
     task_url_template: str = ""
     links: dict[str, str] = field(default_factory=dict)
     deadlines_type: ManytaskDeadlinesType = ManytaskDeadlinesType.HARD
+
+    ci_config_path: Optional[str] = None
+    protected_branches: Optional[list[ProtectedBranchSettings]] = None
 
 
 class Course:
@@ -98,6 +130,17 @@ class Course:
 
         self.task_url_template = config.task_url_template
         self.links = config.links
+
+        self.__ci_config_path = config.ci_config_path
+        self.__protected_branches = config.protected_branches
+
+    @property
+    def ci_config_path(self) -> str:
+        return resolve_effective_ci_config_path(self.__ci_config_path, self.gitlab_course_public_repo)
+
+    @property
+    def protected_branches(self) -> list[ProtectedBranchSettings]:
+        return resolve_effective_protected_branches(self.__protected_branches, self.gitlab_default_branch)
 
     @property
     def gitlab_course_group(self) -> str:

--- a/manytask/manytask/database.py
+++ b/manytask/manytask/database.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Type, TypeVar, cast
@@ -27,7 +27,12 @@ from .config import (
 )
 from .course import Course as AppCourse
 from .course import CourseConfig as AppCourseConfig
-from .course import CourseStatus
+from .course import (
+    CourseStatus,
+    ProtectedBranchSettings,
+    resolve_effective_ci_config_path,
+    resolve_effective_protected_branches,
+)
 from .models import (
     ROLE_NAMESPACE_ADMIN,
     ROLE_PROGRAM_MANAGER,
@@ -87,6 +92,32 @@ def calculate_effective_grade(
         return capped_grade
 
     return calculated_grade
+
+
+def _protected_branches_key(branches: Iterable[Any]) -> dict[str, tuple[Any, Any, Any]]:
+    """Order-insensitive comparison key: branch name -> (push, merge, allow_force_push)."""
+    result = {}
+    for branch in branches:
+        if isinstance(branch, dict):
+            result[branch["name"]] = (
+                branch["push_access_level"],
+                branch["merge_access_level"],
+                branch["allow_force_push"],
+            )
+        else:
+            result[branch.name] = (branch.push_access_level, branch.merge_access_level, branch.allow_force_push)
+    return result
+
+
+def _rms_settings_changed(
+    stored_ci_config_path: Optional[str],
+    stored_protected_branches: Optional[list[dict[str, Any]]],
+    new_ci_config_path: str,
+    new_protected_branches: list[ProtectedBranchSettings],
+) -> bool:
+    if stored_ci_config_path != new_ci_config_path:
+        return True
+    return _protected_branches_key(stored_protected_branches or []) != _protected_branches_key(new_protected_branches)
 
 
 @dataclass
@@ -717,6 +748,33 @@ class DataBaseApi(StorageApi):
         logger.info("Updating course settings for course '%s'", course_name)
 
         with self._session_create() as session:
+            course = self._get(session, models.Course, name=course_name)
+
+            configured_branches = (
+                [
+                    ProtectedBranchSettings(
+                        name=branch.name,
+                        push_access_level=branch.push_access_level,
+                        merge_access_level=branch.merge_access_level,
+                        allow_force_push=branch.allow_force_push,
+                    )
+                    for branch in config.rms.protected_branches
+                ]
+                if config.rms and config.rms.protected_branches
+                else None
+            )
+            new_ci_config_path = resolve_effective_ci_config_path(
+                config.rms.ci_config_path if config.rms else None,
+                course.gitlab_course_public_repo,
+            )
+            new_protected_branches = resolve_effective_protected_branches(
+                configured_branches,
+                course.gitlab_default_branch,
+            )
+            rms_settings_changed = _rms_settings_changed(
+                course.ci_config_path, course.protected_branches, new_ci_config_path, new_protected_branches
+            )
+
             self._update(
                 session,
                 models.Course,
@@ -724,6 +782,9 @@ class DataBaseApi(StorageApi):
                     "task_url_template": config.ui.task_url_template,
                     "links": config.ui.links,
                     "deadlines_type": config.deadlines.deadlines,
+                    "ci_config_path": new_ci_config_path,
+                    "protected_branches": [asdict(branch) for branch in new_protected_branches],
+                    "rms_settings_pending": course.rms_settings_pending or rms_settings_changed,
                 },
                 name=course_name,
             )
@@ -733,6 +794,15 @@ class DataBaseApi(StorageApi):
         self._sync_grades_config(course_name, config.grades)
 
         logger.info("Successfully updated course '%s'", course_name)
+
+    def rms_settings_reconcile_needed(self, course_name: str) -> bool:
+        with self._session_create() as session:
+            course = self._get(session, models.Course, name=course_name)
+            return bool(course.rms_settings_pending)
+
+    def clear_rms_settings_pending(self, course_name: str) -> None:
+        with self._session_create() as session:
+            self._update(session, models.Course, defaults={"rms_settings_pending": False}, name=course_name)
 
     def find_task(self, course_name: str, task_name: str) -> tuple[AppCourse, ManytaskGroupConfig, ManytaskTaskConfig]:
         """Find task and its group by task name. Serialize result to Config objects.

--- a/manytask/manytask/glab.py
+++ b/manytask/manytask/glab.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from typing import Any, Optional, Union
 
@@ -16,6 +17,10 @@ from .course import ProtectedBranchSettings
 from .utils.generic import check_oauth_authenticated
 
 logger = logging.getLogger(__name__)
+
+_PROTECTED_BRANCH_ATTEMPTS = 3
+_PROTECTED_BRANCH_RETRY_DELAY = 5.0
+_FORK_IMPORT_TIMEOUT = 60.0
 
 _ACCESS_LEVEL_MAP: dict[str, int] = {
     "no_access": gitlab.const.AccessLevel.NO_ACCESS,
@@ -480,6 +485,45 @@ class GitLabApi(RmsApi, AuthApi):
             and bool(getattr(protected_branch, "allow_force_push", False)) == desired.allow_force_push
         )
 
+    def _create_protected_branch(self, project: gitlab.v4.objects.Project, desired: ProtectedBranchSettings) -> None:
+        data = {
+            "name": desired.name,
+            "push_access_level": _ACCESS_LEVEL_MAP[desired.push_access_level],
+            "merge_access_level": _ACCESS_LEVEL_MAP[desired.merge_access_level],
+            "allow_force_push": desired.allow_force_push,
+        }
+        # GitLab protects the default branch asynchronously after a fork, so it can appear between our
+        # list and create; re-read and re-apply after a pause instead of failing the whole enrollment
+        for attempt in range(_PROTECTED_BRANCH_ATTEMPTS):
+            try:
+                project.protectedbranches.create(data)
+                return
+            except GitlabCreateError as e:
+                if "already exists" not in str(e) or attempt == _PROTECTED_BRANCH_ATTEMPTS - 1:
+                    raise
+            time.sleep(_PROTECTED_BRANCH_RETRY_DELAY)
+            existing = project.protectedbranches.get(desired.name)
+            if self._protected_branch_matches(existing, desired):
+                return
+            existing.delete()
+
+    @staticmethod
+    def _fork_imported(project: gitlab.v4.objects.Project) -> bool:
+        return getattr(project, "import_status", "none") in ("finished", "none")
+
+    def _wait_fork_imported(
+        self, project: gitlab.v4.objects.Project, timeout: float = _FORK_IMPORT_TIMEOUT
+    ) -> gitlab.v4.objects.Project:
+        deadline = time.monotonic() + timeout
+        while not self._fork_imported(project) and time.monotonic() < deadline:
+            time.sleep(1)
+            project = self._gitlab.projects.get(project.id)
+        if not self._fork_imported(project):
+            logger.warning(
+                "Fork import of %s still %s after %ss", project.path_with_namespace, project.import_status, timeout
+            )
+        return project
+
     def ensure_project_settings(
         self,
         project: Union[str, gitlab.v4.objects.Project],
@@ -508,14 +552,7 @@ class GitLabApi(RmsApi, AuthApi):
         for name, desired in desired_by_name.items():
             matching_existing = existing_by_name.get(name)
             if matching_existing is None or not self._protected_branch_matches(matching_existing, desired):
-                project.protectedbranches.create(
-                    {
-                        "name": desired.name,
-                        "push_access_level": _ACCESS_LEVEL_MAP[desired.push_access_level],
-                        "merge_access_level": _ACCESS_LEVEL_MAP[desired.merge_access_level],
-                        "allow_force_push": desired.allow_force_push,
-                    }
-                )
+                self._create_protected_branch(project, desired)
                 changed = True
 
         logger.info("Ensured RMS settings for project=%s changed=%s", project.path_with_namespace, changed)
@@ -601,8 +638,7 @@ class GitLabApi(RmsApi, AuthApi):
                 "auto_devops_enabled": False,
             }
         )
-        project = self._gitlab.projects.get(fork.id)
-        self.ensure_project_settings(project, ci_config_path, protected_branches)
+        project = self._wait_fork_imported(self._gitlab.projects.get(fork.id))
 
         logger.info("Forked project created for user=%s repo=%s", rms_user.username, project.path_with_namespace)
         try:
@@ -626,6 +662,8 @@ class GitLabApi(RmsApi, AuthApi):
             logger.info("Access granted for course public project user=%s", member.username)
         except gitlab.GitlabCreateError:
             logger.warning("Access already granted or conflict on course public project user=%s", rms_user.username)
+
+        self.ensure_project_settings(project, ci_config_path, protected_branches)
 
     def _construct_rms_user(
         self,

--- a/manytask/manytask/glab.py
+++ b/manytask/manytask/glab.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import gitlab
 import gitlab.const
@@ -12,9 +12,16 @@ from authlib.integrations.flask_client import OAuth
 from gitlab.exceptions import GitlabAuthenticationError, GitlabCreateError, GitlabGetError
 
 from .abstract import AuthApi, AuthenticatedUser, RmsApi, RmsApiException, RmsUser
+from .course import ProtectedBranchSettings
 from .utils.generic import check_oauth_authenticated
 
 logger = logging.getLogger(__name__)
+
+_ACCESS_LEVEL_MAP: dict[str, int] = {
+    "no_access": gitlab.const.AccessLevel.NO_ACCESS,
+    "developer": gitlab.const.AccessLevel.DEVELOPER,
+    "maintainer": gitlab.const.AccessLevel.MAINTAINER,
+}
 
 
 def _validate_and_convert_user_id(user_id: str) -> int:
@@ -456,7 +463,72 @@ class GitLabApi(RmsApi, AuthApi):
         except GitlabGetError:
             return False
 
-    def create_project(self, rms_user: RmsUser, course_students_group: str, course_public_repo: str) -> None:
+    def list_group_projects(self, group_path: str) -> list[str]:
+        group = self._get_group_by_name(group_path)
+        return [project.path_with_namespace for project in group.projects.list(get_all=True)]
+
+    def _protected_branch_matches(
+        self, protected_branch: gitlab.v4.objects.ProjectProtectedBranch, desired: ProtectedBranchSettings
+    ) -> bool:
+        push_access_levels = protected_branch.push_access_levels or []
+        merge_access_levels = protected_branch.merge_access_levels or []
+        push_level = push_access_levels[0]["access_level"] if push_access_levels else None
+        merge_level = merge_access_levels[0]["access_level"] if merge_access_levels else None
+        return (
+            push_level == _ACCESS_LEVEL_MAP[desired.push_access_level]
+            and merge_level == _ACCESS_LEVEL_MAP[desired.merge_access_level]
+            and bool(getattr(protected_branch, "allow_force_push", False)) == desired.allow_force_push
+        )
+
+    def ensure_project_settings(
+        self,
+        project: Union[str, gitlab.v4.objects.Project],
+        ci_config_path: str,
+        protected_branches: list[ProtectedBranchSettings],
+    ) -> bool:
+        if isinstance(project, str):
+            project = self._gitlab.projects.get(project)
+
+        changed = False
+
+        if project.ci_config_path != ci_config_path:
+            project.ci_config_path = ci_config_path
+            project.save()
+            changed = True
+
+        existing_by_name = {branch.name: branch for branch in project.protectedbranches.list(get_all=True)}
+        desired_by_name = {branch.name: branch for branch in protected_branches}
+
+        for name, existing_branch in existing_by_name.items():
+            desired = desired_by_name.get(name)
+            if desired is None or not self._protected_branch_matches(existing_branch, desired):
+                existing_branch.delete()
+                changed = True
+
+        for name, desired in desired_by_name.items():
+            matching_existing = existing_by_name.get(name)
+            if matching_existing is None or not self._protected_branch_matches(matching_existing, desired):
+                project.protectedbranches.create(
+                    {
+                        "name": desired.name,
+                        "push_access_level": _ACCESS_LEVEL_MAP[desired.push_access_level],
+                        "merge_access_level": _ACCESS_LEVEL_MAP[desired.merge_access_level],
+                        "allow_force_push": desired.allow_force_push,
+                    }
+                )
+                changed = True
+
+        logger.info("Ensured RMS settings for project=%s changed=%s", project.path_with_namespace, changed)
+        return changed
+
+    def create_project(
+        self,
+        rms_user: RmsUser,
+        course_students_group: str,
+        course_public_repo: str,
+        ci_config_path: str,
+        protected_branches: list[ProtectedBranchSettings],
+    ) -> None:
         logger.info("Creating project for user=%s in group=%s", rms_user.username, course_students_group)
 
         course_group_path = "/".join(course_students_group.split("/")[:-1])
@@ -505,6 +577,7 @@ class GitLabApi(RmsApi, AuthApi):
                 except gitlab.GitlabCreateError:
                     logger.warning("Access already granted or conflict user=%s", rms_user.username)
 
+                self.ensure_project_settings(project, ci_config_path, protected_branches)
                 return
 
         course_public_project = self._get_project_by_name(course_public_repo)
@@ -521,7 +594,7 @@ class GitLabApi(RmsApi, AuthApi):
                 # TODO: Relay on groups runners
                 # "shared_runners_enabled": students_group.shared_runners_setting == "enabled",
                 # Set external gitlab-ci config from public repo
-                "ci_config_path": f".gitlab-ci.yml@{course_public_project.path_with_namespace}",
+                "ci_config_path": ci_config_path,
                 # Merge method to squash
                 "merge_method": "squash",
                 # Disable AutoDevOps
@@ -529,11 +602,7 @@ class GitLabApi(RmsApi, AuthApi):
             }
         )
         project = self._gitlab.projects.get(fork.id)
-        # TODO: think .evn config value
-        # Unprotect all branches
-        for protected_branch in project.protectedbranches.list(get_all=True):
-            protected_branch.delete()
-        project.save()
+        self.ensure_project_settings(project, ci_config_path, protected_branches)
 
         logger.info("Forked project created for user=%s repo=%s", rms_user.username, project.path_with_namespace)
         try:

--- a/manytask/manytask/main.py
+++ b/manytask/manytask/main.py
@@ -18,6 +18,7 @@ from manytask.mock_auth import MockAuthApi
 from manytask.mock_rms import MockRmsApi
 
 from . import abstract, config, course, database, glab, local_config, sourcecraft, yandex_id
+from .utils.rms_settings import schedule_rms_settings_reconcile
 
 MAX_AGE_IN_SECONDS = 86400
 
@@ -96,6 +97,9 @@ class CustomFlask(Flask):
 
         # Update course settings
         self.storage_api.update_course(course_name, manytask_config)
+
+        if self.storage_api.rms_settings_reconcile_needed(course_name):
+            schedule_rms_settings_reconcile(self.storage_api, self.rms_api, course_name)
 
 
 def _load_common_example_course_yaml() -> dict[str, Any]:

--- a/manytask/manytask/migrations/versions/c1d2e3f4a5b6_add_rms_settings_to_course.py
+++ b/manytask/manytask/migrations/versions/c1d2e3f4a5b6_add_rms_settings_to_course.py
@@ -1,0 +1,32 @@
+"""Add rms settings (ci_config_path, protected_branches, rms_settings_pending) to courses
+
+Revision ID: c1d2e3f4a5b6
+Revises: a1b2c3d4e5f6
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c1d2e3f4a5b6'
+down_revision: Union[str, None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('courses', sa.Column('ci_config_path', sa.String(), nullable=True))
+    op.add_column('courses', sa.Column('protected_branches', sa.JSON(), nullable=True))
+    op.add_column(
+        'courses', sa.Column('rms_settings_pending', sa.Boolean(), server_default='false', nullable=False)
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('courses', 'rms_settings_pending')
+    op.drop_column('courses', 'protected_branches')
+    op.drop_column('courses', 'ci_config_path')

--- a/manytask/manytask/mock_rms.py
+++ b/manytask/manytask/mock_rms.py
@@ -1,9 +1,10 @@
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, List
 
 from authlib.integrations.flask_client import OAuth
 
 from .abstract import RmsApi, RmsApiException, RmsUser
+from .course import ProtectedBranchSettings
 
 
 @dataclass
@@ -31,6 +32,7 @@ class MockRmsApi(RmsApi):
         self.namespace_groups: Dict[str, int] = {}  # path -> group_id
         self.last_user: str = "-1"
         self.last_group_id: int = 0
+        self.project_settings: Dict[str, Dict[str, Any]] = {}  # project_path -> {ci_config_path, protected_branches}
 
     @property
     def base_url(self) -> str:
@@ -152,12 +154,15 @@ class MockRmsApi(RmsApi):
         rms_user: RmsUser,
         course_students_group: str,
         course_public_repo: str,
+        ci_config_path: str,
+        protected_branches: List[ProtectedBranchSettings],
     ) -> None:
         project_path = f"{course_students_group}/{rms_user.username}"
         if project_path in self.projects:
             # Add user as member if not already
             if rms_user.id not in self.projects[project_path].members:
                 self.projects[project_path].members.append(rms_user.id)
+            self.ensure_project_settings(project_path, ci_config_path, protected_branches)
             return
 
         # Create project if it doesn't exist
@@ -169,6 +174,30 @@ class MockRmsApi(RmsApi):
         if course_students_group not in self.groups:
             self.groups[course_students_group] = MockRmsGroup(name=course_students_group)
         self.groups[course_students_group].projects[rms_user.username] = project
+
+        self.ensure_project_settings(project_path, ci_config_path, protected_branches)
+
+    def list_group_projects(self, group_path: str) -> List[str]:
+        group = self.groups.get(group_path)
+        if group is None:
+            return []
+        return [f"{group_path}/{name}" for name in group.projects]
+
+    def ensure_project_settings(
+        self,
+        project: Any,
+        ci_config_path: str,
+        protected_branches: List[ProtectedBranchSettings],
+    ) -> bool:
+        project_path = project if isinstance(project, str) else f"{project.group}/{project.name}"
+        desired = {
+            "ci_config_path": ci_config_path,
+            "protected_branches": [asdict(branch) for branch in protected_branches],
+        }
+        if self.project_settings.get(project_path) == desired:
+            return False
+        self.project_settings[project_path] = desired
+        return True
 
     def get_url_for_task_base(self, course_public_repo: str, default_branch: str) -> str:
         return f"{self.base_url}/{course_public_repo}/blob/{default_branch}"

--- a/manytask/manytask/models.py
+++ b/manytask/manytask/models.py
@@ -2,7 +2,7 @@ import enum
 import logging
 import re
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from sqlalchemy import JSON, BigInteger, DateTime, Enum, ForeignKey, MetaData, UniqueConstraint, func
 from sqlalchemy.engine import Dialect
@@ -11,7 +11,7 @@ from sqlalchemy.types import TypeDecorator
 
 from .course import Course as AppCourse
 from .course import CourseConfig as AppCourseConfig
-from .course import CourseStatus, ManytaskDeadlinesType
+from .course import CourseStatus, ManytaskDeadlinesType, ProtectedBranchSettings
 
 logger = logging.getLogger(__name__)
 
@@ -246,6 +246,11 @@ class Course(Base):
         server_default="HARD",
     )
 
+    # rms (CI config / protected branches) parameters
+    ci_config_path: Mapped[Optional[str]]
+    protected_branches: Mapped[Optional[list[dict[str, Any]]]] = mapped_column(JSON, nullable=True)
+    rms_settings_pending: Mapped[bool] = mapped_column(default=False, server_default="false")
+
     __table_args__ = (
         UniqueConstraint("name", name="uq_courses_name"),
         UniqueConstraint("token", name="uq_courses_token"),
@@ -279,6 +284,10 @@ class Course(Base):
                 task_url_template=self.task_url_template,
                 links=self.links,
                 deadlines_type=self.deadlines_type,
+                ci_config_path=self.ci_config_path,
+                protected_branches=[ProtectedBranchSettings(**branch) for branch in self.protected_branches]
+                if self.protected_branches
+                else None,
             )
         )
 

--- a/manytask/manytask/scripts/reconcile_student_repos.py
+++ b/manytask/manytask/scripts/reconcile_student_repos.py
@@ -1,0 +1,73 @@
+"""Apply a course's rms settings (ci_config_path, protected_branches) to every student repository.
+
+Usage: python -m manytask.scripts.reconcile_student_repos <course_name>
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from manytask.database import DataBaseApi, DatabaseConfig
+from manytask.glab import GitLabApi, GitLabConfig
+from manytask.utils.rms_settings import ReconcileResult, reconcile_course_rms_settings
+
+
+def build_db_api() -> DataBaseApi:
+    database_url = os.environ.get("DATABASE_URL")
+    if database_url is None:
+        raise EnvironmentError("Unable to find DATABASE_URL env")
+
+    instance_admin_username = os.environ.get("INITIAL_INSTANCE_ADMIN", "admin")
+    return DataBaseApi(
+        DatabaseConfig(
+            database_url=database_url,
+            instance_admin_username=instance_admin_username,
+        )
+    )
+
+
+def build_gitlab_api() -> GitLabApi:
+    gitlab_url = os.environ.get("GITLAB_URL")
+    if gitlab_url is None:
+        raise EnvironmentError("Unable to find GITLAB_URL env")
+
+    admin_token = os.environ.get("GITLAB_ADMIN_TOKEN")
+    if admin_token is None:
+        raise EnvironmentError("Unable to find GITLAB_ADMIN_TOKEN env")
+
+    verify_ssl = os.environ.get("GITLAB_VERIFY_SSL", "true").lower() in ("true", "1", "yes")
+    return GitLabApi(GitLabConfig(base_url=gitlab_url, admin_token=admin_token, verify_ssl=verify_ssl))
+
+
+def _print_result(result: ReconcileResult) -> None:
+    for project in result.projects:
+        if project.error is not None:
+            print(f"{project.project_path}: FAILED ({project.error})")
+        elif project.changed:
+            print(f"{project.project_path}: changed")
+        else:
+            print(f"{project.project_path}: already up to date")
+
+    print(
+        f"course={result.course_name} checked={result.checked} changed={result.changed} failed={result.failed}"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("course_name", help="Course name to reconcile RMS settings for")
+    args = parser.parse_args(argv)
+
+    db_api = build_db_api()
+    rms_api = build_gitlab_api()
+
+    result = reconcile_course_rms_settings(db_api, rms_api, args.course_name)
+    _print_result(result)
+
+    return 1 if not result.success else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/manytask/manytask/sourcecraft.py
+++ b/manytask/manytask/sourcecraft.py
@@ -15,6 +15,7 @@ from yandex.cloud.iam.v1.yandex_passport_user_account_service_pb2_grpc import Ya
 from yandexcloud._sdk import SDK
 
 from .abstract import RmsApi, RmsApiException, RmsUser
+from .course import ProtectedBranchSettings
 from .utils.sourcecraft import normalize_string
 
 logger = logging.getLogger(__name__)
@@ -269,17 +270,34 @@ class SourceCraftApi(RmsApi):
                 return True
         return False
 
+    def list_group_projects(self, group_path: str) -> list[str]:
+        logger.debug("SourceCraft does not support listing group projects yet")
+        return []
+
+    def ensure_project_settings(
+        self,
+        project: Any,
+        ci_config_path: str,
+        protected_branches: list[ProtectedBranchSettings],
+    ) -> bool:
+        logger.debug("SourceCraft does not support project CI/protected-branch settings yet")
+        return False
+
     def create_project(
         self,
         rms_user: RmsUser,
         course_students_group: str,
         course_public_repo: str,
+        ci_config_path: str,
+        protected_branches: list[ProtectedBranchSettings],
     ) -> None:
         """Create a personal repo for a student.
 
         :param rms_user: User information
         :param course_students_group: repo slug prefix
         :param course_public_repo: public repo slug
+        :param ci_config_path: UNUSED, SourceCraft has no equivalent setting yet
+        :param protected_branches: UNUSED, SourceCraft has no equivalent setting yet
         """
         logger.info(f"Creating repo for user {rms_user.username}")
 

--- a/manytask/manytask/utils/rms_settings.py
+++ b/manytask/manytask/utils/rms_settings.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass, field
+
+from manytask.abstract import RmsApi, StorageApi
+
+logger = logging.getLogger(__name__)
+
+_courses_in_progress: set[str] = set()
+_courses_in_progress_lock = threading.Lock()
+
+
+@dataclass
+class ProjectReconcileResult:
+    project_path: str
+    changed: bool
+    error: str | None = None
+
+
+@dataclass
+class ReconcileResult:
+    course_name: str
+    projects: list[ProjectReconcileResult] = field(default_factory=list)
+
+    @property
+    def checked(self) -> int:
+        return len(self.projects)
+
+    @property
+    def changed(self) -> int:
+        return sum(1 for project in self.projects if project.changed and project.error is None)
+
+    @property
+    def failed(self) -> int:
+        return sum(1 for project in self.projects if project.error is not None)
+
+    @property
+    def success(self) -> bool:
+        return self.failed == 0
+
+
+def reconcile_course_rms_settings(storage_api: StorageApi, rms_api: RmsApi, course_name: str) -> ReconcileResult:
+    """Apply the course's rms settings to every student project. Synchronous; safe to call repeatedly.
+
+    Clears the course's rms_settings_pending flag if (and only if) every project succeeded.
+    """
+    course = storage_api.get_course(course_name)
+    if course is None:
+        raise ValueError(f"Course {course_name} not found")
+
+    result = ReconcileResult(course_name=course_name)
+    for project_path in rms_api.list_group_projects(course.gitlab_course_students_group):
+        try:
+            changed = rms_api.ensure_project_settings(project_path, course.ci_config_path, course.protected_branches)
+            result.projects.append(ProjectReconcileResult(project_path=project_path, changed=changed))
+        except Exception as e:
+            logger.exception("Failed to apply RMS settings to project=%s course=%s", project_path, course_name)
+            result.projects.append(ProjectReconcileResult(project_path=project_path, changed=False, error=str(e)))
+
+    logger.info(
+        "RMS settings reconcile for course=%s: checked=%s changed=%s failed=%s",
+        course_name,
+        result.checked,
+        result.changed,
+        result.failed,
+    )
+
+    if result.success:
+        storage_api.clear_rms_settings_pending(course_name)
+
+    return result
+
+
+def schedule_rms_settings_reconcile(storage_api: StorageApi, rms_api: RmsApi, course_name: str) -> bool:
+    """Start a background reconcile pass for course_name unless one is already running.
+
+    :returns: whether a new pass was started
+    """
+    with _courses_in_progress_lock:
+        if course_name in _courses_in_progress:
+            logger.info("RMS settings reconcile already running for course=%s, skipping", course_name)
+            return False
+        _courses_in_progress.add(course_name)
+
+    def _run() -> None:
+        try:
+            reconcile_course_rms_settings(storage_api, rms_api, course_name)
+        finally:
+            with _courses_in_progress_lock:
+                _courses_in_progress.discard(course_name)
+
+    threading.Thread(target=_run, daemon=True, name=f"rms-reconcile-{course_name}").start()
+    return True

--- a/manytask/manytask/web.py
+++ b/manytask/manytask/web.py
@@ -390,7 +390,13 @@ def create_project(course_name: str) -> ResponseReturnValue:
 
     # Create use if needed
     try:
-        app.rms_api.create_project(rms_user, course.gitlab_course_students_group, course.gitlab_course_public_repo)
+        app.rms_api.create_project(
+            rms_user,
+            course.gitlab_course_students_group,
+            course.gitlab_course_public_repo,
+            course.ci_config_path,
+            course.protected_branches,
+        )
         logger.info("Successfully created project for user %s in course %s", rms_user.username, course.course_name)
     except gitlab.GitlabError as ex:
         logger.error("Project creation failed: %s", ex.error_message)

--- a/manytask/tests/helpers.py
+++ b/manytask/tests/helpers.py
@@ -8,7 +8,7 @@ from flask import Flask, json
 
 from manytask.abstract import RmsUser, StoredUser
 from manytask.api import namespace_bp
-from manytask.course import CourseStatus, ManytaskDeadlinesType
+from manytask.course import CourseStatus, ManytaskDeadlinesType, ProtectedBranchSettings
 from manytask.database import DataBaseApi, DatabaseConfig, TaskDisabledError
 from manytask.mock_rms import MockRmsApi
 from manytask.models import Namespace, User, UserOnNamespace
@@ -247,6 +247,27 @@ class MockCourseBase:
         self.gitlab_default_branch = "main"
         self.deadlines_type = ManytaskDeadlinesType.HARD
         self.namespace_id = None
+        self._ci_config_path: str | None = None
+        self._protected_branches: list[ProtectedBranchSettings] | None = None
+
+    @property
+    def ci_config_path(self) -> str:
+        if self._ci_config_path:
+            return self._ci_config_path
+        return f".gitlab-ci.yml@{getattr(self, 'gitlab_course_public_repo', '')}"
+
+    @property
+    def protected_branches(self) -> list[ProtectedBranchSettings]:
+        if self._protected_branches:
+            return self._protected_branches
+        return [
+            ProtectedBranchSettings(
+                name=self.gitlab_default_branch,
+                push_access_level="developer",
+                merge_access_level="developer",
+                allow_force_push=True,
+            )
+        ]
 
 
 class MockFinalGradeConfig:

--- a/manytask/tests/test_api.py
+++ b/manytask/tests/test_api.py
@@ -15,6 +15,7 @@ from manytask.abstract import RmsUser
 from manytask.api import _parse_flags, _process_score, _update_score, _validate_and_extract_params
 from manytask.api import bp as api_bp
 from manytask.config import ManytaskConfig, ManytaskDeadlinesType, ManytaskGroupConfig, ManytaskTaskConfig
+from manytask.course import ProtectedBranchSettings
 from manytask.database import DataBaseApi
 from manytask.mock_auth import MockAuthApi
 from manytask.mock_rms import MockRmsApi
@@ -233,7 +234,17 @@ def authenticated_client(app, mock_gitlab_oauth):
         rms_user: RmsUser = app.rms_api.register_new_user(
             TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD
         )
-        app.rms_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+        app.rms_api.create_project(
+            rms_user,
+            TEST_STUDENTS_GROUP,
+            TEST_PUBLIC_REPO,
+            f".gitlab-ci.yml@{TEST_PUBLIC_REPO}",
+            [
+                ProtectedBranchSettings(
+                    name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+                )
+            ],
+        )
 
         mock_authorize_access_token.return_value = {
             "access_token": "test_token",

--- a/manytask/tests/test_config.py
+++ b/manytask/tests/test_config.py
@@ -1,0 +1,69 @@
+import pytest
+from pydantic import ValidationError
+
+from manytask.config import ManytaskRmsConfig, ProtectedBranchConfig
+
+
+def test_protected_branch_config_defaults():
+    branch = ProtectedBranchConfig(name="main")
+
+    assert branch.push_access_level == "developer"
+    assert branch.merge_access_level == "developer"
+    assert branch.allow_force_push is True
+
+
+def test_protected_branch_config_explicit_values():
+    branch = ProtectedBranchConfig(
+        name="release",
+        push_access_level="maintainer",
+        merge_access_level="no_access",
+        allow_force_push=False,
+    )
+
+    assert branch.push_access_level == "maintainer"
+    assert branch.merge_access_level == "no_access"
+    assert branch.allow_force_push is False
+
+
+def test_protected_branch_config_rejects_empty_name():
+    with pytest.raises(ValidationError):
+        ProtectedBranchConfig(name="")
+
+
+def test_protected_branch_config_rejects_invalid_access_level():
+    with pytest.raises(ValidationError):
+        ProtectedBranchConfig(name="main", push_access_level="owner")
+
+
+def test_rms_config_all_fields_optional():
+    rms = ManytaskRmsConfig()
+
+    assert rms.ci_config_path is None
+    assert rms.protected_branches is None
+
+
+def test_rms_config_parses_full_section():
+    rms = ManytaskRmsConfig(
+        ci_config_path=".gitlab-ci.yml@caos-ami/public-2026",
+        protected_branches=[
+            {
+                "name": "main",
+                "push_access_level": "developer",
+                "merge_access_level": "developer",
+                "allow_force_push": True,
+            }
+        ],
+    )
+
+    assert rms.ci_config_path == ".gitlab-ci.yml@caos-ami/public-2026"
+    assert rms.protected_branches[0].name == "main"
+
+
+def test_rms_config_rejects_duplicate_branch_names():
+    with pytest.raises(ValidationError, match="unique"):
+        ManytaskRmsConfig(
+            protected_branches=[
+                {"name": "main"},
+                {"name": "main"},
+            ]
+        )

--- a/manytask/tests/test_course.py
+++ b/manytask/tests/test_course.py
@@ -1,3 +1,91 @@
+from manytask.course import (
+    Course,
+    CourseConfig,
+    CourseStatus,
+    ProtectedBranchSettings,
+    resolve_effective_ci_config_path,
+    resolve_effective_protected_branches,
+)
+
+
 class TestTask:
     def test_dummy(self) -> None:
         assert True
+
+
+def test_resolve_effective_ci_config_path_uses_configured_value():
+    assert resolve_effective_ci_config_path("custom/path.yml@group/repo", "group/repo") == "custom/path.yml@group/repo"
+
+
+def test_resolve_effective_ci_config_path_defaults_to_public_repo():
+    assert resolve_effective_ci_config_path(None, "group/repo") == ".gitlab-ci.yml@group/repo"
+
+
+def test_resolve_effective_protected_branches_uses_configured_value():
+    configured = [
+        ProtectedBranchSettings(
+            name="release", push_access_level="maintainer", merge_access_level="maintainer", allow_force_push=False
+        )
+    ]
+
+    assert resolve_effective_protected_branches(configured, "main") == configured
+
+
+def test_resolve_effective_protected_branches_defaults_to_default_branch():
+    result = resolve_effective_protected_branches(None, "main")
+
+    assert result == [
+        ProtectedBranchSettings(
+            name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+        )
+    ]
+
+
+def _course_config(**overrides):
+    defaults = dict(
+        course_name="test_course",
+        namespace_id=None,
+        gitlab_course_group="group",
+        gitlab_course_public_repo="group/public",
+        gitlab_course_students_group="group/students",
+        gitlab_default_branch="main",
+        registration_secret="secret",
+        token="token",
+        show_allscores=True,
+        status=CourseStatus.CREATED,
+    )
+    defaults.update(overrides)
+    return CourseConfig(**defaults)
+
+
+def test_course_ci_config_path_defaults_when_not_configured():
+    course = Course(_course_config())
+
+    assert course.ci_config_path == ".gitlab-ci.yml@group/public"
+
+
+def test_course_ci_config_path_uses_configured_value():
+    course = Course(_course_config(ci_config_path="custom.yml@group/other"))
+
+    assert course.ci_config_path == "custom.yml@group/other"
+
+
+def test_course_protected_branches_defaults_when_not_configured():
+    course = Course(_course_config())
+
+    assert course.protected_branches == [
+        ProtectedBranchSettings(
+            name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+        )
+    ]
+
+
+def test_course_protected_branches_uses_configured_value():
+    configured = [
+        ProtectedBranchSettings(
+            name="release", push_access_level="no_access", merge_access_level="maintainer", allow_force_push=False
+        )
+    ]
+    course = Course(_course_config(protected_branches=configured))
+
+    assert course.protected_branches == configured

--- a/manytask/tests/test_db_api.py
+++ b/manytask/tests/test_db_api.py
@@ -20,10 +20,12 @@ from manytask.config import (
     ManytaskDeadlinesConfig,
     ManytaskFinalGradeConfig,
     ManytaskGroupConfig,
+    ManytaskRmsConfig,
     ManytaskUiConfig,
+    ProtectedBranchConfig,
 )
 from manytask.course import Course as ManytaskCourse
-from manytask.course import CourseConfig, CourseStatus, ManytaskDeadlinesType
+from manytask.course import CourseConfig, CourseStatus, ManytaskDeadlinesType, ProtectedBranchSettings
 from manytask.database import DataBaseApi, DatabaseConfig, TaskDisabledError
 from manytask.models import (
     Course,
@@ -265,9 +267,12 @@ def update_course(
     ui_config: ManytaskUiConfig,
     deadlines_config: ManytaskDeadlinesConfig,
     final_grade_config: ManytaskFinalGradeConfig | None = None,
+    rms_config: ManytaskRmsConfig | None = None,
 ) -> None:
     """Update created course"""
-    config = ManytaskConfig(version=1, ui=ui_config, deadlines=deadlines_config, grades=final_grade_config)
+    config = ManytaskConfig(
+        version=1, ui=ui_config, deadlines=deadlines_config, grades=final_grade_config, rms=rms_config
+    )
 
     db_api.update_course(course_name=course_name, config=config)
 
@@ -697,6 +702,104 @@ def test_updating_course(
         disabled_groups=disabled_groups,
         disabled_tasks=disabled_tasks,
     )
+
+
+def test_create_course_resolves_rms_defaults_and_sets_pending(db_api_with_initialized_first_course, session):
+    course = session.query(Course).filter_by(name=FIRST_COURSE_NAME).one()
+
+    assert course.ci_config_path == ".gitlab-ci.yml@test_course_public_repo"
+    assert course.protected_branches == [
+        {
+            "name": "test_default_branch",
+            "push_access_level": "developer",
+            "merge_access_level": "developer",
+            "allow_force_push": True,
+        }
+    ]
+    assert course.rms_settings_pending is True
+
+
+def test_update_course_unchanged_rms_keeps_pending_until_cleared(
+    db_api_with_initialized_first_course, first_course_deadlines_config, session
+):
+    db_api_with_initialized_first_course.clear_rms_settings_pending(FIRST_COURSE_NAME)
+
+    update_course(
+        db_api_with_initialized_first_course,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template="https://example.com/$TASK_NAME", links={}),
+        first_course_deadlines_config,
+    )
+
+    course = session.query(Course).filter_by(name=FIRST_COURSE_NAME).one()
+    assert course.rms_settings_pending is False
+    assert db_api_with_initialized_first_course.rms_settings_reconcile_needed(FIRST_COURSE_NAME) is False
+
+
+def test_update_course_rms_change_sets_pending_again(
+    db_api_with_initialized_first_course, first_course_deadlines_config, session
+):
+    db_api_with_initialized_first_course.clear_rms_settings_pending(FIRST_COURSE_NAME)
+
+    update_course(
+        db_api_with_initialized_first_course,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template="https://example.com/$TASK_NAME", links={}),
+        first_course_deadlines_config,
+        rms_config=ManytaskRmsConfig(ci_config_path=".gitlab-ci.yml@other/repo"),
+    )
+
+    course = session.query(Course).filter_by(name=FIRST_COURSE_NAME).one()
+    assert course.ci_config_path == ".gitlab-ci.yml@other/repo"
+    assert course.rms_settings_pending is True
+    assert db_api_with_initialized_first_course.rms_settings_reconcile_needed(FIRST_COURSE_NAME) is True
+
+
+def test_update_course_rms_still_pending_when_reapplied_unchanged(
+    db_api_with_initialized_first_course, first_course_deadlines_config, session
+):
+    # rms_settings_pending is already True from course creation (NULL -> resolved defaults).
+    update_course(
+        db_api_with_initialized_first_course,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template="https://example.com/$TASK_NAME", links={}),
+        first_course_deadlines_config,
+    )
+
+    course = session.query(Course).filter_by(name=FIRST_COURSE_NAME).one()
+    assert course.rms_settings_pending is True
+
+
+def test_update_course_protected_branches_order_insensitive_no_change(
+    db_api_with_initialized_first_course, first_course_deadlines_config, session
+):
+    branches = [
+        ProtectedBranchConfig(name="a", push_access_level="developer"),
+        ProtectedBranchConfig(name="b", push_access_level="maintainer"),
+    ]
+    update_course(
+        db_api_with_initialized_first_course,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template="https://example.com/$TASK_NAME", links={}),
+        first_course_deadlines_config,
+        rms_config=ManytaskRmsConfig(protected_branches=branches),
+    )
+    db_api_with_initialized_first_course.clear_rms_settings_pending(FIRST_COURSE_NAME)
+
+    reordered_branches = [
+        ProtectedBranchConfig(name="b", push_access_level="maintainer"),
+        ProtectedBranchConfig(name="a", push_access_level="developer"),
+    ]
+    update_course(
+        db_api_with_initialized_first_course,
+        FIRST_COURSE_NAME,
+        ManytaskUiConfig(task_url_template="https://example.com/$TASK_NAME", links={}),
+        first_course_deadlines_config,
+        rms_config=ManytaskRmsConfig(protected_branches=reordered_branches),
+    )
+
+    course = session.query(Course).filter_by(name=FIRST_COURSE_NAME).one()
+    assert course.rms_settings_pending is False
 
 
 def test_resync_with_changed_task_name(
@@ -1254,11 +1357,31 @@ def test_store_score_update_error(db_api_with_two_initialized_courses, session):
 
 
 def test_get_course_success(db_api_with_two_initialized_courses, first_course_config, second_course_config):
+    # update_course resolves and persists the effective (defaults-resolved) rms settings, so the
+    # freshly-loaded course carries those instead of the None the config fixtures start with.
     first_course_config.status = CourseStatus.HIDDEN
+    first_course_config.ci_config_path = f".gitlab-ci.yml@{first_course_config.gitlab_course_public_repo}"
+    first_course_config.protected_branches = [
+        ProtectedBranchSettings(
+            name=first_course_config.gitlab_default_branch,
+            push_access_level="developer",
+            merge_access_level="developer",
+            allow_force_push=True,
+        )
+    ]
     course = db_api_with_two_initialized_courses.get_course(FIRST_COURSE_NAME)
     assert course.__dict__ == ManytaskCourse(first_course_config).__dict__
 
     second_course_config.status = CourseStatus.HIDDEN
+    second_course_config.ci_config_path = f".gitlab-ci.yml@{second_course_config.gitlab_course_public_repo}"
+    second_course_config.protected_branches = [
+        ProtectedBranchSettings(
+            name=second_course_config.gitlab_default_branch,
+            push_access_level="developer",
+            merge_access_level="developer",
+            allow_force_push=True,
+        )
+    ]
     course = db_api_with_two_initialized_courses.get_course(SECOND_COURSE_NAME)
     assert course.__dict__ == ManytaskCourse(second_course_config).__dict__
 

--- a/manytask/tests/test_glab.py
+++ b/manytask/tests/test_glab.py
@@ -2,7 +2,7 @@ from unittest import mock
 from unittest.mock import MagicMock, patch
 
 import pytest
-from gitlab import GitlabGetError, const
+from gitlab import GitlabCreateError, GitlabGetError, const
 from gitlab.v4.objects import Group, GroupMember, Project, ProjectFork, User
 
 from manytask.abstract import RmsApiException
@@ -329,6 +329,7 @@ def test_create_project_no_existing_project_creates_fork(
     rms_api._get_group_by_name = MagicMock(return_value=mock_gitlab_group)
     rms_api._get_project_by_name = MagicMock(return_value=mock_gitlab_student_project)
     mock_gitlab_student_project.forks.create.return_value = mock_gitlab_fork
+    mock_gitlab_instance.projects.get.return_value.import_status = "finished"
 
     rms_api.create_project(
         mock_rms_user, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES
@@ -514,3 +515,74 @@ def test_list_group_projects(gitlab):
 
     assert paths == ["group/a", "group/b"]
     group.projects.list.assert_called_once_with(get_all=True)
+
+
+def _already_exists_error():
+    return GitlabCreateError(error_message="Protected branch 'main' already exists", response_code=409)
+
+
+@patch("manytask.glab.time.sleep")
+def test_ensure_project_settings_retries_when_branch_appears_after_listing(mock_sleep, gitlab):
+    rms_api, _ = gitlab
+    project = _mock_project(TEST_CI_CONFIG_PATH, [])
+    project.protectedbranches.create.side_effect = [_already_exists_error(), MagicMock()]
+    appeared = _mock_protected_branch("main", const.AccessLevel.MAINTAINER, const.AccessLevel.MAINTAINER, False)
+    project.protectedbranches.get.return_value = appeared
+
+    changed = rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    assert changed is True
+    mock_sleep.assert_called_once()
+    project.protectedbranches.get.assert_called_once_with("main")
+    appeared.delete.assert_called_once()
+    assert project.protectedbranches.create.call_args_list == [mock.call(mock.ANY), mock.call(mock.ANY)]
+
+
+@patch("manytask.glab.time.sleep")
+def test_ensure_project_settings_keeps_branch_that_appeared_matching(mock_sleep, gitlab):
+    rms_api, _ = gitlab
+    project = _mock_project(TEST_CI_CONFIG_PATH, [])
+    project.protectedbranches.create.side_effect = _already_exists_error()
+    appeared = _mock_protected_branch("main", const.AccessLevel.DEVELOPER, const.AccessLevel.DEVELOPER, True)
+    project.protectedbranches.get.return_value = appeared
+
+    rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    appeared.delete.assert_not_called()
+    assert project.protectedbranches.create.call_count == 1
+
+
+@patch("manytask.glab.time.sleep")
+def test_ensure_project_settings_gives_up_after_retries(mock_sleep, gitlab):
+    rms_api, _ = gitlab
+    project = _mock_project(TEST_CI_CONFIG_PATH, [])
+    project.protectedbranches.create.side_effect = _already_exists_error()
+    project.protectedbranches.get.return_value = _mock_protected_branch(
+        "main", const.AccessLevel.MAINTAINER, const.AccessLevel.MAINTAINER, False
+    )
+
+    with pytest.raises(GitlabCreateError):
+        rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+
+def test_ensure_project_settings_reraises_other_create_errors(gitlab):
+    rms_api, _ = gitlab
+    project = _mock_project(TEST_CI_CONFIG_PATH, [])
+    project.protectedbranches.create.side_effect = GitlabCreateError(error_message="forbidden", response_code=403)
+
+    with pytest.raises(GitlabCreateError):
+        rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+    project.protectedbranches.get.assert_not_called()
+
+
+@patch("manytask.glab.time.sleep")
+def test_wait_fork_imported_polls_until_finished(mock_sleep, gitlab):
+    rms_api, mock_gitlab_instance = gitlab
+    importing = MagicMock(id=7, import_status="started")
+    finished = MagicMock(id=7, import_status="finished")
+    mock_gitlab_instance.projects.get.side_effect = [importing, finished]
+
+    result = rms_api._wait_fork_imported(importing)
+
+    assert result is finished
+    assert mock_sleep.call_args_list == [mock.call(1), mock.call(1)]

--- a/manytask/tests/test_glab.py
+++ b/manytask/tests/test_glab.py
@@ -6,6 +6,7 @@ from gitlab import GitlabGetError, const
 from gitlab.v4.objects import Group, GroupMember, Project, ProjectFork, User
 
 from manytask.abstract import RmsApiException
+from manytask.course import ProtectedBranchSettings
 from manytask.glab import GitLabApi, GitLabConfig, RmsUser, _make_public_repo_params, _make_students_group_params
 from tests.constants import (
     TEST_FORK_ID,
@@ -33,6 +34,13 @@ from tests.constants import (
     TEST_USER_URL,
     TEST_USERNAME,
 )
+
+TEST_CI_CONFIG_PATH = f".gitlab-ci.yml@{TEST_GROUP_PUBLIC_NAME}"
+TEST_PROTECTED_BRANCHES = [
+    ProtectedBranchSettings(
+        name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+    )
+]
 
 
 # Shared fixture logic
@@ -302,7 +310,9 @@ def test_create_project_existing_project(gitlab, mock_rms_user, mock_gitlab_stud
     mock_gitlab_instance.projects.get.return_value = mock_gitlab_student_project
     mock_gitlab_student_project.members.create.return_value = mock_gitlab_group_member
 
-    rms_api.create_project(mock_rms_user, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME)
+    rms_api.create_project(
+        mock_rms_user, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES
+    )
 
     mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=mock_rms_user.username)
     mock_gitlab_instance.projects.get.assert_called_with(mock_gitlab_student_project.id)
@@ -320,7 +330,9 @@ def test_create_project_no_existing_project_creates_fork(
     rms_api._get_project_by_name = MagicMock(return_value=mock_gitlab_student_project)
     mock_gitlab_student_project.forks.create.return_value = mock_gitlab_fork
 
-    rms_api.create_project(mock_rms_user, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME)
+    rms_api.create_project(
+        mock_rms_user, TEST_GROUP_STUDENT_NAME, TEST_GROUP_PUBLIC_NAME, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES
+    )
 
     mock_gitlab_instance.projects.list.assert_called_with(get_all=True, search=mock_rms_user.username)
     rms_api._get_project_by_name.assert_called_with(TEST_GROUP_PUBLIC_NAME)
@@ -402,3 +414,103 @@ def test_get_url_for_repo(gitlab):
     url = gitlab_api.get_url_for_repo(TEST_USERNAME, TEST_GROUP_STUDENT_NAME)
 
     assert url == f"{gitlab_api.base_url}/{TEST_GROUP_STUDENT_NAME}/{TEST_USERNAME}"
+
+
+def _mock_protected_branch(name, push_level, merge_level, allow_force_push):
+    branch = MagicMock()
+    branch.name = name
+    branch.push_access_levels = [{"access_level": push_level}]
+    branch.merge_access_levels = [{"access_level": merge_level}]
+    branch.allow_force_push = allow_force_push
+    return branch
+
+
+def _mock_project(ci_config_path, existing_branches):
+    project = MagicMock()
+    project.ci_config_path = ci_config_path
+    project.path_with_namespace = "group/project"
+    project.protectedbranches.list.return_value = existing_branches
+    return project
+
+
+def test_ensure_project_settings_no_writes_when_matching(gitlab):
+    rms_api, _ = gitlab
+    existing_branch = _mock_protected_branch("main", const.AccessLevel.DEVELOPER, const.AccessLevel.DEVELOPER, True)
+    project = _mock_project(TEST_CI_CONFIG_PATH, [existing_branch])
+
+    changed = rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    assert changed is False
+    project.save.assert_not_called()
+    existing_branch.delete.assert_not_called()
+    project.protectedbranches.create.assert_not_called()
+
+
+def test_ensure_project_settings_fixes_ci_config_path(gitlab):
+    rms_api, _ = gitlab
+    existing_branch = _mock_protected_branch("main", const.AccessLevel.DEVELOPER, const.AccessLevel.DEVELOPER, True)
+    project = _mock_project("stale/path", [existing_branch])
+
+    changed = rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    assert changed is True
+    assert project.ci_config_path == TEST_CI_CONFIG_PATH
+    project.save.assert_called_once()
+    existing_branch.delete.assert_not_called()
+    project.protectedbranches.create.assert_not_called()
+
+
+def test_ensure_project_settings_fixes_mismatched_protected_branch(gitlab):
+    rms_api, _ = gitlab
+    existing_branch = _mock_protected_branch("main", const.AccessLevel.MAINTAINER, const.AccessLevel.DEVELOPER, True)
+    project = _mock_project(TEST_CI_CONFIG_PATH, [existing_branch])
+
+    changed = rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    assert changed is True
+    project.save.assert_not_called()
+    existing_branch.delete.assert_called_once()
+    project.protectedbranches.create.assert_called_once_with(
+        {
+            "name": "main",
+            "push_access_level": const.AccessLevel.DEVELOPER,
+            "merge_access_level": const.AccessLevel.DEVELOPER,
+            "allow_force_push": True,
+        }
+    )
+
+
+def test_ensure_project_settings_creates_missing_branch(gitlab):
+    rms_api, _ = gitlab
+    project = _mock_project(TEST_CI_CONFIG_PATH, [])
+
+    changed = rms_api.ensure_project_settings(project, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    assert changed is True
+    project.protectedbranches.create.assert_called_once()
+
+
+def test_ensure_project_settings_accepts_project_path(gitlab):
+    rms_api, mock_gitlab_instance = gitlab
+    existing_branch = _mock_protected_branch("main", const.AccessLevel.DEVELOPER, const.AccessLevel.DEVELOPER, True)
+    project = _mock_project(TEST_CI_CONFIG_PATH, [existing_branch])
+    mock_gitlab_instance.projects.get.return_value = project
+
+    changed = rms_api.ensure_project_settings("group/project", TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    assert changed is False
+    mock_gitlab_instance.projects.get.assert_called_with("group/project")
+
+
+def test_list_group_projects(gitlab):
+    rms_api, _ = gitlab
+    group = MagicMock()
+    project_a = MagicMock(path_with_namespace="group/a")
+    project_b = MagicMock(path_with_namespace="group/b")
+    group.projects.list.return_value = [project_a, project_b]
+    rms_api._get_group_by_name = MagicMock(return_value=group)
+
+    paths = rms_api.list_group_projects("group")
+
+    assert paths == ["group/a", "group/b"]
+    group.projects.list.assert_called_once_with(get_all=True)

--- a/manytask/tests/test_main.py
+++ b/manytask/tests/test_main.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 from dotenv import load_dotenv
@@ -10,6 +11,24 @@ from tests.constants import (
     TEST_PUBLIC_REPO,
     TEST_STUDENTS_GROUP,
 )
+
+
+def _minimal_config():
+    return {
+        "version": 1,
+        "ui": {"task_url_template": "https://example.org/$GROUP_NAME/$USER_NAME/$TASK_NAME"},
+        "deadlines": {
+            "timezone": "Europe/Moscow",
+            "schedule": [
+                {
+                    "group": "week_1",
+                    "start": "2025-01-01 10:00",
+                    "end": "2025-01-15 23:59",
+                    "tasks": [{"task": "task_1", "score": 10}],
+                }
+            ],
+        },
+    }
 
 
 @pytest.fixture
@@ -85,3 +104,30 @@ def test_create_app_missing_secret_key(mock_env):
     os.environ.pop("FLASK_SECRET_KEY", None)
     with pytest.raises(EnvironmentError):
         create_app()
+
+
+def test_store_config_schedules_reconcile_when_pending():
+    app = CustomFlask(__name__)
+    app.storage_api = MagicMock()
+    app.storage_api.rms_settings_reconcile_needed.return_value = True
+    app.rms_api = MagicMock()
+
+    with patch("manytask.main.schedule_rms_settings_reconcile") as mock_schedule:
+        app.store_config(TEST_COURSE_NAME, _minimal_config())
+
+    app.storage_api.update_course.assert_called_once()
+    app.storage_api.rms_settings_reconcile_needed.assert_called_once_with(TEST_COURSE_NAME)
+    mock_schedule.assert_called_once_with(app.storage_api, app.rms_api, TEST_COURSE_NAME)
+
+
+def test_store_config_skips_reconcile_when_not_pending():
+    app = CustomFlask(__name__)
+    app.storage_api = MagicMock()
+    app.storage_api.rms_settings_reconcile_needed.return_value = False
+    app.rms_api = MagicMock()
+
+    with patch("manytask.main.schedule_rms_settings_reconcile") as mock_schedule:
+        app.store_config(TEST_COURSE_NAME, _minimal_config())
+
+    app.storage_api.update_course.assert_called_once()
+    mock_schedule.assert_not_called()

--- a/manytask/tests/test_mock_rms.py
+++ b/manytask/tests/test_mock_rms.py
@@ -1,6 +1,7 @@
 import pytest
 
 from manytask.abstract import RmsApiException
+from manytask.course import ProtectedBranchSettings
 from manytask.mock_rms import MockRmsApi
 from tests.constants import (
     GITLAB_BASE_URL,
@@ -13,6 +14,13 @@ from tests.constants import (
     TEST_STUDENTS_GROUP,
     TEST_USERNAME,
 )
+
+TEST_CI_CONFIG_PATH = f".gitlab-ci.yml@{TEST_GROUP_NAME}/{TEST_PUBLIC_REPO}"
+TEST_PROTECTED_BRANCHES = [
+    ProtectedBranchSettings(
+        name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+    )
+]
 
 
 def test_register_new_user():
@@ -50,10 +58,43 @@ def test_create_project():
 
     api.create_public_repo(TEST_GROUP_NAME, TEST_PUBLIC_REPO)
     api.create_students_group(TEST_STUDENTS_GROUP)
-    api.create_project(user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+    api.create_project(user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
 
     assert api.check_project_exists(TEST_USERNAME, TEST_STUDENTS_GROUP) is True
     assert (
         api.get_url_for_repo(TEST_USERNAME, TEST_STUDENTS_GROUP)
         == f"{GITLAB_BASE_URL}/{TEST_STUDENTS_GROUP}/{TEST_USERNAME}"
     )
+
+    project_path = f"{TEST_STUDENTS_GROUP}/{TEST_USERNAME}"
+    assert api.project_settings[project_path]["ci_config_path"] == TEST_CI_CONFIG_PATH
+    assert api.list_group_projects(TEST_STUDENTS_GROUP) == [project_path]
+
+
+def test_create_project_existing_project_updates_settings():
+    api = MockRmsApi(GITLAB_BASE_URL)
+    api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
+    user = api.get_rms_user_by_username(TEST_USERNAME)
+
+    api.create_public_repo(TEST_GROUP_NAME, TEST_PUBLIC_REPO)
+    api.create_students_group(TEST_STUDENTS_GROUP)
+    api.create_project(user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES)
+
+    new_ci_config_path = ".gitlab-ci.yml@other/repo"
+    api.create_project(user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO, new_ci_config_path, TEST_PROTECTED_BRANCHES)
+
+    project_path = f"{TEST_STUDENTS_GROUP}/{TEST_USERNAME}"
+    assert api.project_settings[project_path]["ci_config_path"] == new_ci_config_path
+
+
+def test_ensure_project_settings_no_change_returns_false():
+    api = MockRmsApi(GITLAB_BASE_URL)
+    project_path = "group/project"
+
+    assert api.ensure_project_settings(project_path, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES) is True
+    assert api.ensure_project_settings(project_path, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES) is False
+
+
+def test_list_group_projects_unknown_group_returns_empty():
+    api = MockRmsApi(GITLAB_BASE_URL)
+    assert api.list_group_projects("unknown/group") == []

--- a/manytask/tests/test_rms_settings.py
+++ b/manytask/tests/test_rms_settings.py
@@ -1,0 +1,121 @@
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from manytask.course import ProtectedBranchSettings
+from manytask.mock_rms import MockRmsApi, MockRmsGroup, MockRmsProject
+from manytask.utils import rms_settings
+from manytask.utils.rms_settings import reconcile_course_rms_settings, schedule_rms_settings_reconcile
+
+
+class FakeCourse:
+    def __init__(self, students_group, ci_config_path, protected_branches):
+        self.gitlab_course_students_group = students_group
+        self.ci_config_path = ci_config_path
+        self.protected_branches = protected_branches
+
+
+def _branches():
+    return [
+        ProtectedBranchSettings(
+            name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+        )
+    ]
+
+
+def _make_rms_api_with_projects(group_path, usernames):
+    api = MockRmsApi("http://gitlab.test")
+    group = MockRmsGroup(name=group_path)
+    for username in usernames:
+        project = MockRmsProject(name=username, group=group_path)
+        api.projects[f"{group_path}/{username}"] = project
+        group.projects[username] = project
+    api.groups[group_path] = group
+    return api
+
+
+def test_reconcile_applies_settings_and_clears_pending():
+    group_path = "group/students"
+    api = _make_rms_api_with_projects(group_path, ["alice", "bob"])
+    storage_api = MagicMock()
+    storage_api.get_course.return_value = FakeCourse(group_path, ".gitlab-ci.yml@group/public", _branches())
+
+    result = reconcile_course_rms_settings(storage_api, api, "test_course")
+
+    assert result.checked == 2  # noqa: PLR2004
+    assert result.changed == 2  # noqa: PLR2004
+    assert result.failed == 0
+    assert result.success is True
+    storage_api.clear_rms_settings_pending.assert_called_once_with("test_course")
+
+
+def test_reconcile_second_pass_is_idempotent():
+    group_path = "group/students"
+    api = _make_rms_api_with_projects(group_path, ["alice"])
+    storage_api = MagicMock()
+    storage_api.get_course.return_value = FakeCourse(group_path, ".gitlab-ci.yml@group/public", _branches())
+
+    reconcile_course_rms_settings(storage_api, api, "test_course")
+    result = reconcile_course_rms_settings(storage_api, api, "test_course")
+
+    assert result.checked == 1
+    assert result.changed == 0
+
+
+def test_reconcile_reports_failures_and_leaves_pending():
+    group_path = "group/students"
+    api = _make_rms_api_with_projects(group_path, ["alice"])
+    api.ensure_project_settings = MagicMock(side_effect=RuntimeError("boom"))
+    storage_api = MagicMock()
+    storage_api.get_course.return_value = FakeCourse(group_path, ".gitlab-ci.yml@group/public", _branches())
+
+    result = reconcile_course_rms_settings(storage_api, api, "test_course")
+
+    assert result.checked == 1
+    assert result.changed == 0
+    assert result.failed == 1
+    assert result.success is False
+    storage_api.clear_rms_settings_pending.assert_not_called()
+
+
+def test_reconcile_unknown_course_raises():
+    storage_api = MagicMock()
+    storage_api.get_course.return_value = None
+    api = MockRmsApi("http://gitlab.test")
+
+    with pytest.raises(ValueError):
+        reconcile_course_rms_settings(storage_api, api, "missing")
+
+
+def test_schedule_skips_when_already_running():
+    storage_api = MagicMock()
+    api = MagicMock()
+
+    with rms_settings._courses_in_progress_lock:
+        rms_settings._courses_in_progress.add("busy_course")
+    try:
+        started = schedule_rms_settings_reconcile(storage_api, api, "busy_course")
+        assert started is False
+    finally:
+        with rms_settings._courses_in_progress_lock:
+            rms_settings._courses_in_progress.discard("busy_course")
+
+
+def test_schedule_starts_background_reconcile_and_clears_pending():
+    group_path = "group/students"
+    api = _make_rms_api_with_projects(group_path, ["alice"])
+    storage_api = MagicMock()
+    storage_api.get_course.return_value = FakeCourse(group_path, ".gitlab-ci.yml@group/public", _branches())
+
+    started = schedule_rms_settings_reconcile(storage_api, api, "threaded_course")
+    assert started is True
+
+    for _ in range(50):
+        with rms_settings._courses_in_progress_lock:
+            still_running = "threaded_course" in rms_settings._courses_in_progress
+        if not still_running:
+            break
+        time.sleep(0.05)
+
+    storage_api.clear_rms_settings_pending.assert_called_once_with("threaded_course")

--- a/manytask/tests/test_sourcecraft.py
+++ b/manytask/tests/test_sourcecraft.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from manytask.abstract import RmsApiException, RmsUser
+from manytask.course import ProtectedBranchSettings
 from manytask.sourcecraft import SourceCraftApi, SourceCraftConfig
 
 TEST_ORG = "hsemanytask"
@@ -23,6 +24,13 @@ TEST_PUBLIC_REPO = "public-2026-fall"
 YANDEX_LOGIN = "Ps5"
 SOURCECRAFT_USERNAME = "ps5-1"
 TEST_RMS_ID = "rms-uuid-1"
+# SourceCraft ignores these; passed to satisfy create_project's signature.
+TEST_CI_CONFIG_PATH = f".gitlab-ci.yml@{TEST_PUBLIC_REPO}"
+TEST_PROTECTED_BRANCHES = [
+    ProtectedBranchSettings(
+        name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+    )
+]
 DOMAIN_LOGIN = "anna@example.org"
 DOMAIN_SLUG = "anna-example-org"
 
@@ -86,7 +94,9 @@ def test_create_project_slug_derives_from_rms_user_username(sourcecraft_api):
         raise AssertionError(f"unexpected request {method} {path}")
 
     with patch.object(sourcecraft_api, "_request", side_effect=request_side_effect) as mock_request:
-        sourcecraft_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+        sourcecraft_api.create_project(
+            rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES
+        )
 
     create_calls = [call for call in mock_request.call_args_list if call.args == ("POST", f"orgs/{TEST_ORG}/repos")]
     assert len(create_calls) == 1
@@ -120,7 +130,9 @@ def test_existence_check_and_create_use_matching_slug(sourcecraft_api):
 
     with patch.object(sourcecraft_api, "_request", side_effect=record_request):
         # Simulate what create_project (using rms_user.username) would create ...
-        sourcecraft_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+        sourcecraft_api.create_project(
+            rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO, TEST_CI_CONFIG_PATH, TEST_PROTECTED_BRANCHES
+        )
         # ... and then verify that a subsequent existence check with the SAME
         # (SC-native) username hits the same slug.
         assert (

--- a/manytask/tests/test_web.py
+++ b/manytask/tests/test_web.py
@@ -10,7 +10,7 @@ from flask_wtf import CSRFProtect
 
 from manytask.abstract import AuthenticatedUser, StudentCourseScores, TaskScore
 from manytask.api import bp as api_bp
-from manytask.course import CourseStatus
+from manytask.course import CourseStatus, ProtectedBranchSettings
 from manytask.local_config import LocalConfig
 from manytask.mock_auth import MockAuthApi
 from manytask.mock_rms import MockRmsApi
@@ -61,7 +61,17 @@ def app(mock_storage_api):
     app.register_blueprint(instance_admin_bp)
     app.rms_api = MockRmsApi(GITLAB_BASE_URL)
     rms_user = app.rms_api.register_new_user(TEST_USERNAME, TEST_FIRST_NAME, TEST_LAST_NAME, TEST_EMAIL, TEST_PASSWORD)
-    app.rms_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+    app.rms_api.create_project(
+        rms_user,
+        TEST_STUDENTS_GROUP,
+        TEST_PUBLIC_REPO,
+        f".gitlab-ci.yml@{TEST_PUBLIC_REPO}",
+        [
+            ProtectedBranchSettings(
+                name="main", push_access_level="developer", merge_access_level="developer", allow_force_push=True
+            )
+        ],
+    )
     app.auth_api = MockAuthApi()
     app.auth_api.user = AuthenticatedUser(id=TEST_USER_ID, username=TEST_USERNAME)
     app.storage_api = mock_storage_api


### PR DESCRIPTION
Adds an optional rms section to .manytask.yml that controls two GitLab settings of every student repository:

```yaml
  rms:
    ci_config_path: .gitlab-ci.yml@my-course/public-2026
    protected_branches:
      - name: main
        push_access_level: developer   # no_access | developer | maintainer
        merge_access_level: developer
        allow_force_push: true
```