### PR TITLE
sourcecraft: idempotent create_project + retry on transient errors

### DIFF
--- a/manytask/manytask/sourcecraft.py
+++ b/manytask/manytask/sourcecraft.py
@@ -193,17 +193,10 @@ class SourceCraftApi(RmsApi):
         role: str,
         user_id: str,
     ) -> None:
-        # Idempotency: if the user already has any role on this repo, skip the
-        # POST entirely. create_project can be safely re-invoked to recover a
-        # partial setup (repo created, role assignment failed on previous run).
-        get_response = self._request("GET", f"repos/{self._org_slug}/{repo_slug}/roles")
-        if get_response.status_code == HTTPStatus.OK:
-            for entry in get_response.json().get("subject_roles", []):
-                subject = entry.get("subject", {})
-                if subject.get("id") == user_id and subject.get("type") == "user":
-                    logger.info(f"User {user_id} already has role on {repo_slug}, skipping")
-                    return
-
+        # POST /roles is idempotent on the SourceCraft side: re-posting a role
+        # that already exists returns 200 OK. That means create_project can be
+        # safely re-invoked to recover a partial setup (repo created, role
+        # assignment failed on a previous run) without extra pre-flight checks.
         payload: dict[str, Any] = {
             "subject_roles": [
                 {

--- a/manytask/manytask/sourcecraft.py
+++ b/manytask/manytask/sourcecraft.py
@@ -9,6 +9,14 @@ from typing import Any
 
 import grpc
 import httpx
+from tenacity import (
+    RetryCallState,
+    before_sleep_log,
+    retry,
+    retry_if_result,
+    stop_after_attempt,
+    wait_exponential,
+)
 from yandex.cloud.iam.v1.iam_token_service_pb2_grpc import IamTokenServiceStub
 from yandex.cloud.iam.v1.yandex_passport_user_account_service_pb2 import GetUserAccountByLoginRequest
 from yandex.cloud.iam.v1.yandex_passport_user_account_service_pb2_grpc import YandexPassportUserAccountServiceStub
@@ -18,6 +26,28 @@ from .abstract import RmsApi, RmsApiException, RmsUser
 from .utils.sourcecraft import normalize_string
 
 logger = logging.getLogger(__name__)
+
+
+# HTTP statuses for which POST /roles is retried. 429 = rate limit; 502/503/504
+# = transient gateway errors (observed in prod - one push had 400 then 504,
+# leaving the role assignment broken). 4xx (other than 429) is a client bug
+# - retrying won't help.
+_RETRY_STATUSES = frozenset(
+    {HTTPStatus.TOO_MANY_REQUESTS, HTTPStatus.BAD_GATEWAY, HTTPStatus.SERVICE_UNAVAILABLE, HTTPStatus.GATEWAY_TIMEOUT}
+)
+
+
+def _is_transient(response: httpx.Response) -> bool:
+    return response.status_code in _RETRY_STATUSES
+
+
+def _return_last_response(retry_state: RetryCallState) -> httpx.Response:
+    """After exhausting retries, return the last response instead of raising RetryError.
+
+    Caller inspects response.status_code / body to build a meaningful error.
+    """
+    assert retry_state.outcome is not None
+    return retry_state.outcome.result()
 
 
 @dataclass
@@ -146,44 +176,16 @@ class SourceCraftApi(RmsApi):
         if response.status_code != HTTPStatus.OK:
             raise RmsApiException(f"Failed to update repo: {response.json()}")
 
-    # HTTP status codes for which _add_repo_role should transparently retry
-    # the POST /roles request. 502/503/504 are transient gateway errors seen
-    # in practice; a fresh call within a few seconds usually succeeds. 429 is
-    # included so we back off politely on rate limiting.
-    _RETRY_STATUSES = frozenset({
-        HTTPStatus.TOO_MANY_REQUESTS,
-        HTTPStatus.BAD_GATEWAY,
-        HTTPStatus.SERVICE_UNAVAILABLE,
-        HTTPStatus.GATEWAY_TIMEOUT,
-    })
-    _RETRY_MAX_ATTEMPTS = 3
-    _RETRY_BACKOFF_SECONDS = 1.0
-
-    def _post_repo_role(
-        self,
-        repo_slug: str,
-        payload: dict[str, Any],
-    ) -> httpx.Response:
+    @retry(
+        retry=retry_if_result(_is_transient),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=4),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        retry_error_callback=_return_last_response,
+    )
+    def _post_repo_role(self, repo_slug: str, payload: dict[str, Any]) -> httpx.Response:
         """POST /roles with retry on transient gateway/rate-limit errors."""
-        last_response: httpx.Response | None = None
-        for attempt in range(self._RETRY_MAX_ATTEMPTS):
-            response = self._request("POST", f"repos/{self._org_slug}/{repo_slug}/roles", json=payload)
-            last_response = response
-            if response.status_code not in self._RETRY_STATUSES:
-                return response
-            if attempt < self._RETRY_MAX_ATTEMPTS - 1:
-                sleep_for = self._RETRY_BACKOFF_SECONDS * (2**attempt)
-                logger.warning(
-                    "POST %s roles got %s, retrying in %.1fs (attempt %d/%d)",
-                    repo_slug,
-                    response.status_code,
-                    sleep_for,
-                    attempt + 1,
-                    self._RETRY_MAX_ATTEMPTS,
-                )
-                time.sleep(sleep_for)
-        assert last_response is not None
-        return last_response
+        return self._request("POST", f"repos/{self._org_slug}/{repo_slug}/roles", json=payload)
 
     def _add_repo_role(
         self,

--- a/manytask/manytask/sourcecraft.py
+++ b/manytask/manytask/sourcecraft.py
@@ -124,8 +124,18 @@ class SourceCraftApi(RmsApi):
                 "template_id": template_id,
             }
         response = self._request("POST", f"orgs/{self._org_slug}/repos", json=payload)
-        if response.status_code != HTTPStatus.CREATED:
-            raise RmsApiException(f"Failed to create repo: {response.json()}")
+        if response.status_code == HTTPStatus.CREATED:
+            return
+        # Idempotency: SC returns 409 with error_code=SlugIsNotAvailable when the
+        # repo already exists. This happens on any retry of create_project (e.g.
+        # after a previous run failed at _add_repo_role). Treat as success so
+        # create_project can be safely re-invoked to recover a partial setup.
+        if response.status_code == HTTPStatus.CONFLICT:
+            data = response.json()
+            if data.get("error_code") == "SlugIsNotAvailable":
+                logger.info(f"Repo {repo_slug} already exists, skipping creation")
+                return
+        raise RmsApiException(f"Failed to create repo: {response.json()}")
 
     def _update_repo(
         self,
@@ -136,12 +146,62 @@ class SourceCraftApi(RmsApi):
         if response.status_code != HTTPStatus.OK:
             raise RmsApiException(f"Failed to update repo: {response.json()}")
 
+    # HTTP status codes for which _add_repo_role should transparently retry
+    # the POST /roles request. 502/503/504 are transient gateway errors seen
+    # in practice; a fresh call within a few seconds usually succeeds. 429 is
+    # included so we back off politely on rate limiting.
+    _RETRY_STATUSES = frozenset({
+        HTTPStatus.TOO_MANY_REQUESTS,
+        HTTPStatus.BAD_GATEWAY,
+        HTTPStatus.SERVICE_UNAVAILABLE,
+        HTTPStatus.GATEWAY_TIMEOUT,
+    })
+    _RETRY_MAX_ATTEMPTS = 3
+    _RETRY_BACKOFF_SECONDS = 1.0
+
+    def _post_repo_role(
+        self,
+        repo_slug: str,
+        payload: dict[str, Any],
+    ) -> httpx.Response:
+        """POST /roles with retry on transient gateway/rate-limit errors."""
+        last_response: httpx.Response | None = None
+        for attempt in range(self._RETRY_MAX_ATTEMPTS):
+            response = self._request("POST", f"repos/{self._org_slug}/{repo_slug}/roles", json=payload)
+            last_response = response
+            if response.status_code not in self._RETRY_STATUSES:
+                return response
+            if attempt < self._RETRY_MAX_ATTEMPTS - 1:
+                sleep_for = self._RETRY_BACKOFF_SECONDS * (2**attempt)
+                logger.warning(
+                    "POST %s roles got %s, retrying in %.1fs (attempt %d/%d)",
+                    repo_slug,
+                    response.status_code,
+                    sleep_for,
+                    attempt + 1,
+                    self._RETRY_MAX_ATTEMPTS,
+                )
+                time.sleep(sleep_for)
+        assert last_response is not None
+        return last_response
+
     def _add_repo_role(
         self,
         repo_slug: str,
         role: str,
         user_id: str,
     ) -> None:
+        # Idempotency: if the user already has any role on this repo, skip the
+        # POST entirely. create_project can be safely re-invoked to recover a
+        # partial setup (repo created, role assignment failed on previous run).
+        get_response = self._request("GET", f"repos/{self._org_slug}/{repo_slug}/roles")
+        if get_response.status_code == HTTPStatus.OK:
+            for entry in get_response.json().get("subject_roles", []):
+                subject = entry.get("subject", {})
+                if subject.get("id") == user_id and subject.get("type") == "user":
+                    logger.info(f"User {user_id} already has role on {repo_slug}, skipping")
+                    return
+
         payload: dict[str, Any] = {
             "subject_roles": [
                 {
@@ -153,7 +213,7 @@ class SourceCraftApi(RmsApi):
                 }
             ]
         }
-        response = self._request("POST", f"repos/{self._org_slug}/{repo_slug}/roles", json=payload)
+        response = self._post_repo_role(repo_slug, payload)
         if response.status_code != HTTPStatus.OK:
             data = response.json()
             if data.get("error_code", "") == "FailedPrecondition":
@@ -163,7 +223,7 @@ class SourceCraftApi(RmsApi):
                     "type": "invitee",
                     "id": invitee_id,
                 }
-                response = self._request("POST", f"repos/{self._org_slug}/{repo_slug}/roles", json=payload)
+                response = self._post_repo_role(repo_slug, payload)
                 if response.status_code != HTTPStatus.OK:
                     raise RmsApiException(f"Failed to add repo role: {response.json()}")
             else:

--- a/manytask/pyproject.toml
+++ b/manytask/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "httpx>=0.28.1",
     "yandexcloud>=0.388.0",
     "grpcio>=1.78.0",
+    "tenacity>=9.0.0",
 ]
 
 

--- a/manytask/tests/test_sourcecraft.py
+++ b/manytask/tests/test_sourcecraft.py
@@ -294,7 +294,7 @@ def test_add_repo_role_retries_on_gateway_timeout(sourcecraft_api):
 
     with (
         patch.object(sourcecraft_api, "_request", side_effect=side_effect),
-        patch("manytask.sourcecraft.time.sleep"),  # no real sleep in tests
+        patch("tenacity.nap.sleep"),  # no real sleep in tests
     ):
         # Must not raise — second attempt succeeds.
         sourcecraft_api._add_repo_role(repo_slug, "developer", TEST_RMS_ID)
@@ -319,7 +319,7 @@ def test_add_repo_role_does_not_retry_on_client_error(sourcecraft_api):
 
     with (
         patch.object(sourcecraft_api, "_request", side_effect=side_effect),
-        patch("manytask.sourcecraft.time.sleep"),
+        patch("tenacity.nap.sleep"),
     ):
         with pytest.raises(RmsApiException):
             sourcecraft_api._add_repo_role(repo_slug, "developer", TEST_RMS_ID)

--- a/manytask/tests/test_sourcecraft.py
+++ b/manytask/tests/test_sourcecraft.py
@@ -81,9 +81,6 @@ def test_create_project_slug_derives_from_rms_user_username(sourcecraft_api):
             return _make_response(HTTPStatus.OK, {"id": 42})
         if method == "POST" and path == f"orgs/{TEST_ORG}/repos":
             return _make_response(HTTPStatus.CREATED)
-        if method == "GET" and path.endswith("/roles"):
-            # _add_repo_role does a pre-flight GET to check for existing role.
-            return _make_response(HTTPStatus.OK, {"subject_roles": []})
         if method == "POST" and path.endswith("/roles"):
             return _make_response(HTTPStatus.OK)
         raise AssertionError(f"unexpected request {method} {path}")
@@ -115,8 +112,6 @@ def test_existence_check_and_create_use_matching_slug(sourcecraft_api):
             return _make_response(HTTPStatus.OK, {"id": 42})
         if method == "POST" and path == f"orgs/{TEST_ORG}/repos":
             return _make_response(HTTPStatus.CREATED)
-        if method == "GET" and path.endswith("/roles"):
-            return _make_response(HTTPStatus.OK, {"subject_roles": []})
         if method == "POST" and path.endswith("/roles"):
             return _make_response(HTTPStatus.OK)
         if method == "GET" and path.startswith(f"repos/{TEST_ORG}/{TEST_STUDENTS_GROUP}-"):
@@ -228,8 +223,6 @@ def test_create_project_is_idempotent_when_repo_already_exists(sourcecraft_api):
                 HTTPStatus.CONFLICT,
                 {"error_code": "SlugIsNotAvailable", "message": "slug taken"},
             )
-        if method == "GET" and path.endswith("/roles"):
-            return _make_response(HTTPStatus.OK, {"subject_roles": []})
         if method == "POST" and path.endswith("/roles"):
             return _make_response(HTTPStatus.OK)
         raise AssertionError(f"unexpected request {method} {path}")
@@ -238,35 +231,22 @@ def test_create_project_is_idempotent_when_repo_already_exists(sourcecraft_api):
         sourcecraft_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
 
 
-def test_add_repo_role_skips_post_when_user_already_has_role(sourcecraft_api):
-    """If the user is already an active member of the repo, do not re-POST /roles.
-
-    This makes create_project safe to call multiple times without racing on
-    duplicate-role errors, and lets a recovery hook re-run setup as a no-op.
+def test_add_repo_role_when_role_already_exists_is_a_noop(sourcecraft_api):
+    """POST /roles is idempotent on the SourceCraft side: posting a role that
+    already exists returns 200 OK, not a duplicate-role error. This lets
+    create_project be safely re-invoked (e.g. after a partial setup) without
+    a pre-flight GET or duplicate-error handling.
     """
     repo_slug = f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}"
 
-    seen_posts = []
-
     def side_effect(method, path, **kwargs):
-        if method == "GET" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
-            return _make_response(
-                HTTPStatus.OK,
-                {
-                    "subject_roles": [
-                        {"role": "developer", "subject": {"type": "user", "id": TEST_RMS_ID}}
-                    ]
-                },
-            )
-        if method == "POST" and path.endswith("/roles"):
-            seen_posts.append(path)
+        if method == "POST" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
             return _make_response(HTTPStatus.OK)
         raise AssertionError(f"unexpected request {method} {path}")
 
     with patch.object(sourcecraft_api, "_request", side_effect=side_effect):
+        # Must not raise even when role already exists on SC side.
         sourcecraft_api._add_repo_role(repo_slug, "developer", TEST_RMS_ID)
-
-    assert seen_posts == [], "POST /roles must be skipped when role already present"
 
 
 def test_add_repo_role_retries_on_gateway_timeout(sourcecraft_api):
@@ -286,8 +266,6 @@ def test_add_repo_role_retries_on_gateway_timeout(sourcecraft_api):
     )
 
     def side_effect(method, path, **kwargs):
-        if method == "GET" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
-            return _make_response(HTTPStatus.OK, {"subject_roles": []})
         if method == "POST" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
             return next(responses)
         raise AssertionError(f"unexpected request {method} {path}")
@@ -310,8 +288,6 @@ def test_add_repo_role_does_not_retry_on_client_error(sourcecraft_api):
     call_count = {"n": 0}
 
     def side_effect(method, path, **kwargs):
-        if method == "GET" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
-            return _make_response(HTTPStatus.OK, {"subject_roles": []})
         if method == "POST" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
             call_count["n"] += 1
             return _make_response(HTTPStatus.BAD_REQUEST, {"error_code": "BadRequest"})

--- a/manytask/tests/test_sourcecraft.py
+++ b/manytask/tests/test_sourcecraft.py
@@ -81,6 +81,9 @@ def test_create_project_slug_derives_from_rms_user_username(sourcecraft_api):
             return _make_response(HTTPStatus.OK, {"id": 42})
         if method == "POST" and path == f"orgs/{TEST_ORG}/repos":
             return _make_response(HTTPStatus.CREATED)
+        if method == "GET" and path.endswith("/roles"):
+            # _add_repo_role does a pre-flight GET to check for existing role.
+            return _make_response(HTTPStatus.OK, {"subject_roles": []})
         if method == "POST" and path.endswith("/roles"):
             return _make_response(HTTPStatus.OK)
         raise AssertionError(f"unexpected request {method} {path}")
@@ -112,6 +115,8 @@ def test_existence_check_and_create_use_matching_slug(sourcecraft_api):
             return _make_response(HTTPStatus.OK, {"id": 42})
         if method == "POST" and path == f"orgs/{TEST_ORG}/repos":
             return _make_response(HTTPStatus.CREATED)
+        if method == "GET" and path.endswith("/roles"):
+            return _make_response(HTTPStatus.OK, {"subject_roles": []})
         if method == "POST" and path.endswith("/roles"):
             return _make_response(HTTPStatus.OK)
         if method == "GET" and path.startswith(f"repos/{TEST_ORG}/{TEST_STUDENTS_GROUP}-"):
@@ -196,3 +201,127 @@ def test_get_rms_user_by_username_prefers_yandex_login(sourcecraft_api):
 
     assert rms_user.username == SOURCECRAFT_USERNAME
     mock_request.assert_called_once_with("GET", f"users/cloud-id:{cloud_id}")
+
+
+# ---------------------------------------------------------------------------
+# Recovery from partial setup: create_project is idempotent and _add_repo_role
+# retries on transient errors. See fix/create-project-recovery.
+# ---------------------------------------------------------------------------
+
+
+def test_create_project_is_idempotent_when_repo_already_exists(sourcecraft_api):
+    """A repeated create_project call after a partial setup must not raise.
+
+    Real-world scenario: first attempt created the repo but the follow-up
+    POST /roles failed with 504. On the next call, POST /orgs/.../repos
+    returns 409 SlugIsNotAvailable, which used to bubble up as
+    RmsApiException and blocked recovery. We now treat it as success and
+    let _add_repo_role finish the job.
+    """
+    rms_user = RmsUser(id=TEST_RMS_ID, username=SOURCECRAFT_USERNAME, name="Test User")
+
+    def side_effect(method, path, **kwargs):
+        if method == "GET" and path == f"repos/{TEST_ORG}/{TEST_PUBLIC_REPO}":
+            return _make_response(HTTPStatus.OK, {"id": 42})
+        if method == "POST" and path == f"orgs/{TEST_ORG}/repos":
+            return _make_response(
+                HTTPStatus.CONFLICT,
+                {"error_code": "SlugIsNotAvailable", "message": "slug taken"},
+            )
+        if method == "GET" and path.endswith("/roles"):
+            return _make_response(HTTPStatus.OK, {"subject_roles": []})
+        if method == "POST" and path.endswith("/roles"):
+            return _make_response(HTTPStatus.OK)
+        raise AssertionError(f"unexpected request {method} {path}")
+
+    with patch.object(sourcecraft_api, "_request", side_effect=side_effect):
+        sourcecraft_api.create_project(rms_user, TEST_STUDENTS_GROUP, TEST_PUBLIC_REPO)
+
+
+def test_add_repo_role_skips_post_when_user_already_has_role(sourcecraft_api):
+    """If the user is already an active member of the repo, do not re-POST /roles.
+
+    This makes create_project safe to call multiple times without racing on
+    duplicate-role errors, and lets a recovery hook re-run setup as a no-op.
+    """
+    repo_slug = f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}"
+
+    seen_posts = []
+
+    def side_effect(method, path, **kwargs):
+        if method == "GET" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
+            return _make_response(
+                HTTPStatus.OK,
+                {
+                    "subject_roles": [
+                        {"role": "developer", "subject": {"type": "user", "id": TEST_RMS_ID}}
+                    ]
+                },
+            )
+        if method == "POST" and path.endswith("/roles"):
+            seen_posts.append(path)
+            return _make_response(HTTPStatus.OK)
+        raise AssertionError(f"unexpected request {method} {path}")
+
+    with patch.object(sourcecraft_api, "_request", side_effect=side_effect):
+        sourcecraft_api._add_repo_role(repo_slug, "developer", TEST_RMS_ID)
+
+    assert seen_posts == [], "POST /roles must be skipped when role already present"
+
+
+def test_add_repo_role_retries_on_gateway_timeout(sourcecraft_api):
+    """504 from POST /roles must trigger transparent retry within the same call.
+
+    Motivated by production incident: SC returned one 504 during a real
+    student sign-up, manytask propagated the error, and the student's repo
+    was left permanently without a developer-role assignment because no
+    retry mechanism existed.
+    """
+    repo_slug = f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}"
+    responses = iter(
+        [
+            _make_response(HTTPStatus.GATEWAY_TIMEOUT, {"error_code": "GatewayTimeout"}),
+            _make_response(HTTPStatus.OK),
+        ]
+    )
+
+    def side_effect(method, path, **kwargs):
+        if method == "GET" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
+            return _make_response(HTTPStatus.OK, {"subject_roles": []})
+        if method == "POST" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
+            return next(responses)
+        raise AssertionError(f"unexpected request {method} {path}")
+
+    with (
+        patch.object(sourcecraft_api, "_request", side_effect=side_effect),
+        patch("manytask.sourcecraft.time.sleep"),  # no real sleep in tests
+    ):
+        # Must not raise — second attempt succeeds.
+        sourcecraft_api._add_repo_role(repo_slug, "developer", TEST_RMS_ID)
+
+
+def test_add_repo_role_does_not_retry_on_client_error(sourcecraft_api):
+    """4xx from POST /roles must fail immediately without retry.
+
+    Retrying a 400 Bad Request would just waste time — the request is
+    malformed, retrying with the same payload cannot succeed.
+    """
+    repo_slug = f"{TEST_STUDENTS_GROUP}-{SOURCECRAFT_USERNAME}"
+    call_count = {"n": 0}
+
+    def side_effect(method, path, **kwargs):
+        if method == "GET" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
+            return _make_response(HTTPStatus.OK, {"subject_roles": []})
+        if method == "POST" and path == f"repos/{TEST_ORG}/{repo_slug}/roles":
+            call_count["n"] += 1
+            return _make_response(HTTPStatus.BAD_REQUEST, {"error_code": "BadRequest"})
+        raise AssertionError(f"unexpected request {method} {path}")
+
+    with (
+        patch.object(sourcecraft_api, "_request", side_effect=side_effect),
+        patch("manytask.sourcecraft.time.sleep"),
+    ):
+        with pytest.raises(RmsApiException):
+            sourcecraft_api._add_repo_role(repo_slug, "developer", TEST_RMS_ID)
+
+    assert call_count["n"] == 1, "4xx must not be retried"

--- a/manytask/uv.lock
+++ b/manytask/uv.lock
@@ -779,6 +779,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlalchemy" },
+    { name = "tenacity" },
     { name = "werkzeug" },
     { name = "yandexcloud" },
 ]
@@ -826,6 +827,7 @@ requires-dist = [
     { name = "requests-mock", marker = "extra == 'dev'", specifier = ">=1.0.0,<2.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.4" },
     { name = "sqlalchemy", specifier = ">=2.0.44,<3.0.0" },
+    { name = "tenacity", specifier = ">=9.0.0" },
     { name = "testcontainers", marker = "extra == 'dev'", specifier = "==4.14.0" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = "==6.0.12.12" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = "==2.33.0.20260327" },
@@ -1420,6 +1422,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/0e66097fc64fa266f29a7963296b40a80d6a997b7ac13806183700676f86/sqlalchemy-2.0.44-cp313-cp313-win32.whl", hash = "sha256:ee51625c2d51f8baadf2829fae817ad0b66b140573939dd69284d2ba3553ae73", size = 2101275, upload-time = "2025-10-10T15:03:26.096Z" },
     { url = "https://files.pythonhosted.org/packages/03/51/665617fe4f8c6450f42a6d8d69243f9420f5677395572c2fe9d21b493b7b/sqlalchemy-2.0.44-cp313-cp313-win_amd64.whl", hash = "sha256:c1c80faaee1a6c3428cecf40d16a2365bcf56c424c92c2b6f0f9ad204b899e9e", size = 2127901, upload-time = "2025-10-10T15:03:27.548Z" },
     { url = "https://files.pythonhosted.org/packages/9c/5e/6a29fa884d9fb7ddadf6b69490a9d45fded3b38541713010dad16b77d015/sqlalchemy-2.0.44-py3-none-any.whl", hash = "sha256:19de7ca1246fbef9f9d1bff8f1ab25641569df226364a0e40457dc5457c54b05", size = 1928718, upload-time = "2025-10-10T15:29:45.32Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Recover from partial student setups (repo created but `_add_repo_role` failed on 4xx/5xx). See tests for details.